### PR TITLE
Fix incorrect data

### DIFF
--- a/kedict.yml
+++ b/kedict.yml
@@ -9,7 +9,7 @@
   pos: part
   defs:
     - def: "Indicates the subject of a sentence.(Compare with Japanese が)"
-      examples: 
+      examples:
         - example: "그렇지만, 내가 펜을 갖고 있을텐데…"
           transliteration: "geureochiman, naega peneul gatgo isseultende…"
           translation: "I know I have a pen, though…"
@@ -71,7 +71,7 @@
   pos: n
   defs:
     - def: "store, shop"
-      examples: 
+      examples:
         - example: "그는 길을 따라, 그 가게에 이르렀다."
           transliteration: "Geuneun gireul ttara, geu gagee ireureotda."
           translation: "He went down the road to the store."
@@ -169,14 +169,14 @@
   pos: a
   defs:
     - def: "To be close, near (in distance, time)"
-      examples: 
+      examples:
         - example: "새로 이사한 집에선 학교가 가깝다."
           transliteration: "Saero isahan jibeseon hakgyoga gakkapda."
           translation: "The school is close to our new house."
     - def: "To be on friendly terms."
     - def: "To be of similar quantity."
     - def: "To be closely related."
-      examples: 
+      examples:
         - example: "가까운 친척"
           transliteration: "gakkaun chincheok"
           translation: "close relatives"
@@ -285,7 +285,7 @@
   pos: a
   defs:
     - def: "to be possible; able"
-      examples: 
+      examples:
         - example: "나는 가능한 한 빨리 왔다."
           transliteration: "Naneun ganeunghan han ppalli watda."
           translation: "I came as soon as I could."
@@ -302,7 +302,7 @@
   pos: v
   defs:
     - def: "to go"
-      examples: 
+      examples:
         - example: "가자!"
           transliteration: "Gaja!"
           translation: "Let's go!"
@@ -394,7 +394,7 @@
   pos: v
   defs:
     - def: "to sink, to go down"
-      examples: 
+      examples:
         - example: "물에 수영할 거면 가라앉지 마세요!"
           transliteration: "Mure suyeonghal geomyeon garaanji maseyo!"
           translation: "If you're going to go swimming in the water, please don't sink!"
@@ -421,7 +421,7 @@
   defs:
     - def: "a twinned pair of rings"
     - def: "a ring, a finger ring"
-      examples: 
+      examples:
         - example: "가락지를 끼다"
           transliteration: "garakjireul kkida"
           translation: "put on/wear a ring"
@@ -537,7 +537,7 @@
   pos: v
   defs:
     - def: "to teach or impart knowledge."
-      examples: 
+      examples:
         - example: "로버트는 수학을 가르치는 선생님입니다."
           transliteration: "Robeoteuneun suhageul gareuchineun seonsaengnimimnida."
           translation: "Robert is a teacher who teaches math."
@@ -565,7 +565,7 @@
   pos: n
   defs:
     - def: "A traditional folding screen having two panels."
-      examples: 
+      examples:
         - example: "가리개 뒤에서 옷을 갈아입다."
           transliteration: "Garigae dwieseo oseul garaipda."
           translation: "One changes one's clothes behind the folding screen."
@@ -596,12 +596,12 @@
   pos: n
   defs:
     - def: "kiln; oven"
-      examples: 
+      examples:
         - example: "벽돌을 가마에 굽다"
           transliteration: "byeokdoreul gamae gupda"
           translation: "to bake bricks in a kiln"
     - def: "cauldron"
-      examples: 
+      examples:
         - example: "가마 밑이 노구솥 밑을 검다 한다."
           transliteration: "Gama michi nogusot miteul geomda handa."
           translation: "The pot calls the kettle black."
@@ -611,7 +611,7 @@
   pos: n
   defs:
     - def: "whorl of hair, vortex of hair (on the vertex of the head)"
-      examples: 
+      examples:
         - example: "내 머리에 가마가 하나니 둘이니?"
           transliteration: "Nae meorie gamaga hanani durini?"
           translation: "Do I have one or two hair whorls?"
@@ -622,7 +622,7 @@
   defs:
     - def: "sack made of straw"
     - def: "bag, sack"
-      examples: 
+      examples:
         - example: "쌀 한 가마에 십만 원 간다."
           transliteration: "Ssal han gamae simman won ganda."
           translation: "The market price of rice is 100,000 won a bag."
@@ -632,7 +632,7 @@
   pos: n
   defs:
     - def: "palanquin"
-      examples: 
+      examples:
         - example: "가마를 타고 가다"
           transliteration: "gamareul tago gada"
           translation: "to go by palanquin"
@@ -849,7 +849,7 @@
   pos: v
   defs:
     - def: "to go"
-      examples: 
+      examples:
         - example: "가자!"
           transliteration: "Gaja!"
           translation: "Let's go!"
@@ -963,7 +963,7 @@
   defs:
     - def: "to leave; to disappear"
     - def: "honorific of 가다 (gada) : to go"
-      examples: 
+      examples:
         - example: "그 사무실에 당도하려면 두개 층을 내려가셔야 합니다."
           transliteration: "Geu samusire dangdoharyeomyeon dugae cheung-eul naeryeogasyeoya hamnida."
           translation: "You'll need to go down two floors to get to that office."
@@ -1107,7 +1107,7 @@
   pos: propn
   defs:
     - def: "Gaza (a city in Palestine)"
-      examples: 
+      examples:
         - example: "가자 지구"
           transliteration: "Gaja jigu"
           translation: "Gaza strip"
@@ -1118,7 +1118,7 @@
   defs:
     - def: "most"
     - def: "(by extension also used to form superlatives of adjectives) the most; the best (of its kind)"
-      examples: 
+      examples:
         - example: "이 사전이 가장 좋아요."
           transliteration: "I sajeoni gajang joayo."
           translation: "This dictionary is the best."
@@ -1144,7 +1144,7 @@
   pos: n
   defs:
     - def: "edge, verge, brink"
-      examples: 
+      examples:
         - example: "그는, “우리가 현재 있는 이곳은 2008년으로 거슬러 가면 온통 눈으로 덮여 있었어요. 여기 저기 가장자리 쪽에서 빙하가 약 20에서 30미터 줄어들었지요.”라고 말했다."
           transliteration: "Geuneun, “uriga hyeonjae inneun igoseun 2008nyeoneuro geoseulleo gamyeon ontong nuneuro deopyeo isseosseoyo. Yeogi jeogi gajangjari jjogeseo binghaga yak 20eseo 30miteo jureodeureotjiyo.”rago malhaetda."
           translation: "He said, “Where we’re at right now was back in 2008 all covered with ice. From here to there at the side, the glacier shrank about 20 to 30 meters.”"
@@ -1197,7 +1197,7 @@
   pos: v
   defs:
     - def: "to take something (somewhere), to take away"
-      examples: 
+      examples:
         - example: "로사의 생일 선물을 가져갈거야."
           transliteration: "Rosaui saeng-il seonmureul gajyeogalgeoya."
           translation: "I will take a present to Rosa for her birthday."
@@ -1217,7 +1217,7 @@
   pos: n
   defs:
     - def: "household; family"
-      examples: 
+      examples:
         - example: "저희 가족을 소개하겠습니다."
           transliteration: "Jeohui gajogeul sogaehagetseumnida."
           translation: "(I) will introduce my family."
@@ -1241,7 +1241,7 @@
   pos: n
   defs:
     - def: "leather strap; leash"
-      examples: 
+      examples:
         - example: "그는 가죽끈으로 맨 개 한 마리를 가져왔다."
           transliteration: "Geuneun gajukkkeuneuro maen gae han marireul gajyeowatda."
           translation: "He brought a dog on a leash."
@@ -1287,7 +1287,7 @@
   pos: n
   defs:
     - def: "with; by; by means of"
-      examples: 
+      examples:
         - example: "공을 가지고 놀다"
           transliteration: "gong-eul gajigo nolda"
           translation: "to play with a ball"
@@ -1297,7 +1297,7 @@
   pos: v
   defs:
     - def: "to have, to possess"
-      examples: 
+      examples:
         - example: "왜 세계지도를 가지고 있지?"
           transliteration: "Wae segyejidoreul gajigo itji?"
           translation: "Why do you have a map of the world?"
@@ -1358,7 +1358,7 @@
   pos: n
   defs:
     - def: "value (one's morals, morality, or belief system)"
-      examples: 
+      examples:
         - example: "그 집안의 아버지와 딸은 서로 다른 기치관을 고집한다."
           transliteration: "Geu jibanui abeojiwa ttareun seoro dareun gichigwaneul gojiphanda."
           translation: "The father and the daughter of this household hold different values from each other."
@@ -1434,7 +1434,7 @@
   pos: adv
   defs:
     - def: "each, every, respective"
-      examples: 
+      examples:
         - example: "각각의 금액이 매도인 측 은행에서 수령된 때에"
           transliteration: "gakgagui geumaegi maedoin cheuk eunhaeng-eseo suryeongdoen ttaee"
           translation: "when the respective sums due have been received by the Seller’s bank"
@@ -1451,7 +1451,7 @@
   pos: adv
   defs:
     - def: "each, respectively, individually"
-      examples: 
+      examples:
         - example: "그들에게 사과를 각기 두 개씩 주어라."
           transliteration: "Geudeurege sagwareul gakgi du gaessik jueora."
           translation: "Give them two apples each."
@@ -1480,7 +1480,7 @@
   pos: n
   defs:
     - def: "attractive visual quality for describing the legs of a person"
-      examples: 
+      examples:
         - example: "우리 언니의 각선미가 참 예뻐!"
           transliteration: "Uri eonniui gakseonmiga cham yeppeo!"
           translation: "My older sister has very nice legs!"
@@ -1582,7 +1582,7 @@
   pos: a
   defs:
     - def: "To be simple or straightforward."
-      examples: 
+      examples:
         - example: "아주 간단합니다."
           transliteration: "Aju gandanhamnida."
           translation: "It's really simple."
@@ -1718,7 +1718,7 @@
   pos: n
   defs:
     - def: "indirectness"
-      examples: 
+      examples:
         - example: "간접 목적어"
           transliteration: "ganjeop mokjeogeo"
           translation: "indirect object"
@@ -1852,12 +1852,12 @@
   pos: v
   defs:
     - def: "Future adnominal form of 가다 (gada, “to go”), thus often \"who/that will go\""
-      examples: 
+      examples:
         - example: "서울로 갈 사람"
           transliteration: "Seoul-lo gal saram"
           translation: "someone who will go to Seoul"
     - def: "Future adnominal form of 갈다 (galda, “to change, grind, or cultivate”)"
-      examples: 
+      examples:
         - example: "밭을 갈 때"
           transliteration: "bat-eul gal ttae"
           translation: "when plowing the field"
@@ -1960,7 +1960,7 @@
   pos: n
   defs:
     - def: "forked road, the fork of a road"
-      examples: 
+      examples:
         - example: "갈림길에서 오른쪽으로 접어들다"
           transliteration: "gallimgireseo oreunjjogeuro jeobeodeulda"
           translation: "take the right-hand fork"
@@ -1968,7 +1968,7 @@
           transliteration: "I dororeul ttaraseo gotjang gasimyeon gallimgiri naolgeomnida."
           translation: "Go straight down this road till you come to a fork in the road."
     - def: "crossroads, turning point or opportunity to change direction, course, or goal"
-      examples: 
+      examples:
         - example: "갈림길에 서다"
           transliteration: "gallimgire seoda"
           translation: "stand at the crossroads"
@@ -2037,7 +2037,7 @@
   pos: adv
   defs:
     - def: "as time goes by, the more ... the more ..."
-      examples: 
+      examples:
         - example: "소득 수준이 높아지면서 대형 가전제품의 수요가 갈수록 늘어나고 있다."
           transliteration: "Sodeuk sujuni nopajimyeonseo daehyeong gajeonjepumui suyoga galsurok neureonago itda."
           translation: "As income level is raised, the demand for large-sized household electrical appliances is also increasing."
@@ -2164,7 +2164,7 @@
   pos: n
   defs:
     - def: "a cold; influenza"
-      examples: 
+      examples:
         - example: "감기가 들다"
           transliteration: "gamgiga deulda"
           translation: "to catch a cold (Literally, \"A cold enters\")"
@@ -2177,7 +2177,7 @@
   pos: v
   defs:
     - def: "to close"
-      examples: 
+      examples:
         - example: "눈이 감겨요."
           transliteration: "Nuni gamgyeoyo."
           translation: "Close your eyes."
@@ -2188,7 +2188,7 @@
   pos: v
   defs:
     - def: "to wash oneself; to bathe"
-      examples: 
+      examples:
         - example: "머리를 감다"
           transliteration: "meorireul gamda"
           translation: "to wash (one's) hair."
@@ -2313,7 +2313,7 @@
   pos: v
   defs:
     - def: "Formal indicative assertive of 감사하다 (gamsahada), thus \"give(s) thanks.\""
-      examples: 
+      examples:
         - example: "그럼에도 그는 감사합니다."
           transliteration: "Geureomedo geuneun gamsahamnida."
           translation: "Nonetheless he gives thanks."
@@ -2323,7 +2323,7 @@
   pos: n
   defs:
     - def: "reduction"
-      examples: 
+      examples:
         - example: "한 조사팀이 바이수에이의 감소가 지난 10년간 연간 약 27미터라고 기록하였다."
           transliteration: "Han josatimi baisueiui gamsoga jinan 10nyeon-gan yeon-gan yak 27miteorago girokhayeotda."
           translation: "One research team has recorded Baishui’s decrease at about 27 meters per year over the last 10 years."
@@ -2410,7 +2410,7 @@
   pos: n
   defs:
     - def: "admiration; wonderment"
-      examples: 
+      examples:
         - example: "그림을 밝고 빛나는 색깔로 덕지덕지 그려 놓으면, 서민들은 그것을 휼륭한 작품이라며 감탄해 한다."
           transliteration: "Geurimeul balgo binnaneun saekkkallo deokjideokji geuryeo noeumyeon, seomindeureun geugeoseul hyullyunghan jakpumiramyeo gamtanhae handa."
           translation: "If a picture is daubed with many bright and glaring colours, the vulgar admire it as an excellent piece. (I. Watts)"
@@ -2426,7 +2426,7 @@
   pos: adv
   defs:
     - def: "boldly, fearlessly, daringly"
-      examples: 
+      examples:
         - example: "제가 감히 한 말씀 드리겠습니다."
           transliteration: "Jega gamhi han malsseum deurigetseumnida."
           translation: "If I may, I would like to say one thing."
@@ -2527,7 +2527,7 @@
   pos: n
   defs:
     - def: "(가격): price"
-      examples: 
+      examples:
         - example: "값이 얼마입니까?"
           transliteration: "Gapsi eolmaimnikka?"
           translation: "How much does it cost?"
@@ -2709,7 +2709,7 @@
   pos: n
   defs:
     - def: "compulsion, coercion"
-      examples: 
+      examples:
         - example: "강제로"
           transliteration: "gangjero"
           translation: "forcibly, by force"
@@ -2816,7 +2816,7 @@
   pos: a
   defs:
     - def: "(to be) the same"
-      examples: 
+      examples:
         - example: "같은 말을 되풀이하다"
           transliteration: "gateun mareul doepurihada"
           translation: "to say the same thing over and over"
@@ -2825,7 +2825,7 @@
           translation: "the same as your mother"
     - def: "(to be) like or similar (often used with 와 (wa)/과 (gwa))"
     - def: "(to be) probably so; (to be) apparently so"
-      examples: 
+      examples:
         - example: "In this sense, it often follows 것 (geot) and is often translated as \"it looks like\"."
         - example: "비가 올 것 같다."
           transliteration: "Biga ol geot gatda."
@@ -2840,7 +2840,7 @@
   pos: det
   defs:
     - def: "the same"
-      examples: 
+      examples:
         - example: "같은 말을 되풀이하다"
           transliteration: "gateun mareul doepurihada"
           translation: "to say the same thing over and over"
@@ -2850,7 +2850,7 @@
   pos: adv
   defs:
     - def: "with, together"
-      examples: 
+      examples:
         - example: "선생님과 같이 기념 사진을 찍었다."
           transliteration: "Seonsaengnimgwa gachi ginyeom sajineul jjigeotda."
           translation: "We took a commemorative photo with our teacher."
@@ -2860,12 +2860,12 @@
   pos: part
   defs:
     - def: "like, in a similar way"
-      examples: 
+      examples:
         - example: "형제같이 사이가 좋다."
           transliteration: "Hyeongjegachi saiga jota."
           translation: "They are as close as brothers (literally \"The relationship is as good as one between brothers\".)"
     - def: "every time, as soon as"
-      examples: 
+      examples:
         - example: "매일같이 지각하다."
           transliteration: "Maeilgachi jigakhada."
           translation: "(One) is late every day."
@@ -2894,7 +2894,7 @@
   pos: v
   defs:
     - def: "to repay, to return (something loaned)"
-      examples: 
+      examples:
         - example: "빌린 곡식을 두 배로 갚아 주다"
           transliteration: "billin goksigeul du baero gapa juda"
           translation: "to repay twice as much grain as one had borrowed"
@@ -3049,7 +3049,7 @@
   pos: n
   defs:
     - def: "ant"
-      examples: 
+      examples:
         - example: "개미처럼 부지런하다"
           transliteration: "gaemicheoreom bujireonhada"
           translation: "(metaphorical) as hardworking as an ant"
@@ -3194,7 +3194,7 @@
   defs:
     - def: "an individual or individuals; a private person"
     - def: "personal, individual"
-      examples: 
+      examples:
         - example: "커피 메이커를 개인 용도로 쓰든 업무용으로 쓰든 간에"
           transliteration: "keopi meikeoreul gaein yongdoro sseudeun eommuyong-euro sseudeun gane"
           translation: "Whether you want coffeemaker for personal or for business use,"
@@ -3204,7 +3204,7 @@
   pos: n
   defs:
     - def: "cult of personality"
-      examples: 
+      examples:
         - example: "개인숭배를 둘러싼 논쟁은 공산주의 진영에 확산되면서 국제공산주의운동의 분열을 가져오는 계기가 되기도 하였다."
           transliteration: "Gaeinsungbaereul dulleossan nonjaeng-eun gongsanjuui jinyeong-e hwaksandoemyeonseo gukjegongsanjuuiundong-ui bunyeoreul gajyeooneun gyegiga doegido hayeotda."
           translation: "As the debate over the cult of personality spread to the Communist camp, it also served as a beginning of the division of the international communism movement."
@@ -3287,7 +3287,7 @@
   pos: n
   defs:
     - def: "disorder; mess"
-      examples: 
+      examples:
         - example: "이 동네는 완전히 개판이로군!"
           transliteration: "I dongneneun wanjeonhi gaepanirogun!"
           translation: "Boy, this neighborhood is a complete mess!"
@@ -3350,7 +3350,7 @@
   pos: n
   defs:
     - def: "rashness, ill-advised bravery"
-      examples: 
+      examples:
         - example: "객기를 부리다"
           transliteration: "gaekgireul burida"
           translation: "to be carried away by a rash impulse"
@@ -3367,7 +3367,7 @@
   pos: a
   defs:
     - def: "unnecessary, needless; silly, idle"
-      examples: 
+      examples:
         - example: "객쩍은 소리 그만하고, 할 일 없으면 이리 와서 일이나 좀 거들어라."
           transliteration: "Gaekjjeogeun sori geumanhago, hal il eopseumyeon iri waseo irina jom geodeureora."
           translation: "Enough of that nonsense, if you don't have anything to do come here and help us."
@@ -3462,7 +3462,7 @@
   pos: pron
   defs:
     - def: "that kid; he or she"
-      examples: 
+      examples:
         - example: "걔는 학교에서 늘 우등생이었다."
           transliteration: "gyae-neun hakgyo-eseo neul udeungsaeng-ieotta."
           translation: "That kid was always on the honor roll in school."
@@ -3479,11 +3479,11 @@
   defs:
     - def: "thing."
     - def: "what, that which."
-      examples: 
+      examples:
         - example: "그건 내 한 거예요."
           translation: "Geugeon nae han geoyeyo."
     - def: "that of. pronounced as 꺼."
-      examples: 
+      examples:
         - example: "내 거예요."
           translation: "Nae geoyeyo."
 
@@ -3545,7 +3545,7 @@
   pos: n
   defs:
     - def: "transaction; trade."
-      examples: 
+      examples:
         - example: "제2항에 규정한 권리는 영업주가 그 거래를 안 날로부터 2주간을 경과하거나 그 거래가 있은 날로부터 1년을 경과하면 소멸한다."
           transliteration: "Je2hang-e gyujeonghan gwollineun yeong-eopjuga geu georaereul an nallobuteo 2juganeul gyeonggwahageona geu georaega isseun nallobuteo 1nyeoneul gyeonggwahamyeon somyeolhanda."
           translation: "The rights stipulated in clause 2 are lost 2 weeks after the business owner learns of the transaction, or one year after the transaction takes place."
@@ -3772,7 +3772,7 @@
   pos: adv
   defs:
     - def: "almost, nearly"
-      examples: 
+      examples:
         - example: "거의 여섯시야."
           transliteration: "Geoui yeoseotsiya."
           translation: "It's almost six o'clock."
@@ -3780,7 +3780,7 @@
           transliteration: "Geunyeoneun jigabe doni geoui namji anatda."
           translation: "She had little money left in her purse."
     - def: ""
-      examples: 
+      examples:
         - example: "나무들이 거의 꽃으로 뒤덮여 있다."
           transliteration: "Namudeuri geoui kkocheuro dwideopyeo itda."
           translation: "Trees are almost covered with blossoms."
@@ -3863,7 +3863,7 @@
   defs:
     - def: "to cross through or over"
     - def: "to pass through or undergo (e.g. regulatory examination)"
-      examples: 
+      examples:
         - example: "관광버스는 오타와를 거쳐 몬트리올로 간다."
           transliteration: "Gwan-gwangbeoseuneun Otawareul geochyeo Monteuriollo ganda."
           translation: "The tour bus goes to Montreal by crossing through Ottawa."
@@ -3921,7 +3921,7 @@
   pos: v
   defs:
     - def: "past determinative of 걸다 (geolda, “to speak or suspend”): having been suspended, spoken; of a telephone call, having been made"
-      examples: 
+      examples:
         - example: "내가 건 전화"
           transliteration: "naega geon jeonhwa"
           translation: "the call I made"
@@ -3940,7 +3940,7 @@
   pos: pref
   defs:
     - def: "dry"
-      examples: 
+      examples:
         - example: "건포도"
           transliteration: "geonpodo"
           translation: "raisin (literally, \"dried grape\")"
@@ -3951,7 +3951,7 @@
   pos: n
   defs:
     - def: "health"
-      examples: 
+      examples:
         - example: "건강을 조심하다"
           transliteration: "geon-gang-eul josimhada"
           translation: "to take care of one's health"
@@ -3967,7 +3967,7 @@
   pos: a
   defs:
     - def: "to be healthy"
-      examples: 
+      examples:
         - example: "아이는 건강하죠?"
           transliteration: "Aineun geon-ganghajyo?"
           translation: "Your child is healthy, isn’t he?"
@@ -4038,7 +4038,7 @@
   pos: v
   defs:
     - def: "To touch"
-      examples: 
+      examples:
         - example: "우리 집고양이를 건들지 마세요."
           transliteration: "Uri jipgoyang-ireul geondeulji maseyo."
           translation: "Don't touch my (our) house cat, please."
@@ -4058,7 +4058,7 @@
   pos: n
   defs:
     - def: "building, construction, edifice"
-      examples: 
+      examples:
         - example: "그 건물은 보수가 몹시 필요한 상태이다."
           transliteration: "Geu geonmureun bosuga mopsi piryohan sangtaeida."
           translation: "The building is badly in need of repair."
@@ -4099,7 +4099,7 @@
   pos: a
   defs:
     - def: "sound, wholesome (in terms of having upright ethics)"
-      examples: 
+      examples:
         - example: "건전한 노래는 어린이들한테 안성맞춤이지."
           transliteration: "Geonjeonhan noraeneun eorinideulhante anseongmatchumiji."
           translation: "Children-friendly songs are perfect for children. (casual speech)"
@@ -4179,7 +4179,7 @@
   pos: v
   defs:
     - def: "to walk"
-      examples: 
+      examples:
         - example: "매일 30분씩 걷는게 몸에 좋다."
           transliteration: "Maeil 30bunssik geonneun-ge mome jota."
           translation: "Walking 30 minutes a day is good for your health."
@@ -4205,12 +4205,12 @@
   pos: v
   defs:
     - def: "to hang (transitive), to suspend"
-      examples: 
+      examples:
         - example: "거울을 벽에 걸다."
           transliteration: "Geoureul byeoge geolda."
           translation: "Hang a mirror on a wall"
     - def: "to bet, to wager"
-      examples: 
+      examples:
         - example: "전화를 걸다"
           transliteration: "jeonhwareul geolda"
           translation: "(Idiom) To call (by telephone); to telephone"
@@ -4221,7 +4221,7 @@
   pos: a
   defs:
     - def: "rich in quality"
-      examples: 
+      examples:
         - example: "건 땅"
           transliteration: "geon ttang"
           translation: "rich soil, fertile soil"
@@ -4242,13 +4242,13 @@
   defs:
     - def: "to hang; to be hung"
     - def: "to catch; to be caught"
-      examples: 
+      examples:
         - example: "감기에 걸리다"
           transliteration: "gamgie geollida"
           translation: "be sick/ill with a cold"
     - def: "to become involved in something"
     - def: "to take (time)"
-      examples: 
+      examples:
         - example: "차로 한 시간쯤 걸려요."
           transliteration: "Charo han siganjjeum geollyeoyo."
           translation: "By car it takes about an hour."
@@ -4325,7 +4325,7 @@
   defs:
     - def: "to put (something) on, to lay (something) over, to lay (something) across"
     - def: "to extend over time or space, to cover"
-      examples: 
+      examples:
         - example: "우리는 그 문제에 대해 몇 시간에 걸쳐 얘기를 나누었다."
           transliteration: "Urineun geu munjee daehae myeot sigane geolchyeo yaegireul nanueotda."
           translation: "We discussed the problem for several hours."
@@ -4467,7 +4467,7 @@
   pos: n
   defs:
     - def: "black"
-      examples: 
+      examples:
         - example: "검정 장갑 옆에 있는 것은 어떠세요? 손님께서 찾으시는 것과 꽤 비슷한데요."
           transliteration: "Geomjeong janggap yeope inneun geoseun eotteoseyo? Sonnimkkeseo chajeusineun geotgwa kkwae biseuthandeyo."
           translation: "How about the one next to the black gloves? It's very similar to the one you like."
@@ -4532,7 +4532,7 @@
   pos: v
   defs:
     - def: "to be seized with fear; to be frightened"
-      examples: 
+      examples:
         - example: "개가 짖어대어 겁났다."
           transliteration: "Gaega jijeodaeeo geomnatda."
           translation: "I was frightened when a dog barked at me."
@@ -4552,7 +4552,7 @@
   pos: v
   defs:
     - def: "to be frightened"
-      examples: 
+      examples:
         - example: "겁먹게 만들다"
           transliteration: "geommeokge mandeulda"
           translation: "to frighten"
@@ -4569,7 +4569,7 @@
   pos: n
   defs:
     - def: "A thing; an object, one (impersonal pronoun)"
-      examples: 
+      examples:
         - example: "비싼 것"
           transliteration: "bissan geot"
           translation: "an expensive thing; something expensive; an (the) expensive one"
@@ -4577,7 +4577,7 @@
           transliteration: "I sesang-eun urideurui geosieotjiman, ijeneun neohuideurui geosida."
           translation: "This world was ours, but now it’s yours."
     - def: "(used to create noun phrases) what; the thing which"
-      examples: 
+      examples:
         - example: "내가 원하는 것"
           transliteration: "naega wonhaneun geot"
           translation: "what I want"
@@ -4596,7 +4596,7 @@
   pos: n
   defs:
     - def: "A thing; an object, one (impersonal pronoun)"
-      examples: 
+      examples:
         - example: "비싼 것"
           transliteration: "bissan geot"
           translation: "an expensive thing; something expensive; an (the) expensive one"
@@ -4604,7 +4604,7 @@
           transliteration: "I sesang-eun urideurui geosieotjiman, ijeneun neohuideurui geosida."
           translation: "This world was ours, but now it’s yours."
     - def: "(used to create noun phrases) what; the thing which"
-      examples: 
+      examples:
         - example: "내가 원하는 것"
           transliteration: "naega wonhaneun geot"
           translation: "what I want"
@@ -4633,7 +4633,7 @@
   pos: n
   defs:
     - def: "thing (nominative case)"
-      examples: 
+      examples:
         - example: "콜린 박사를 만나러 가는 게 어때요?"
           transliteration: "Kollin baksareul mannareo ganeun ge eottaeyo?"
           translation: "What do you think if we go to see Dr. Collins?"
@@ -4643,7 +4643,7 @@
   pos: pron
   defs:
     - def: "there"
-      examples: 
+      examples:
         - example: "게 누구 있느냐?"
           transliteration: "Ge nugu inneunya?"
           translation: "Is someone there?"
@@ -4659,12 +4659,12 @@
   pos: suf
   defs:
     - def: "an adverbial suffix"
-      examples: 
+      examples:
         - example: "하늘이 붉게 물들었다."
           transliteration: "Haneuri bulge muldeureotda."
           translation: "The sky turned red."
     - def: "so that; to the extent where"
-      examples: 
+      examples:
         - example: "물 마시게 컵 좀."
           transliteration: "Mul masige keop jom."
           translation: "A cup please, so I can have water."
@@ -4677,7 +4677,7 @@
   pos: suf
   defs:
     - def: "a familiar style imperative suffix"
-      examples: 
+      examples:
         - example: "말하게. 그날 자네는 뭘 하고 있었나?"
           transliteration: "Malhage. Geunal janeneun mwol hago isseonna?"
           translation: "Please tell me. What were you doing that day?"
@@ -4687,17 +4687,17 @@
   pos: suf
   defs:
     - def: "Are you going to...?"
-      examples: 
+      examples:
         - example: "지금 가게? 너무 이르지 않아?"
           transliteration: "Jigeum gage? Neomu ireuji ana?"
           translation: "Are you going now? Isn't it too early?"
     - def: "Guess what/if...!"
-      examples: 
+      examples:
         - example: "누구게?"
           transliteration: "Nuguge?"
           translation: "Guess who!"
     - def: "used to sarcastically deny the possibility of being true"
-      examples: 
+      examples:
         - example: "말만 하면 다 되게?"
           transliteration: "Malman hamyeon da doege?"
           translation: "Will it be all done just by saying?"
@@ -4729,7 +4729,7 @@
   pos: n
   defs:
     - def: "Germanic"
-      examples: 
+      examples:
         - example: "게르만 어파"
           transliteration: "gereuman eopa"
           translation: "Germanic languages"
@@ -4777,7 +4777,7 @@
   pos: n
   defs:
     - def: "laziness, idleness"
-      examples: 
+      examples:
         - example: "게으름을 피우다 (ge-eureum-eul piuda) to laze (about); to be lazy"
         - example: "시험에 떨어지지 않으려면 게으름을 그만 피우도록 하여라 (siheom-e ddeor-eojiji ant-euryeomyeon ge-eureum-eul geuman piudorok hayeora). Stop your indolence if you don't want to fail the examination."
 
@@ -4813,7 +4813,7 @@
     - def: "gate"
     - def: "gate"
     - def: "scandal, -gate"
-      examples: 
+      examples:
         - example: "최순실 게이트"
           transliteration: "choesunsil geiteu"
           translation: "2016 South Korean political scandal"
@@ -4847,7 +4847,7 @@
   pos: suf
   defs:
     - def: "(indicating intention) will; intend"
-      examples: 
+      examples:
         - example: "집에 가겠어요."
           transliteration: "Jibe gagesseoyo."
           translation: "[I] intend to go home."
@@ -4855,7 +4855,7 @@
           transliteration: "Geureoneun ge joketgunyo."
           translation: "I think I should."
     - def: "(indicating supposition) I suppose; probably"
-      examples: 
+      examples:
         - example: "비가 오겠어요."
           transliteration: "Biga ogesseoyo."
           translation: "It will probably rain."
@@ -4871,7 +4871,7 @@
   pos: n
   defs:
     - def: "bran, chaff, hull, husk (of grains)"
-      examples: 
+      examples:
         - example: "똥 묻은 개가 겨 묻은 개를 나무란다."
           transliteration: "Ttong mudeun gaega gyeo mudeun gaereul namuranda."
           translation: "A dung-stained dog finds fault with a bran-stained dog."
@@ -4895,12 +4895,12 @@
   pos: n
   defs:
     - def: "descendants of the same forefather; brothers; brethren; fellow countrymen"
-      examples: 
+      examples:
         - example: "겨레 사랑"
           transliteration: "gyeore sarang"
           translation: "fraternity among compatriots"
     - def: "race; nation; people"
-      examples: 
+      examples:
         - example: "우리 겨레의 역사"
           transliteration: "uri gyeoreui yeoksa"
           translation: "history of our nation"
@@ -5055,7 +5055,7 @@
   pos: n
   defs:
     - def: "result; outcome"
-      examples: 
+      examples:
         - example: "그 연구의 결과들은 그 주제에 관한 선행 조사들을 확증한다."
           transliteration: "Geu yeon-guui gyeolgwadeureun geu jujee gwanhan seonhaeng josadeureul hwakjeunghanda."
           translation: "The results of the study confirm previous research on the topic."
@@ -5213,7 +5213,7 @@
   pos: v
   defs:
     - def: "to marry, to get married"
-      examples: 
+      examples:
         - example: "결혼하셨어요?"
           transliteration: "Gyeolhonhasyeosseoyo?"
           translation: "Are you married?"
@@ -5224,12 +5224,12 @@
   pos: n
   defs:
     - def: "cum"
-      examples: 
+      examples:
         - example: "서재 겸 사랑"
           transliteration: "seojae gyeom sarang"
           translation: "a study cum salon"
     - def: "as well as, in addition"
-      examples: 
+      examples:
         - example: "님도 보고 뽕도 딸 겸"
           transliteration: "nimdo bogo ppongdo ttal gyeom"
           translation: "to see the lover as well as to pick mulberry leaves"
@@ -5279,7 +5279,7 @@
   pos: suf
   defs:
     - def: "around a certain time"
-      examples: 
+      examples:
         - example: "5시경, taseot-si gyeong, \"around five o'clock\""
 
 - word: 경
@@ -5292,7 +5292,7 @@
   pos: n
   defs:
     - def: "boundary"
-      examples: 
+      examples:
         - example: "중동은 경계가 명확하지는 않은 아프로·유라시아의 역사적 및 정치적 지역이다."
           transliteration: "Jungdong-eun gyeonggyega myeonghwakhajineun aneun apeuro·yurasiaui yeoksajeok mit jeongchijeok jiyeogida."
           translation: "The Middle East is a historical and political region of Afro-Eurasia with no clear boundaries."
@@ -5484,7 +5484,7 @@
   defs:
     - def: "conditions, circumstances"
     - def: "case, event"
-      examples: 
+      examples:
         - example: "그럴 경우 세미나는 연기될 수 있는 것인지요?"
           transliteration: "Geureol gyeong-u seminaneun yeon-gidoel su inneun geodinjiyo?"
           translation: "If that were to occur (In the case of it being so), could the seminar be postponed?"
@@ -5519,7 +5519,7 @@
   pos: n
   defs:
     - def: "economy"
-      examples: 
+      examples:
         - example: "아마도 미네소타 경제의 가장 두드러진 특징은 \"다양성\"일 것이다. 경제 부분의 상대적인 생산량(즉, 생산량의 비율)은 미국 전체의 그것과 대체적으로 매우 일치한다."
           transliteration: "Amado minesota gyeongjeui gajang dudeureojin teukjing-eun dayangseong-il geosida. Gyeongje bubunui sangdaejeogin saengsallyang(jeuk, saengsallyang-ui biyul)eun miguk jeonche-ui geugeotgwa daechejeogeuro mae-u ilchihanda."
           translation: "Perhaps the most significant characteristic of Minnesota's economy is its diversity; the relative outputs of its business sectors closely match the United States as a whole."
@@ -5554,7 +5554,7 @@
   pos: n
   defs:
     - def: "the police"
-      examples: 
+      examples:
         - example: "아니야, 경찰들은 민중들을 위해 존재해."
           transliteration: "Aniya, gyeongchaldeureun minjungdeureul wihae jonjaehae."
           translation: "No, the police exists for the people."
@@ -5608,7 +5608,7 @@
   pos: v
   defs:
     - def: "to experience"
-      examples: 
+      examples:
         - example: "실패를 경험하다"
           transliteration: "silpaereul gyeongheomhada"
           translation: "to experience (i.e. to suffer) a failure"
@@ -5730,7 +5730,7 @@
   pos: v
   defs:
     - def: "honorific of 있다 (itda) to stay"
-      examples: 
+      examples:
         - example: "안녕히 계세요."
           transliteration: "Annyeonghi gyeseyo."
           translation: "Goodbye. (as said by the person leaving to the person staying)"
@@ -5785,7 +5785,7 @@
   pos: v
   defs:
     - def: "honorific of 있다 (itda) to stay"
-      examples: 
+      examples:
         - example: "안녕히 계세요."
           transliteration: "Annyeonghi gyeseyo."
           translation: "Goodbye. (as said by the person leaving to the person staying)"
@@ -5859,7 +5859,7 @@
   pos: n
   defs:
     - def: "girl, chick"
-      examples: 
+      examples:
         - example: "계집애처럼 던지는데요?"
           transliteration: "Gyejibaecheoreom deonjineundeyo?"
           translation: "You throw like a girl."
@@ -5869,7 +5869,7 @@
   pos: n
   defs:
     - def: "class of people, stratum"
-      examples: 
+      examples:
         - example: "사회에서 지배계층이 하급계층의 요구를 묵살하는 일은 흔하다."
           transliteration: "Sahoeeseo jibaegyecheung-i hageupgyecheung-ui yogureul muksalhaneun ireun heunhada."
           translation: "In society a dominant group often ignores the wishes of subordinate groups."
@@ -5885,7 +5885,7 @@
   pos: n
   defs:
     - def: "a plan"
-      examples: 
+      examples:
         - example: "너는 이 계획에 대해서 어떻게 생각하지?"
           transliteration: "Neoneun i gyehoege daehaeseo eotteoke saenggakhaji?"
           translation: "What do you think of this plan?"
@@ -6130,7 +6130,7 @@
   pos: v
   defs:
     - def: "To consider or reflect on something."
-      examples: 
+      examples:
         - example: "그는 파리를 떠날 것을 고려하고 있다."
           transliteration: "Geuneun parireul tteonal geoseul goryeohago itda."
           translation: "He’s thinking about leaving Paris."
@@ -6230,7 +6230,7 @@
   pos: a
   defs:
     - def: "(to be) thankful"
-      examples: 
+      examples:
         - example: "This adjective is often translated as a form of “to thank”."
         - example: "고맙습니다"
           transliteration: "gomapseumnida"
@@ -6431,7 +6431,7 @@
   pos: a
   defs:
     - def: "awful, nasty, foul"
-      examples: 
+      examples:
         - example: "그 값이 싸고 질이 나쁜 음식은 냄새가 고약했다."
           transliteration: "Geu gapsi ssago jiri nappeun eumsigeun naemsaega goyakhaetda."
           translation: "The cheap and nasty food smelled awful."
@@ -6442,7 +6442,7 @@
   pos: n
   defs:
     - def: "cat"
-      examples: 
+      examples:
         - example: "조용한 고양이가 쥐를 잡는다."
           transliteration: "Joyonghan goyang-iga jwireul jamneunda."
           translation: "The quiet cat catches the mouse. (proverb)"
@@ -6473,7 +6473,7 @@
   defs:
     - def: "characteristics; essence"
     - def: "the identity of a particular person; the characteristic of an ethnic group"
-      examples: 
+      examples:
         - example: "In this sense, it is often used attributively and translated as \"proper\". See also Category:Korean proper nouns."
 
 - word: 고유명사
@@ -6549,7 +6549,7 @@
   pos: n
   defs:
     - def: "fixity; immobility"
-      examples: 
+      examples:
         - example: "고정 자산 fixed assets"
         - example: "나는 고정된 급여에 고정된 시간 동안 일한다. I work fixed hours for a fixed salary."
         - example: "모든 종교는 각각 고정된 사상을 가지고 있다. Every religion has its own fixed ideas."
@@ -6568,7 +6568,7 @@
   defs:
     - def: "To tone up; be raised"
     - def: "To be elated; be enhanced"
-      examples: 
+      examples:
         - example: "그것은 기후 변화의 효과로 인해 고조되었다고 그녀는 덧붙였다."
           transliteration: "Geugeoseun gihu byeonhwaui hyogwaro inhae gojodoeeotdago geunyeoneun deotbutyeotda."
           translation: "“That’s heightened by the impact of climate change,” she added."
@@ -6585,7 +6585,7 @@
   pos: n
   defs:
     - def: "A chronic disease, a disease that is not easily healed."
-      examples: 
+      examples:
         - example: "우울증이 내 고질병이야."
           transliteration: "Uuljeung-i nae gojilbyeong-iya."
           translation: "I am chronically depressed."
@@ -6824,7 +6824,7 @@
   pos: adv
   defs:
     - def: "soon, at once, immediately, shortly, straightway"
-      examples: 
+      examples:
         - example: "곧 야구 경기가 시작된다."
           transliteration: "Got yagu gyeonggiga sijakdoenda."
           translation: "The baseball match will begin shortly."
@@ -6896,7 +6896,7 @@
   pos: n
   defs:
     - def: "alley"
-      examples: 
+      examples:
         - example: "그 골목에는 그라피티가 가득하다."
           transliteration: "Geu golmogeneun geurapitiga gadeukhada."
           translation: "The alleyway has a lot of grafitti."
@@ -6950,7 +6950,7 @@
   pos: n
   defs:
     - def: "golf (sport)"
-      examples: 
+      examples:
         - example: "골프를 치다"
           transliteration: "golpeureul chida"
           translation: "to play golf"
@@ -7109,7 +7109,7 @@
   pos: n
   defs:
     - def: "offensive war"
-      examples: 
+      examples:
         - example: "《공격전이다》"
           transliteration: "《 Gonggyeokjeonida》"
           translation: "\"It's War\" "
@@ -7143,7 +7143,7 @@
   pos: n
   defs:
     - def: "supply"
-      examples: 
+      examples:
         - example: "그녀는 \"중국은 세계 인구의 20퍼센트를 가진 나라로, 깨끗한 물은 세계의 7퍼센트 밖에는 가지지 못하여, 항상 깨끗한 물의 공급 문제를 안고 있다.\"고 말했다."
           transliteration: "Geunyeoneun junggugeun segye in-guui 20peosenteureul gajin nararo, kkaekkeuthan mureun segye-ui 7peosenteu bakkeneun gajiji mothayeo, hangsang kkaekkeuthan murui gonggeup munjereul an-go itda.go malhaetda."
           translation: "She said, “China has always had a freshwater supply problem with 20 percent of the world’s population but only 7 percent of its freshwater."
@@ -7252,7 +7252,7 @@
   pos: n
   defs:
     - def: "construction"
-      examples: 
+      examples:
         - example: "그러나 실제 공사는 한군데 이상 서로 다른 장소에서 수행된다."
           transliteration: "Geureona silje gongsaneun han-gunde isang seoro dareun jangso-eseo suhaengdoenda."
           translation: "But the actual construction work is performed at one or more different sites."
@@ -7446,7 +7446,7 @@
   pos: n
   defs:
     - def: "process"
-      examples: 
+      examples:
         - example: "공장장이 우리에게 신제품 생산 공정을 보여주었다."
           transliteration: "Gongjangjang-i uriege sinjepum saengsan gongjeong-eul boyeojueotda."
           translation: "The plant manager showed us the new product line."
@@ -7500,7 +7500,7 @@
   pos: n
   defs:
     - def: "something which is free, which does not have to be paid for"
-      examples: 
+      examples:
         - example: "공짜음악"
           transliteration: "gongjjaeumak"
           translation: "free music (e.g. downloadable)"
@@ -7538,7 +7538,7 @@
   pos: n
   defs:
     - def: "airport"
-      examples: 
+      examples:
         - example: "인천 공항까지 좀 태워 주실래요?"
           transliteration: "Incheon gonghangkkaji jom taewo jusillaeyo?"
           translation: "Can you give me a ride to Incheon airport?"
@@ -7556,7 +7556,7 @@
   pos: a
   defs:
     - def: "(to be) void"
-      examples: 
+      examples:
         - example: "땅이 混沌하고 空虛하며 黑暗이 깊음 위에 있고 하나님의 神은 水面에 運行하시니라땅이 혼돈하고 공허하며; 흑암이 깊음 위에 있고. 하나님의 신은 수면에 운행하시니라."
           transliteration: "Ttang-i hondonhago gongheohamyeo; heugami gipeum wie itgo. Hananimui sineun sumyeone unhaenghasinira."
           translation: "And the earth was without form, and void; and darkness was upon the face of the deep. And the Spirit of God moved upon the face of the waters."
@@ -7567,7 +7567,7 @@
   pos: n
   defs:
     - def: "republic"
-      examples: 
+      examples:
         - example: "남아프리카 공화국"
           transliteration: "Namapeurika gonghwaguk"
           translation: "Republic of South Africa"
@@ -7589,12 +7589,12 @@
   pos: part
   defs:
     - def: "and"
-      examples: 
+      examples:
         - example: "책과 연필"
           transliteration: "chaekgwa yeonpil"
           translation: "pencil and book"
     - def: "with; together with"
-      examples: 
+      examples:
         - example: "가족과 같이 가세요?"
           transliteration: "Gajokgwa gachi gaseyo?"
           translation: "Are [you] going with [your] family?"
@@ -7611,12 +7611,12 @@
   pos: suf
   defs:
     - def: "an academic department"
-      examples: 
+      examples:
         - example: "물리학과"
           transliteration: "mullihakgwa"
           translation: "department of physics"
     - def: "a taxonomic family"
-      examples: 
+      examples:
         - example: "사다샛과"
           transliteration: "sadasaetgwa"
           translation: "Pelecanidae"
@@ -7627,7 +7627,7 @@
   pos: n
   defs:
     - def: "lesson, chapter"
-      examples: 
+      examples:
         - example: "제1(일)과"
           transliteration: "je1(il)gwa"
           translation: "the first lesson"
@@ -7749,7 +7749,7 @@
   pos: n
   defs:
     - def: "fruit"
-      examples: 
+      examples:
         - example: "과일에는 많은 비타민이 들어 있다."
           transliteration: "Gwaireneun maneun bitamini deureo itda."
           translation: "There are many vitamins in fruit."
@@ -7879,7 +7879,7 @@
   pos: n
   defs:
     - def: "connection; relationship"
-      examples: 
+      examples:
         - example: "제니와 마크는 그들이 멕시코로 휴가를 다녀온 이후로 연인 관계에 있다."
           transliteration: "Jeniwa makeuneun geudeuri meksikoro hyugareul danyeoon ihuro yeonin gwan-gyee itda."
           translation: "Jenny and Mark have been together since they went on holiday to Mexico."
@@ -7901,7 +7901,7 @@
   pos: adv
   defs:
     - def: "irrespectively, regardlessly"
-      examples: 
+      examples:
         - example: "성패에 관계없이"
           transliteration: "seongpaee gwan-gyeeopsi"
           translation: "whether successful or not"
@@ -7915,7 +7915,7 @@
   defs:
     - def: "a concerned, involved or interested party"
     - def: "authorized personnel; official"
-      examples: 
+      examples:
         - example: "지난 해, 위롱 설산 공원의 관계자는 이백육십만명의 방문객이 그 산을 방문했다고 보고했다."
           transliteration: "Jinan hae, wirong seolsan gong-wonui gwan-gyejaneun ibaegyuksimmanmyeong-ui bangmun-gaegi geu saneul bangmunhaetdago bogohaetda."
           translation: "Last year, Yulong Snow Mountain park officials reported that 2.6 million visitors came to the mountain."
@@ -8208,7 +8208,7 @@
   pos: n
   defs:
     - def: "a place of storage, especially a granary."
-      examples: 
+      examples:
         - example: "Proverb: 광에서 인심 난다 (gwang-eseo insim nanda, “compassion comes from the storehouse”) i.e. only when one is provided for can one care for others"
 
 - word: 광
@@ -8217,7 +8217,7 @@
   defs:
     - def: "light; a light"
     - def: "luster, sheen"
-      examples: 
+      examples:
         - example: "note: in this sense the vowel is lengthened, /kwaːŋ/"
         - example: "광을 내다 (gwang-eul naeda, “to be lustrous”)"
 
@@ -8430,7 +8430,7 @@
   pos: a
   defs:
     - def: "to be nice, good, passable, OK, all right"
-      examples: 
+      examples:
         - example: "괜찮아"
           transliteration: "gwaenchana"
           translation: "OK"
@@ -8453,7 +8453,7 @@
   pos: a
   defs:
     - def: "to be nice, good, passable, OK, all right"
-      examples: 
+      examples:
         - example: "괜찮아"
           transliteration: "gwaenchana"
           translation: "OK"
@@ -8589,7 +8589,7 @@
   pos: n
   defs:
     - def: "believer (of a religion); follower"
-      examples: 
+      examples:
         - example: "이슬람교도"
           transliteration: "iseullamgyodo"
           translation: "Muslim"
@@ -8611,7 +8611,7 @@
   pos: n
   defs:
     - def: "bridge"
-      examples: 
+      examples:
         - example: "월스트리트에서 애펄래치아 산맥까지 미시시피 강 삼각주까지 교량을 만들기 위해"
           transliteration: "wolseuteuriteueseo aepeollaechia sanmaekkkaji misisipi gang samgakjukkaji gyoryang-eul mandeulgi wihae"
           translation: "to build a bridge from Wall Street to Appalachia to the Mississippi Delta"
@@ -8716,7 +8716,7 @@
   pos: n
   defs:
     - def: "education"
-      examples: 
+      examples:
         - example: "그녀는 교육을 잘 받았기에 좋은 직장을 구하였다."
           transliteration: "Geunyeoneun gyoyugeul jal badatgie joeun jikjang-eul guhayeotda."
           translation: "She is well educated because of which she has got a good job."
@@ -8726,7 +8726,7 @@
   pos: v
   defs:
     - def: "to educate; to train"
-      examples: 
+      examples:
         - example: "왕 씨는 바이수에이 운하의 그러한 변화는 기후 변화에게 관하여 방문객들을 교육할 기회를 제공한다고 말했다."
           transliteration: "Wang ssineun baisuei unhaui geureohan byeonhwaneun gihu byeonhwa-ege gwanhayeo bangmun-gaekdeureul gyoyukhal gihoereul jegonghandago malhaetda."
           translation: "Wang said such changes to the Baishui glacier provide the chance to educate visitors about global warming."
@@ -8784,7 +8784,7 @@
   pos: n
   defs:
     - def: "crossing, crossroad, crossway, intersection, junction"
-      examples: 
+      examples:
         - example: "예술, 과학, 문화의 교차로에서"
           transliteration: "yesul, gwahak, munhwaui gyocharoeseo"
           translation: "at the intersection of art, science and culture"
@@ -8820,7 +8820,7 @@
   pos: n
   defs:
     - def: "teacher's pointer"
-      examples: 
+      examples:
         - example: "교편을 잡다"
           transliteration: "gyopyeoneul japda"
           translation: "to teach at school"
@@ -9002,7 +9002,7 @@
   pos: n
   defs:
     - def: "hole"
-      examples: 
+      examples:
         - example: "바지에 구녕이 났네!"
           transliteration: "Baji-e gunyeong-i nanne!"
           translation: "There's a hole in my pants!"
@@ -9107,7 +9107,7 @@
   pos: n
   defs:
     - def: "cloud"
-      examples: 
+      examples:
         - example: "구름 개다"
           transliteration: "gureum gaeda"
           translation: " to be cleared"
@@ -9184,7 +9184,7 @@
   pos: n
   defs:
     - def: "hole, aperture, opening"
-      examples: 
+      examples:
         - example: "벽에 구멍을 뚫다"
           transliteration: "byeoge gumeong-eul ttulta"
           translation: "to drill a hole in a wall"
@@ -9225,7 +9225,7 @@
   pos: v
   defs:
     - def: "to differentiate, to distinguish; to tell the difference"
-      examples: 
+      examples:
         - example: "일난성 쌍동이의 외모는 구별하기 어렵다."
           transliteration: "Illanseong ssangdong-iui oemoneun gubyeolhagi eoryeopda."
           translation: "It's difficult to distinguish between the identical twins."
@@ -9307,7 +9307,7 @@
   pos: v
   defs:
     - def: "To be configured or shaped."
-      examples: 
+      examples:
         - example: "물은 수소와 산소로 구성되어 있다."
           transliteration: "Mureun susowa sansoro guseongdoeeo itda."
           translation: "Water is composed of hydrogen and oxygen."
@@ -9347,7 +9347,7 @@
   pos: n
   defs:
     - def: "old style"
-      examples: 
+      examples:
         - example: "그런 모자는 이제는 구식이다."
           transliteration: "Geureon mojaneun ijeneun gusigida."
           translation: "That kind of hat is out of fashion now."
@@ -9516,7 +9516,7 @@
   pos: v
   defs:
     - def: "to look for, to seek, to save"
-      examples: 
+      examples:
         - example: "파트타임 일자리를 구하다"
           transliteration: "pateutaim iljarireul guhada"
           translation: "to look for a part-time job"
@@ -9558,7 +9558,7 @@
   pos: n
   defs:
     - def: "national anthem"
-      examples: 
+      examples:
         - example: "국가가 끝나면 청중들을 착석하게 하고서는 첫번째 연설자를 소개해 주세요."
           transliteration: "Gukgaga kkeunnamyeon cheongjungdeureul chakseokhage hagoseoneun cheotbeonjjae yeonseoljareul sogaehae juseyo."
           translation: "Please seat the audience after the national anthem and then introduce the first speaker."
@@ -9609,7 +9609,7 @@
   pos: n
   defs:
     - def: "situation, state, phase; aspect"
-      examples: 
+      examples:
         - example: "파업이 새로운 국면에 접어들었다."
           transliteration: "Pa-eobi saeroun gungmyeone jeobeodeureotda."
           translation: "The strike has entered new conditions."
@@ -9675,7 +9675,7 @@
     - def: "national language"
     - def: "one's native language"
     - def: "the Korean language"
-      examples: 
+      examples:
         - example: "국어사전"
           transliteration: "gugeosajeon"
           translation: "dictionary of the national language; Korean dictionary"
@@ -9792,7 +9792,7 @@
     - def: "君: a prince"
     - def: "君: a young man (often used following a name, e.g. \"김 군\")"
     - def: "郡: county, a secondary administrative division of both North and South Korea. (/kuːn/) "
-      examples: 
+      examples:
         - example: "(Administrative divisions of South Korea) 리 (ri), 동 (dong), 면 (myeon), 읍 (eup), 구 (gu), 군 (gun), 시 (si), 도 (do) "
 
 - word: 군
@@ -9818,7 +9818,7 @@
   pos: v
   defs:
     - def: "to behave, to conduct oneself, to act"
-      examples: 
+      examples:
         - example: "너는 우습게 군다."
           transliteration: "Neoneun useupge gunda."
           translation: "You are being funny."
@@ -9829,7 +9829,7 @@
   pos: n
   defs:
     - def: "corps; legion"
-      examples: 
+      examples:
         - example: "로마 군단"
           transliteration: "Roma gundan"
           translation: "Roman legion"
@@ -9888,7 +9888,7 @@
   pos: n
   defs:
     - def: "Military affairs."
-      examples: 
+      examples:
         - example: "군사 훈련은 힘들었지만, 난 이겨냈다."
           transliteration: "Gunsa hullyeoneun himdeureotjiman, nan igyeonaetda."
           translation: "Military training was hard, but I got through it."
@@ -9898,7 +9898,7 @@
   pos: n
   defs:
     - def: "chatter; prattle"
-      examples: 
+      examples:
         - example: "군소리 좀 작작 하여라."
           transliteration: "gunsori jom jakjak hayeora."
           translation: "Kindly keep your prattle to a reasonable level."
@@ -9907,7 +9907,7 @@
   pos: suf
   defs:
     - def: "really, indeed. inflectional suffix to express exclamation after an adjective or 있다 (itda)."
-      examples: 
+      examples:
         - example: "그는 다재다능한 사람이군요!"
           translation: "He is multi-talented!"
         - example: "그는 재미있는 사람이군요."
@@ -9918,7 +9918,7 @@
   pos: n
   defs:
     - def: "soldier"
-      examples: 
+      examples:
         - example: "군인은 상대방을 쏘기 위해서 화기를 사용한다."
           transliteration: "Gunineun sangdaebang-eul ssogi wihaeseo hwagireul sayonghanda."
           translation: "Soldiers used the firearms to shot the other side."
@@ -9945,7 +9945,7 @@
   pos: n
   defs:
     - def: "crowd"
-      examples: 
+      examples:
         - example: "군중들이 다가와서 난 기차까지 뚫고 지나갈 수 없었다."
           transliteration: "Gunjungdeuri dagawaseo nan gichakkaji ttulko jinagal su eopseotda."
           translation: "The crowd closed up and I couldn't get through to the train."
@@ -9961,7 +9961,7 @@
   pos: n
   defs:
     - def: "(a biological) colony"
-      examples: 
+      examples:
         - example: "개미 군체"
           transliteration: "gaemi gunche"
           translation: "a colony of ants; anthill"
@@ -10025,7 +10025,7 @@
   pos: v
   defs:
     - def: "to behave, to conduct oneself, to act"
-      examples: 
+      examples:
         - example: "너는 우습게 군다."
           transliteration: "Neoneun useupge gunda."
           translation: "You are being funny."
@@ -10087,7 +10087,7 @@
   pos: v
   defs:
     - def: "to skip (a meal), to starve, to fast"
-      examples: 
+      examples:
         - example: "굶어 죽다"
           transliteration: "gulmeo jukda"
           translation: "to be starved to death"
@@ -10103,7 +10103,7 @@
   pos: v
   defs:
     - def: "to skip (a meal), to starve, to fast"
-      examples: 
+      examples:
         - example: "굶어 죽다"
           transliteration: "gulmeo jukda"
           translation: "to be starved to death"
@@ -10280,7 +10280,7 @@
   pos: n
   defs:
     - def: "power and prestige; authority"
-      examples: 
+      examples:
         - example: "그 소위, 높이 평가된다는 권위 기관이 그에게, 그가 그곳에 들어갈 수 없다고 말했다."
           transliteration: "Geu sowi, nopi pyeonggadoendaneun gwonwi gigwani geuege, geuga geugose deureogal su eopdago malhaetda."
           translation: "That esteemed establishment told him that he wasn't allowed to enter it."
@@ -10340,7 +10340,7 @@
   pos: n
   defs:
     - def: "ear, auricle"
-      examples: 
+      examples:
         - example: "쇠귀에 경 읽기"
           transliteration: "soegwie gyeong ilgi"
           translation: "As useless as reciting a sutra to the ears of a cow."
@@ -10492,7 +10492,7 @@
   pos: a
   defs:
     - def: "(to be) tiresome, annoying, bothering, troublesome"
-      examples: 
+      examples:
         - example: "양이 너무 많아서 하기가 귀찮다."
           transliteration: "Yang-i neomu manaseo hagiga gwichanta."
           translation: "It's too much to do."
@@ -10528,7 +10528,7 @@
   pos: n
   defs:
     - def: "earlobe"
-      examples: 
+      examples:
         - example: "부처님은 귓불이 길다."
           transliteration: "Bucheonimeun gwitburi gilda."
           translation: "Buddha has long earlobes."
@@ -10576,7 +10576,7 @@
   pos: n
   defs:
     - def: "rule"
-      examples: 
+      examples:
         - example: "넌 여러 가지의 규칙을 어겼다."
           transliteration: "Neon yeoreo gajiui gyuchigeul eogyeotda."
           translation: "You have broken various rules."
@@ -10588,7 +10588,7 @@
   pos: det
   defs:
     - def: "regular; systematic"
-      examples: 
+      examples:
         - example: "규칙적 생활"
           transliteration: "gyuchikjeok saenghwal"
           translation: "regular life"
@@ -10597,7 +10597,7 @@
   pos: n
   defs:
     - def: "均:  An ancient Chinese musical term indicating which of the twelve pitches of the Chinese chromatic scale would be the starting pitch"
-      examples: 
+      examples:
         - example: "태주균"
           transliteration: "taeju-gyun"
           translation: "starting from the da cu pitch"
@@ -10616,7 +10616,7 @@
   pos: n
   defs:
     - def: "balance; equilibrium"
-      examples: 
+      examples:
         - example: "그리고 균형 예산으로 또 다른 20만명이 일을 한다는 자존감과 긍지를 갖도록 도울 것입니다."
           transliteration: "Geurigo gyunhyeong yesaneuro tto dareun 20manmyeong-i ireul handaneun jajon-gamgwa geungjireul gatdorok doul geosimnida."
           translation: "And our balanced budget will help another 200,000 people move to the dignity and pride of work."
@@ -10652,7 +10652,7 @@
   pos: pron
   defs:
     - def: "that (thing near the listener)"
-      examples: 
+      examples:
         - example: "그것은 펜이 아니야. 그것은 책이야."
           transliteration: "Geugeoseun peni aniya. Geugeoseun chaegiya."
           translation: "It is not a pen. It is a book."
@@ -10759,7 +10759,7 @@
   pos: adv
   defs:
     - def: "so much; to that extent"
-      examples: 
+      examples:
         - example: "그의 방은 그다지 따뜻하지 않다."
           transliteration: "geuui bang-eun geudaji ttatteuthaji anta."
           translation: "It isn't very warm in his room."
@@ -10783,7 +10783,7 @@
   pos: adv
   defs:
     - def: "since our last meeting or conversation"
-      examples: 
+      examples:
         - example: "그동안 잘 지내셨습니까?"
         - example: "geudongan jal jinaesyeosseumnikka? - Have you been well?"
     - def: "the period of time just mentioned (= 그 동안)"
@@ -10829,12 +10829,12 @@
   pos: intj
   defs:
     - def: "yeah"
-      examples: 
+      examples:
         - example: "응, 그래."
           transliteration: "Eung, geurae."
           translation: "Yeah, okay. (casual)"
     - def: "really?"
-      examples: 
+      examples:
         - example: "그래? 미처 생각도 못했네."
           transliteration: "Geurae? Micheo saenggakdo mothaenne."
           translation: "Really? (I) didn't really think about that either. (casual)"
@@ -10887,12 +10887,12 @@
   pos: v
   defs:
     - def: "to do so, to do it"
-      examples: 
+      examples:
         - example: "그러시죠."
           transliteration: "Geureosijyo."
           translation: "Let’s do so."
     - def: "to say so"
-      examples: 
+      examples:
         - example: "누가 그랬어?"
           transliteration: "Nuga geuraesseo?"
           translation: "Who said so?"
@@ -10950,12 +10950,12 @@
   pos: adv
   defs:
     - def: "so, so much"
-      examples: 
+      examples:
         - example: "나는 그렇게 생각하지 않아."
           transliteration: "Naneun geureoke saenggakhaji ana."
           translation: "I don't think so."
     - def: "in that way, to that extent"
-      examples: 
+      examples:
         - example: "난 정말 그렇게 하기는 원하지 않아."
           transliteration: "Nan jeongmal geureoke hagineun wonhaji ana."
           translation: "I really do not want to do that."
@@ -10965,7 +10965,7 @@
   pos: a
   defs:
     - def: "to be thus, in that way; to be correct"
-      examples: 
+      examples:
         - example: "그래요?"
           transliteration: "Geuraeyo?"
           translation: "Really? Is it really so?"
@@ -10977,7 +10977,7 @@
   defs:
     - def: "yes"
     - def: "isn't it? aren't you?, etc. (seeking confirmation)"
-      examples: 
+      examples:
         - example: "농담이지, 그렇지?"
           transliteration: "Nongdamiji, geureochi?"
           translation: "You're kidding, right?"
@@ -11050,7 +11050,7 @@
   pos: a
   defs:
     - def: "to be wrong, incorrect"
-      examples: 
+      examples:
         - example: "행실이 그르다"
           transliteration: "haengsiri geureuda"
           translation: "wrong conduct"
@@ -11073,7 +11073,7 @@
   pos: n
   defs:
     - def: "bowl"
-      examples: 
+      examples:
         - example: "밥 한그릇"
           transliteration: "bap han-geureut"
           translation: "a bowl of rice"
@@ -11094,7 +11094,7 @@
   pos: v
   defs:
     - def: "to become wrong (immoral); to become false; to become bad (a bad action, habit)"
-      examples: 
+      examples:
         - example: "Usually be translated with \"be\" instead of \"become\"."
   conj: [그릇된다, 그릇돼, 그릇돼요/그릇되어요, 그릇됩니다]
 
@@ -11186,7 +11186,7 @@
   pos: n
   defs:
     - def: "picture, drawing, painting, sketch"
-      examples: 
+      examples:
         - example: "거실 벽에는 그림들이 걸려 있었다."
           transliteration: "Geosil byeogeneun geurimdeuri geollyeo isseotda."
           translation: "Some pictures were hanging on the wall in the living room."
@@ -11211,7 +11211,7 @@
   pos: n
   defs:
     - def: "shadow, shady image"
-      examples: 
+      examples:
         - example: "그 컨설턴트가 지난 주 내내 내 업무에 그림자처럼 나를 따라다녔다."
           transliteration: "Geu keonseolteonteuga jinan ju naenae nae eommue geurimjacheoreom nareul ttaradanyeotda."
           translation: "The consultant shadowed me in my jobs over the last week."
@@ -11235,7 +11235,7 @@
   pos: adv
   defs:
     - def: "this much only; no more. often used in imperatives."
-      examples: 
+      examples:
         - example: "그만 먹어!"
           transliteration: "Geuman meogeo!"
           translation: "Eat no more! (Stop eating!)"
@@ -11265,7 +11265,7 @@
   pos: n
   defs:
     - def: "net, fishnet"
-      examples: 
+      examples:
         - example: "그물이 삼천 코라도 벼리가 으뜸."
           transliteration: "Geumuri samcheon korado byeoriga eutteum."
           translation: "The manipulation rope is the top-flight of a fishnet that even has as many as three thousand meshes."
@@ -11337,7 +11337,7 @@
   pos: adv
   defs:
     - def: "there, that way"
-      examples: 
+      examples:
         - example: "헬스클럽은 라운지 건너편에 있어. 우편실 옆이야. 저쪽으로 가렴. 고마워 피트. 아냐, 안나, 그쪽이 아냐. 저쪽으로 가렴."
           transliteration: "Helseukeulleobeun raunji geonneopyeone isseo. Upyeonsil yeopiya. Jeojjogeuro garyeom. Gomawo piteu. Anya, anna, geujjogi anya. Jeojjogeuro garyeom."
           translation: "The gym is across from the lounge. It’s next to the mailroom. Go that way. — Thanks, Pete! — No, Anna! Not that way! Go that way!"
@@ -11373,7 +11373,7 @@
   pos: v
   defs:
     - def: "To overcome; to prevail against adversity."
-      examples: 
+      examples:
         - example: "위기를 극복하다"
           transliteration: "wigireul geukbokhada"
           translation: "to overcome a crisis"
@@ -11559,7 +11559,7 @@
   pos: n
   defs:
     - def: "neighborhood; vicinity; the nearby area"
-      examples: 
+      examples:
         - example: "이 근처에 수퍼마켓이 있을까?"
           transliteration: "I geuncheoe supeomakesi isseulkka?"
           translation: "Is there a supermarket near here?"
@@ -11569,7 +11569,7 @@
   pos: propn
   defs:
     - def: "Geun-hye (Korean female given name)"
-      examples: 
+      examples:
         - example: "박근혜"
           transliteration: "BakGeunhye"
           translation: "Park Geun-hye (the eleventh President of South Korea) (朴槿惠)"
@@ -11735,7 +11735,7 @@
   pos: adv
   defs:
     - def: "soon, shortly"
-      examples: 
+      examples:
         - example: "금방 돌아올게요."
           transliteration: "Geumbang doraolgeyo."
           translation: "I'll be right back."
@@ -12134,7 +12134,7 @@
   pos: v
   defs:
     - def: "To be expected"
-      examples: 
+      examples:
         - example: "잘 될 것으로 기대된다."
           transliteration: "jal doel geos-euro gidaedoenda."
           translation: "It is expected to turn out OK."
@@ -12189,7 +12189,7 @@
   pos: n
   defs:
     - def: "pillar, column, post"
-      examples: 
+      examples:
         - example: "헤라클레스의 기둥은 지중해 입구에 놓여진 것으로 추정된다."
           transliteration: "Herakeulleseuui gidung-eun jijunghae ipgue noyeojin geoseuro chujeongdoenda."
           translation: "The Pillars of Hercules, [...] (are) [...] supposed to have been placed at the mouth of the Mediterranean."
@@ -12298,7 +12298,7 @@
   pos: n
   defs:
     - def: "fraud; deception"
-      examples: 
+      examples:
         - example: "기망행위"
           transliteration: "gimanghaeng-wi"
           translation: "act of fraud"
@@ -12364,7 +12364,7 @@
   pos: n
   defs:
     - def: "feeling, mood"
-      examples: 
+      examples:
         - example: "지금은 기분이 안 좋아요."
           transliteration: "Jigeumeun gibuni an joayo."
           translation: "I'm not feeling well now."
@@ -12388,7 +12388,7 @@
   pos: n
   defs:
     - def: "joy; happiness"
-      examples: 
+      examples:
         - example: "기쁨에 넘쳐 자신도 모르게 크게 소리치다."
           transliteration: "Gippeume neomchyeo jasindo moreuge keuge sorichida."
           translation: "To be so overcome with joy that one cries out."
@@ -12441,7 +12441,7 @@
   pos: n
   defs:
     - def: "parasite"
-      examples: 
+      examples:
         - example: "우리 몸 속에 있는 기생충의 알"
           transliteration: "uri mom soge inneun gisaengchung-ui al"
           translation: "the nits on our bodies"
@@ -12469,7 +12469,7 @@
   pos: n
   defs:
     - def: "dormitory, dorm, hall of residence"
-      examples: 
+      examples:
         - example: "기숙사가 어디입니까?"
           transliteration: " Gisuksaga eodiimnikka?"
           translation: "Where is the dormitory?"
@@ -12536,7 +12536,7 @@
   pos: v
   defs:
     - def: "to remember"
-      examples: 
+      examples:
         - example: "저 기억하세요? 저 당신 건물에 살아요."
           transliteration: "Jeo gieokhaseyo? Jeo dangsin geonmure sarayo."
           translation: "Remember me? I live in your building."
@@ -12676,7 +12676,7 @@
   pos: n
   defs:
     - def: "steam whistle"
-      examples: 
+      examples:
         - example: "기적소리"
           transliteration: "gijeoksori"
           translation: "sound of a steam whistle"
@@ -12715,7 +12715,7 @@
   pos: a
   defs:
     - def: "amazing; breathtaking; kickass"
-      examples: 
+      examples:
         - example: "기차게 노래를 잘 한다."
           transliteration: "Gichage noraereul jal handa."
           translation: "[He] sings insanely well."
@@ -12824,7 +12824,7 @@
   pos: n
   defs:
     - def: "climate (long-term atmospheric conditions)"
-      examples: 
+      examples:
         - example: "그리고, 기후 변화로 인한 효과는 이미 극심하다."
           transliteration: "Geurigo, gihu byeonhwaro inhan hyogwaneun imi geuksimhada."
           translation: "And the effects from climate change are already extreme."
@@ -12956,7 +12956,7 @@
   pos: propn
   defs:
     - def: "Kim (most common surname in Korea, both North and South)"
-      examples: 
+      examples:
         - example: "김정은"
           transliteration: "GimJeong-eun"
           translation: "Kim Jong-un"
@@ -13132,7 +13132,7 @@
   pos: n
   defs:
     - def: "reason, cause"
-      examples: 
+      examples:
         - example: "그 까닭이 무엇인고?"
           transliteration: "Geu kkadalgi mueodin-go?"
           translation: "What is the reason?"
@@ -13246,7 +13246,7 @@ Used to illustrate the degree or intensity of a situation.
   defs:
     - def: "to cut, to shave, to peel"
     - def: "to reduce, to discount"
-      examples: 
+      examples:
         - example: "너무 비싸요. 조금만 깎아 주세요?"
           transliteration: "Neomu bissayo. Jogeumman kkakka juseyo?"
           translation: "It's too expensive. Can you give a little discount?"
@@ -13302,7 +13302,7 @@ Used to illustrate the degree or intensity of a situation.
   pos: n
   defs:
     - def: "can, tin"
-      examples: 
+      examples:
         - example: "깡통을 차다"
           transliteration: "kkangtong-eul chada"
           translation: "[idiom] to be reduced to begging"
@@ -13332,7 +13332,7 @@ Used to illustrate the degree or intensity of a situation.
   pos: a
   defs:
     - def: "to be clean"
-      examples: 
+      examples:
         - example: "존슨은 \"그것이 얼마나 많이 녹느냐에 따라서, 많은 깨끗한 물이 지역을 떠나서 대양으로 향하게 될 것이며, 이는 식수와 음식의 안전에 심각한 충격을 줄 것이다\"라고 한다."
           transliteration: "Jonseuneun geugeosi eolmana mani nongneunya-e ttaraseo, maneun kkaekkeuthan muri jiyeogeul tteonaseo daeyang-euro hyanghage doel geosimyeo, ineun siksuwa eumsigui anjeone simgakhan chunggyeogeul jul geosidarago handa."
           translation: "Johnson said, “Depending on how it melts, a lot of the freshwater will be leaving the region for the ocean, which will have severe impacts on water and food security.\""
@@ -13377,7 +13377,7 @@ Used to illustrate the degree or intensity of a situation.
   pos: v
   defs:
     - def: "to chew, to bite hard, to gnaw"
-      examples: 
+      examples:
         - example: "혀를 깨물다"
           transliteration: "hyeoreul kkaemulda"
           translation: "to bite one's tongue"
@@ -13438,7 +13438,7 @@ Used to illustrate the degree or intensity of a situation.
   pos: n
   defs:
     - def: "that of."
-      examples: 
+      examples:
         - example: "내 꺼에요."
           translation: "It’s mine."
 
@@ -13472,7 +13472,7 @@ Used to illustrate the degree or intensity of a situation.
     - def: "to sink, to cave in"
     - def: "to become sunken, to become hollow"
     - def: "to fade away"
-      examples: 
+      examples:
         - example: "이제 꺼져."
           transliteration: "Ije kkeojyeo."
           translation: "Now bugger off!"
@@ -13529,7 +13529,7 @@ Used to illustrate the degree or intensity of a situation.
   pos: n
   defs:
     - def: "gum, chewing gum"
-      examples: 
+      examples:
         - example: "껌은 단맛이 빠질때까지 씹다가 삼키지 않고 버리는 음식이다."
           transliteration: "Kkeomeun danmasi ppajilttaekkaji ssipdaga samkiji anko beorineun eumsigida."
           translation: "Gum is a substance which you chew for a long time until it loses its sweetness, but do not swallow."
@@ -13545,7 +13545,7 @@ Used to illustrate the degree or intensity of a situation.
   pos: part
   defs:
     - def: "The honorific form of the particle 에게 (ege) meaning to, by, or for"
-      examples: 
+      examples:
         - example: "저는 선생님께 사과를 드렸습니다."
           transliteration: "Jeoneun seonsaengnimkke sagwareul deuryeotseumnida."
           translation: "I gave an apple to the teacher."
@@ -13558,7 +13558,7 @@ Used to illustrate the degree or intensity of a situation.
   pos: part
   defs:
     - def: "The honorific form of the particles 이 (i) and 가 (ga) denoting the subject of a sentence."
-      examples: 
+      examples:
         - example: "선생님께서 저에게 사과를 주셨습니다."
           transliteration: "Seonsaengnimkkeseo jeo-ege sagwareul jusyeotseumnida."
           translation: "The teacher gave an apple to me."
@@ -13709,7 +13709,7 @@ Used to illustrate the degree or intensity of a situation.
   pos: n
   defs:
     - def: "flower; flowering plant"
-      examples: 
+      examples:
         - example: "꽃이 핀다."
           transliteration: "Kkochi pinda."
           translation: "Flowers bloom."
@@ -13807,7 +13807,7 @@ Used to illustrate the degree or intensity of a situation.
   pos: n
   defs:
     - def: "feigned illness, pretended sickness"
-      examples: 
+      examples:
         - example: "꾀병을 부리다"
           transliteration: "kkoebyeong-eul burida"
           translation: "to malinger"
@@ -13823,7 +13823,7 @@ Used to illustrate the degree or intensity of a situation.
   pos: v
   defs:
     - def: "to dream"
-      examples: 
+      examples:
         - example: "꿈을 꾸다"
           transliteration: "kkumeul kkuda"
           translation: "to dream a dream"
@@ -13841,7 +13841,7 @@ Used to illustrate the degree or intensity of a situation.
   pos: v
   defs:
     - def: "to dream"
-      examples: 
+      examples:
         - example: "꿈을 꾸다"
           transliteration: "kkumeul kkuda"
           translation: "to dream a dream"
@@ -13921,7 +13921,7 @@ Used to illustrate the degree or intensity of a situation.
   pos: n
   defs:
     - def: "honey (substance)"
-      examples: 
+      examples:
         - example: "꿀을 따다"
           transliteration: "kkureul ttada"
           translation: "to collect honey"
@@ -13963,7 +13963,7 @@ Used to illustrate the degree or intensity of a situation.
   pos: n
   defs:
     - def: "dream"
-      examples: 
+      examples:
         - example: "꿈인가, 현실인가."
           transliteration: "Kkumin-ga, hyeonsirin-ga."
           translation: "Is it a dream, or is it real?"
@@ -13973,7 +13973,7 @@ Used to illustrate the degree or intensity of a situation.
   pos: v
   defs:
     - def: "to dream of, to dream about"
-      examples: 
+      examples:
         - example: "부자가 되기를 꿈꾸다"
           transliteration: "bujaga doegireul kkumkkuda"
           translation: "to dream of being rich"
@@ -13984,7 +13984,7 @@ Used to illustrate the degree or intensity of a situation.
   pos: n
   defs:
     - def: "dream"
-      examples: 
+      examples:
         - example: "꿈인가, 현실인가."
           transliteration: "Kkumin-ga, hyeonsirin-ga."
           translation: "Is it a dream, or is it real?"
@@ -14117,7 +14117,7 @@ Used to illustrate the degree or intensity of a situation.
   pos: adv
   defs:
     - def: "continuously; ceaselessly"
-      examples: 
+      examples:
         - example: "이 텔레비전 프로그램은 나를 끊임없이 웃게 만든다."
           transliteration: "I tellebijeon peurogeuraemeun nareul kkeunimeopsi utge mandeunda."
           translation: "This television program makes me continuously laugh."
@@ -14188,7 +14188,7 @@ Used to illustrate the degree or intensity of a situation.
   pos: adv
   defs:
     - def: ""
-      examples: 
+      examples:
         - example: "나는 끝내 다리를 다쳤다."
           transliteration: "Naneun kkeunnae darireul dachyeotda."
           translation: "I hurt my leg. (emphasizing a conclusion of a certain event that ended with hurting one's own leg)"
@@ -14210,7 +14210,7 @@ Used to illustrate the degree or intensity of a situation.
   pos: n
   defs:
     - def: "meal"
-      examples: 
+      examples:
         - example: "끼니를 거르다"
           transliteration: "kkinireul georeuda"
           translation: "to skip a meal"
@@ -14250,7 +14250,7 @@ Used to illustrate the degree or intensity of a situation.
   pos: pron
   defs:
     - def: "I, the first-person singular plain (non-polite) pronoun"
-      examples: 
+      examples:
         - example: "네가 아니고 나야."
           transliteration: "Nega anigo naya."
           translation: "It's not you, it's me."
@@ -14260,27 +14260,27 @@ Used to illustrate the degree or intensity of a situation.
   pos: part
   defs:
     - def: "just; at least"
-      examples: 
+      examples:
         - example: "하던 거나 하련다."
           transliteration: "Hadeon geona haryeonda."
           translation: "Gonna do just what I've been doing."
     - def: "or"
-      examples: 
+      examples:
         - example: "진주나 창원 쪽으로 가려면 몇 번 국도를 타야 하나요?"
           transliteration: "Jinjuna chang-won jjogeuro garyeomyeon myeot beon gukdoreul taya hanayo?"
           translation: "What route should I take to get to Jinju or Changwon?"
     - def: "no less than"
-      examples: 
+      examples:
         - example: "8km나 걸었는데도 거의 지치지 않은 기색이다."
           transliteration: "8kmna georeonneundedo geoui jichiji aneun gisaegida."
           translation: "He has walked 5 miles already, but still seems nearly untired."
     - def: "no matter which/who"
-      examples: 
+      examples:
         - example: "누구나 한번쯤은 넘어질 수 있어."
           transliteration: "Nuguna hanbeonjjeumeun neomeojil su isseo."
           translation: "It's fine. Everyone falls over once or twice."
     - def: "sb said ... (I'm suspicious or not interested, though)"
-      examples: 
+      examples:
         - example: "자기는 몰랐다나, 뭐 그러데."
           transliteration: "Jagineun mollatdana, mwo geureode."
           translation: "Well, maybe he said he didn't know? Something like that."
@@ -14290,17 +14290,17 @@ Used to illustrate the degree or intensity of a situation.
   pos: suf
   defs:
     - def: "but"
-      examples: 
+      examples:
         - example: "광주·전남지역은 곳에 따라 구름이 많이 끼겠으나 대체로 맑겠습니다."
           transliteration: "Gwangju·jeonnamjiyeogeun gose ttara gureumi mani kkigesseuna daechero malgetseumnida."
           translation: "Gwangju and Jeonnam region will be partly cloudy, but mostly clear."
     - def: "regardless whether"
-      examples: 
+      examples:
         - example: "있으나 없으나 별 차이가 없다."
           transliteration: "Isseuna eopseuna byeol chaiga eopda."
           translation: "There's little difference whether there it is or not."
     - def: "(in the form of '-나 -ㄴ') very"
-      examples: 
+      examples:
         - example: "기나긴 여정 끝에 마침내 한국에 도착했다."
           transliteration: "Ginagin yeojeong kkeute machimnae han-guge dochakhaetda."
           translation: "After the long long journey, we finally arrived in Korea."
@@ -14310,7 +14310,7 @@ Used to illustrate the degree or intensity of a situation.
   pos: suf
   defs:
     - def: "a familiar style interrogative suffix"
-      examples: 
+      examples:
         - example: "자네는 전공을 무엇으로 정했나?"
           transliteration: "Janeneun jeon-gong-eul mueoseuro jeonghaenna?"
           translation: "What did you choose to major in?"
@@ -14318,7 +14318,7 @@ Used to illustrate the degree or intensity of a situation.
           transliteration: "Seouryeoge eotteoke ganayo?"
           translation: "How can I get to Seoul Station?"
     - def: "(in the form of '-나 하다/싶다/보다') indicates the monologic question or inference"
-      examples: 
+      examples:
         - example: "잘 지내나 싶어서 전화했지."
           transliteration: "Jal jinaena sipeoseo jeonhwahaetji."
           translation: "I called you to see if you fare well."
@@ -14326,7 +14326,7 @@ Used to illustrate the degree or intensity of a situation.
           transliteration: "Geudeuldo deopgo himdeulgin machan-gajiyeonna boda."
           translation: "It looks they also felt hot and tired."
     - def: "a monologic interrogative suffix"
-      examples: 
+      examples:
         - example: "내가 미쳤나, 어떻게 이런 실수를..."
           transliteration: "Naega michyeonna, eotteoke ireon silsureul..."
           translation: "I must have been crazy to make this ridiculous mistake..!"
@@ -14342,7 +14342,7 @@ Used to illustrate the degree or intensity of a situation.
   pos: v
   defs:
     - def: "to go out, to leave"
-      examples: 
+      examples:
         - example: "방에서 나가다"
           transliteration: "bang-eseo nagada"
           translation: "to leave the room"
@@ -14399,7 +14399,7 @@ Used to illustrate the degree or intensity of a situation.
   pos: pron
   defs:
     - def: "I, the first-person singular plain (non-polite) pronoun"
-      examples: 
+      examples:
         - example: "네가 아니고 나야."
           transliteration: "Nega anigo naya."
           translation: "It's not you, it's me."
@@ -14409,27 +14409,27 @@ Used to illustrate the degree or intensity of a situation.
   pos: part
   defs:
     - def: "just; at least"
-      examples: 
+      examples:
         - example: "하던 거나 하련다."
           transliteration: "Hadeon geona haryeonda."
           translation: "Gonna do just what I've been doing."
     - def: "or"
-      examples: 
+      examples:
         - example: "진주나 창원 쪽으로 가려면 몇 번 국도를 타야 하나요?"
           transliteration: "Jinjuna chang-won jjogeuro garyeomyeon myeot beon gukdoreul taya hanayo?"
           translation: "What route should I take to get to Jinju or Changwon?"
     - def: "no less than"
-      examples: 
+      examples:
         - example: "8km나 걸었는데도 거의 지치지 않은 기색이다."
           transliteration: "8kmna georeonneundedo geoui jichiji aneun gisaegida."
           translation: "He has walked 5 miles already, but still seems nearly untired."
     - def: "no matter which/who"
-      examples: 
+      examples:
         - example: "누구나 한번쯤은 넘어질 수 있어."
           transliteration: "Nuguna hanbeonjjeumeun neomeojil su isseo."
           translation: "It's fine. Everyone falls over once or twice."
     - def: "sb said ... (I'm suspicious or not interested, though)"
-      examples: 
+      examples:
         - example: "자기는 몰랐다나, 뭐 그러데."
           transliteration: "Jagineun mollatdana, mwo geureode."
           translation: "Well, maybe he said he didn't know? Something like that."
@@ -14439,17 +14439,17 @@ Used to illustrate the degree or intensity of a situation.
   pos: suf
   defs:
     - def: "but"
-      examples: 
+      examples:
         - example: "광주·전남지역은 곳에 따라 구름이 많이 끼겠으나 대체로 맑겠습니다."
           transliteration: "Gwangju·jeonnamjiyeogeun gose ttara gureumi mani kkigesseuna daechero malgetseumnida."
           translation: "Gwangju and Jeonnam region will be partly cloudy, but mostly clear."
     - def: "regardless whether"
-      examples: 
+      examples:
         - example: "있으나 없으나 별 차이가 없다."
           transliteration: "Isseuna eopseuna byeol chaiga eopda."
           translation: "There's little difference whether there it is or not."
     - def: "(in the form of '-나 -ㄴ') very"
-      examples: 
+      examples:
         - example: "기나긴 여정 끝에 마침내 한국에 도착했다."
           transliteration: "Ginagin yeojeong kkeute machimnae han-guge dochakhaetda."
           translation: "After the long journey, we finally arrived in Korea."
@@ -14459,7 +14459,7 @@ Used to illustrate the degree or intensity of a situation.
   pos: suf
   defs:
     - def: "a familiar style interrogative suffix"
-      examples: 
+      examples:
         - example: "자네는 전공을 무엇으로 정했나?"
           transliteration: "Janeneun jeon-gong-eul mueoseuro jeonghaenna?"
           translation: "What did you choose to major in?"
@@ -14467,7 +14467,7 @@ Used to illustrate the degree or intensity of a situation.
           transliteration: "Seouryeoge eotteoke ganayo?"
           translation: "How can I get to Seoul Station?"
     - def: "(in the form of '-나 하다/싶다/보다') indicates the monologic question or inference"
-      examples: 
+      examples:
         - example: "잘 지내나 싶어서 전화했지."
           transliteration: "Jal jinaena sipeoseo jeonhwahaetji."
           translation: "I called you to see if you fare well."
@@ -14475,7 +14475,7 @@ Used to illustrate the degree or intensity of a situation.
           transliteration: "Geudeuldo deopgo himdeulgin machan-gajiyeonna boda."
           translation: "It looks they also felt hot and tired."
     - def: "a monologic interrogative suffix"
-      examples: 
+      examples:
         - example: "내가 미쳤나, 어떻게 이런 실수를..."
           transliteration: "Naega michyeonna, eotteoke ireon silsureul..."
           translation: "I must have been crazy to make this ridiculous mistake..!"
@@ -14501,7 +14501,7 @@ Used to illustrate the degree or intensity of a situation.
   pos: pron
   defs:
     - def: "I, the first-person singular plain (non-polite) pronoun"
-      examples: 
+      examples:
         - example: "네가 아니고 나야."
           transliteration: "Nega anigo naya."
           translation: "It's not you, it's me."
@@ -14511,27 +14511,27 @@ Used to illustrate the degree or intensity of a situation.
   pos: part
   defs:
     - def: "just; at least"
-      examples: 
+      examples:
         - example: "하던 거나 하련다."
           transliteration: "Hadeon geona haryeonda."
           translation: "Gonna do just what I've been doing."
     - def: "or"
-      examples: 
+      examples:
         - example: "진주나 창원 쪽으로 가려면 몇 번 국도를 타야 하나요?"
           transliteration: "Jinjuna chang-won jjogeuro garyeomyeon myeot beon gukdoreul taya hanayo?"
           translation: "What route should I take to get to Jinju or Changwon?"
     - def: "no less than"
-      examples: 
+      examples:
         - example: "8km나 걸었는데도 거의 지치지 않은 기색이다."
           transliteration: "8kmna georeonneundedo geoui jichiji aneun gisaegida."
           translation: "He has walked 5 miles already, but still seems nearly untired."
     - def: "no matter which/who"
-      examples: 
+      examples:
         - example: "누구나 한번쯤은 넘어질 수 있어."
           transliteration: "Nuguna hanbeonjjeumeun neomeojil su isseo."
           translation: "It's fine. Everyone falls over once or twice."
     - def: "sb said ... (I'm suspicious or not interested, though)"
-      examples: 
+      examples:
         - example: "자기는 몰랐다나, 뭐 그러데."
           transliteration: "Jagineun mollatdana, mwo geureode."
           translation: "Well, maybe he said he didn't know? Something like that."
@@ -14541,17 +14541,17 @@ Used to illustrate the degree or intensity of a situation.
   pos: suf
   defs:
     - def: "but"
-      examples: 
+      examples:
         - example: "광주·전남지역은 곳에 따라 구름이 많이 끼겠으나 대체로 맑겠습니다."
           transliteration: "Gwangju·jeonnamjiyeogeun gose ttara gureumi mani kkigesseuna daechero malgetseumnida."
           translation: "Gwangju and Jeonnam region will be partly cloudy, but mostly clear."
     - def: "regardless whether"
-      examples: 
+      examples:
         - example: "있으나 없으나 별 차이가 없다."
           transliteration: "Isseuna eopseuna byeol chaiga eopda."
           translation: "There's little difference whether there it is or not."
     - def: "(in the form of '-나 -ㄴ') very"
-      examples: 
+      examples:
         - example: "기나긴 여정 끝에 마침내 한국에 도착했다."
           transliteration: "Ginagin yeojeong kkeute machimnae han-guge dochakhaetda."
           translation: "After the long journey, we finally arrived in Korea."
@@ -14561,7 +14561,7 @@ Used to illustrate the degree or intensity of a situation.
   pos: suf
   defs:
     - def: "a familiar style interrogative suffix"
-      examples: 
+      examples:
         - example: "자네는 전공을 무엇으로 정했나?"
           transliteration: "Janeneun jeon-gong-eul mueoseuro jeonghaenna?"
           translation: "What did you choose to major in?"
@@ -14569,7 +14569,7 @@ Used to illustrate the degree or intensity of a situation.
           transliteration: "Seouryeoge eotteoke ganayo?"
           translation: "How can I get to Seoul Station?"
     - def: "(in the form of '-나 하다/싶다/보다') indicates the monologic question or inference"
-      examples: 
+      examples:
         - example: "잘 지내나 싶어서 전화했지."
           transliteration: "Jal jinaena sipeoseo jeonhwahaetji."
           translation: "I called you to see if you fare well."
@@ -14577,7 +14577,7 @@ Used to illustrate the degree or intensity of a situation.
           transliteration: "Geudeuldo deopgo himdeulgin machan-gajiyeonna boda."
           translation: "It looks they also felt hot and tired."
     - def: "a monologic interrogative suffix"
-      examples: 
+      examples:
         - example: "내가 미쳤나, 어떻게 이런 실수를..."
           transliteration: "Naega michyeonna, eotteoke ireon silsureul..."
           translation: "I must have been crazy to make this ridiculous mistake..!"
@@ -14618,7 +14618,7 @@ Used to illustrate the degree or intensity of a situation.
   pos: v
   defs:
     - def: "to carry"
-      examples: 
+      examples:
         - example: "이 매트리스 나르는 걸 좀 도와주시겠어요?"
           transliteration: "I maeteuriseu nareuneun geol jom dowajusigesseoyo?"
           translation: "Could you please give me a hand carrying this mattress?"
@@ -14629,7 +14629,7 @@ Used to illustrate the degree or intensity of a situation.
   pos: n
   defs:
     - def: "dependence, essence, nature"
-      examples: 
+      examples:
         - example: "사람 나름"
           transliteration: "saram nareum"
           translation: "dependence on personality"
@@ -14660,7 +14660,7 @@ Used to illustrate the degree or intensity of a situation.
   defs:
     - def: "tree"
     - def: "wood"
-      examples: 
+      examples:
         - example: "나무는 종이를 만드는 재료로 쓰인다."
           transliteration: "Namuneun jong-ireul mandeuneun jaeryoro sseu-inda."
           translation: "Wood is the material used to make paper."
@@ -14735,32 +14735,32 @@ Used to illustrate the degree or intensity of a situation.
   pos: a
   defs:
     - def: "to be bad, inferior, of lower grade"
-      examples: 
+      examples:
         - example: "나쁜 물건"
           transliteration: "nappeun mulgeon"
           translation: "inferior goods"
     - def: "to be bad, evil, ill-natured"
-      examples: 
+      examples:
         - example: "나쁜 인간"
           transliteration: "nappeun in-gan"
           translation: "wicked man"
     - def: "to be immoral, wrong"
-      examples: 
+      examples:
         - example: "나쁜 짓을 하다"
           transliteration: "nappeun jiseul hada"
           translation: "to commit a sin/crime"
     - def: "to be in the wrong, blamable"
-      examples: 
+      examples:
         - example: "내가 나빴어."
           transliteration: "Naega nappasseo."
           translation: "It's my fault."
     - def: "to be harmful, injurious"
-      examples: 
+      examples:
         - example: "이 날씨는 농작물에 나쁘다."
           transliteration: "I nalssineun nongjangmure nappeuda."
           translation: "This weather is bad for the crops."
     - def: "to be sick, ill"
-      examples: 
+      examples:
         - example: "심장이 나쁘다"
           transliteration: "simjang-i nappeuda"
           translation: "to have a heart disease"
@@ -14935,7 +14935,7 @@ Used to illustrate the degree or intensity of a situation.
   pos: n
   defs:
     - def: "the future; a later time"
-      examples: 
+      examples:
         - example: "나중에 제가 드릴게요."
           transliteration: " Najung-e jega deurilgeyo."
           translation: "I will give [it to you] at a later time."
@@ -15028,7 +15028,7 @@ Used to illustrate the degree or intensity of a situation.
   pos: n
   defs:
     - def: "four days"
-      examples: 
+      examples:
         - example: "나흘 후에"
           transliteration: "naheul hue"
           translation: "four days from now"
@@ -15230,7 +15230,7 @@ Used to illustrate the degree or intensity of a situation.
   pos: a
   defs:
     - def: "awkward; embarrassing"
-      examples: 
+      examples:
         - example: "그러나 난처한 기상 조건으로 윈난은 깨끗한 물을 풍부하게 가지게 될 것이다."
           transliteration: "Geureona nancheohan gisang jogeoneuro winnaneun kkaekkeuthan mureul pungbuhage gajige doel geosida."
           translation: "However, the difficult weather conditions will ensure Yunnan has plenty of freshwater."
@@ -15253,7 +15253,7 @@ Used to illustrate the degree or intensity of a situation.
   pos: n
   defs:
     - def: "day, time"
-      examples: 
+      examples:
         - example: "그는 날마다 일하러 간다."
           transliteration: "Geuneun nalmada ilhareo ganda."
           translation: "He goes to work every day."
@@ -15299,7 +15299,7 @@ Used to illustrate the degree or intensity of a situation.
   pos: n
   defs:
     - def: "wing (of a bird, aeroplane etc)"
-      examples: 
+      examples:
         - example: "잠자리의 날개는 두 짝이다."
           transliteration: "Jamjariui nalgaeneun du jjagida."
           translation: "Dragonflies have two pairs of wings."
@@ -15334,7 +15334,7 @@ Used to illustrate the degree or intensity of a situation.
   pos: v
   defs:
     - def: "to fly (travel through the air)"
-      examples: 
+      examples:
         - example: "종이 비행기가 아주 멋지게 난다."
           transliteration: "Jong-i bihaenggiga aju meotjige nanda."
           translation: "The paper airplane flies really splendidly."
@@ -15472,7 +15472,7 @@ Used to illustrate the degree or intensity of a situation.
   pos: v
   defs:
     - def: "to leave behind"
-      examples: 
+      examples:
         - example: "거기에 다른 사람을 남겨 뒀습니다."
           transliteration: "Geogie dareun sarameul namgyeo dwotseumnida."
           translation: "I left someone else there."
@@ -15650,7 +15650,7 @@ Used to illustrate the degree or intensity of a situation.
   pos: n
   defs:
     - def: "man; gentleman; boy; male"
-      examples: 
+      examples:
         - example: "이 남자들은 미국인입니까, 아니면 독일인입니까?  독일인입니다."
           transliteration: "I namjadeureun miguginimnikka, animyeon dogirinimnikka?  dogirinimnida."
           translation: "Are these men American or German? - They are German."
@@ -15860,7 +15860,7 @@ Used to illustrate the degree or intensity of a situation.
   pos: n
   defs:
     - def: "daytime; noon"
-      examples: 
+      examples:
         - example: "낮 열두 시에"
           transliteration: "nat yeoldu sie"
           translation: "at twelve p.m."
@@ -15870,7 +15870,7 @@ Used to illustrate the degree or intensity of a situation.
   pos: a
   defs:
     - def: "To be low (in height, in value)"
-      examples: 
+      examples:
         - example: "낮은 울타리"
           transliteration: "najeun ultari"
           translation: "a low fence"
@@ -15887,7 +15887,7 @@ Used to illustrate the degree or intensity of a situation.
   pos: v
   defs:
     - def: "to decrease; to lower"
-      examples: 
+      examples:
         - example: "그들은 갑자기 목소리가 낮아졌다."
           transliteration: "Geudeureun gapjagi moksoriga najajyeotda."
           translation: "They suddenly lowered their voices."
@@ -15898,7 +15898,7 @@ Used to illustrate the degree or intensity of a situation.
   pos: n
   defs:
     - def: "daytime; noon"
-      examples: 
+      examples:
         - example: "낮 열두 시에"
           transliteration: "nat yeoldu sie"
           translation: "at twelve p.m."
@@ -15914,12 +15914,12 @@ Used to illustrate the degree or intensity of a situation.
   pos: v
   defs:
     - def: "to make it lower, bring down"
-      examples: 
+      examples:
         - example: "주는 높은 나무를 낮추고 낮은 나무를 높이신다. (에스겔 17:24)"
           transliteration: "Juneun nopeun namureul natchugo najeun namureul nopisinda. (Eseugel 17:24)"
           translation: "The Lord bring down the tall tree and make the low tree grow tall. (Ezekiel 17:24)"
     - def: "to humble"
-      examples: 
+      examples:
         - example: "누구든지 자신을 높이는 이는 낮아지고, 자신을 낮추는 이는 높아질 것이다. (누가복음 14:11)"
           transliteration: "Nugudeunji jasineul nopineun ineun najajigo, jasineul natchuneun ineun nopajil geosida. (Nugabogeum 14:11)"
           translation: "For everyone who exalts himself will be humbled, and he who humbles himself will be exalted. (Luke 14:11)"
@@ -15972,7 +15972,7 @@ Used to illustrate the degree or intensity of a situation.
   pos: v
   defs:
     - def: "to lay (an egg); to give birth"
-      examples: 
+      examples:
         - example: "연어는 알을 낳으려고 강을 거슬러 올라간다."
           transliteration: "Yeoneoneun areul naeuryeogo gang-eul geoseulleo ollaganda."
           translation: "The salmon swims upstream to spawn."
@@ -15997,7 +15997,7 @@ Used to illustrate the degree or intensity of a situation.
   pos: n
   defs:
     - def: "interior, inside"
-      examples: 
+      examples:
         - example: "사무실 내에서는 흡연 금지입니다."
           transliteration: "Samusil naeeseoneun heubyeon geumjiimnida."
           translation: "Smoking is forbidden in the office."
@@ -16102,7 +16102,7 @@ Used to illustrate the degree or intensity of a situation.
   pos: v
   defs:
     - def: "to come down"
-      examples: 
+      examples:
         - example: "가끔 봄비도 내려요."
           transliteration: "Gakkeum bombido naeryeoyo."
           translation: "Sometimes it rains too. (literally: Sometimes a spring rain also comes down.)"
@@ -16181,7 +16181,7 @@ Used to illustrate the degree or intensity of a situation.
   pos: n
   defs:
     - def: "tomorrow"
-      examples: 
+      examples:
         - example: "내일이 소풍가는 날이다."
           transliteration: "Naeiri sopungganeun narida."
           translation: "Tomorrow is the day [we] are going on a picnic."
@@ -16213,12 +16213,12 @@ Used to illustrate the degree or intensity of a situation.
   pos: adv
   defs:
     - def: "from how many to how many (Sino-Korean manifestation of 얼마에서 얼마까지)"
-      examples: 
+      examples:
         - example: "컴퓨터 프로그래머 열 명 내지 스무 명이 이 앱을 제작했다."
           transliteration: "Keompyuteo peurogeuraemeo yeol myeong naeji seumu myeong-i i aebeul jejakhaetda."
           translation: "Around 10 or 20 computer programmers created this (smartphone) app."
     - def: "or (close to \"if not\")"
-      examples: 
+      examples:
         - example: "우리가 가야 할 피시지는 산 내지 바다다."
           transliteration: "Uriga gaya hal pisijineun san naeji badada."
           translation: "The summer vacation spot that we will go is the mountains or the sea."
@@ -16268,7 +16268,7 @@ Used to illustrate the degree or intensity of a situation.
   pos: n
   defs:
     - def: "a cold Korean noodle dish, usually in a tangy broth with a slice of a pear, a boiled egg, and beef"
-      examples: 
+      examples:
         - example: "평양냉면"
           transliteration: "pyeong-yangnaengmyeon"
           translation: "Pyongyang naengmyeon"
@@ -16301,7 +16301,7 @@ Used to illustrate the degree or intensity of a situation.
   pos: suf
   defs:
     - def: "a plain style interrogative suffix"
-      examples: 
+      examples:
         - example: "농사가 그리 싫으냐?"
           transliteration: "Nongsaga geuri sireunya?"
           translation: "I see you don't like farming, but that much?"
@@ -16314,7 +16314,7 @@ Used to illustrate the degree or intensity of a situation.
   pos: pron
   defs:
     - def: "second-person singular informal pronoun; you"
-      examples: 
+      examples:
         - example: "너를 사랑해."
           transliteration: "Neoreul saranghae."
           translation: "I love you."
@@ -16343,7 +16343,7 @@ Used to illustrate the degree or intensity of a situation.
   pos: pron
   defs:
     - def: "second-person singular informal pronoun; you"
-      examples: 
+      examples:
         - example: "너를 사랑해."
           transliteration: "Neoreul saranghae."
           translation: "I love you."
@@ -16371,7 +16371,7 @@ Used to illustrate the degree or intensity of a situation.
   pos: pron
   defs:
     - def: "second-person singular informal pronoun; you"
-      examples: 
+      examples:
         - example: "너를 사랑해."
           transliteration: "Neoreul saranghae."
           translation: "I love you."
@@ -16387,7 +16387,7 @@ Used to illustrate the degree or intensity of a situation.
   pos: n
   defs:
     - def: "beyond, the other side"
-      examples: 
+      examples:
         - example: "산 너머로"
           transliteration: "san neomeoro"
           translation: "beyond the mountains"
@@ -16570,7 +16570,7 @@ Used to illustrate the degree or intensity of a situation.
   pos: v
   defs:
     - def: "to put in, include, insert"
-      examples: 
+      examples:
         - example: "붙들어 손에 넣다."
           transliteration: "Butdeureo sone neota."
           translation: "To capture someone or something."
@@ -16595,11 +16595,11 @@ Used to illustrate the degree or intensity of a situation.
   pos: pron
   defs:
     - def: "you"
-      examples: 
+      examples:
         - example: "a nominative synonym for 너 (neo, “you”) (the second person singular familiar pronoun)"
         - example: "generally used only in 네가 (nega)"
     - def: "your"
-      examples: 
+      examples:
         - example: "a contraction of 너의 (neoui, “your”), the possessive form of 너 (neo, “you”) (the second person singular familiar pronoun)"
 
 - word: 네
@@ -16614,10 +16614,10 @@ Used to illustrate the degree or intensity of a situation.
   pos: suf
   defs:
     - def: "the group to which someone belongs; the family, home, party of ..."
-      examples: 
+      examples:
         - example: "언니네 (eonnine, “sister's family”), 순이네 (sunine, “Suni's family (hypocoristic)”)"
     - def: "(soft or somewhat belittled) person/people who is/are ..."
-      examples: 
+      examples:
         - example: "아낙네 (anangne, “woman/women (in rural area)”), 남정네 (namjeongne, “man/men (in rural area)”)"
         - example: "우리네 (urine, “we (emphasis on community)”)"
 
@@ -16784,7 +16784,7 @@ Used to illustrate the degree or intensity of a situation.
   pos: n
   defs:
     - def: "a period of years such as a decade or century"
-      examples: 
+      examples:
         - example: "1990년대"
           transliteration: "1990nyeondae"
           translation: "the 1990s"
@@ -16825,7 +16825,7 @@ Used to illustrate the degree or intensity of a situation.
   pos: n
   defs:
     - def: "old age"
-      examples: 
+      examples:
         - example: "노인을 공경해라."
           transliteration: "Noineul gonggyeonghaera."
           translation: "Respect the old man."
@@ -16868,7 +16868,7 @@ Used to illustrate the degree or intensity of a situation.
   pos: n
   defs:
     - def: "lark, skylark"
-      examples: 
+      examples:
         - example: "노고지리는 \"노골노골 지리지리\" 운다."
           transliteration: "Nogojirineun nogollogol jirijiri unda."
           translation: "Larks chirk."
@@ -16890,7 +16890,7 @@ Used to illustrate the degree or intensity of a situation.
   pos: v
   defs:
     - def: "to distribute (among), to divide, to split, to share (with)"
-      examples: 
+      examples:
         - example: "그는 재산을 넷으로 노나서 네 아들에게 똑같이 주었다."
           transliteration: "Geuneun jaesaneul neseuro nonaseo ne adeurege ttokgachi jueotda."
           translation: "He divided his property into four parts and gave his four sons equal portions."
@@ -16901,7 +16901,7 @@ Used to illustrate the degree or intensity of a situation.
   pos: v
   defs:
     - def: "to play, to frolic"
-      examples: 
+      examples:
         - example: "지난 주말에 친구와 놀았어요."
           transliteration: "Jinan jumare chin-guwa norasseoyo."
           translation: "Last weekend I hung out with friends."
@@ -16985,7 +16985,7 @@ Used to illustrate the degree or intensity of a situation.
   pos: n
   defs:
     - def: "song"
-      examples: 
+      examples:
         - example: "그는 노래를 잘한다."
           transliteration: "Geuneun noraereul jalhanda."
           translation: "He's good at singing."
@@ -17041,7 +17041,7 @@ Used to illustrate the degree or intensity of a situation.
   pos: n
   defs:
     - def: "roe deer (Capreolus capreolus)"
-      examples: 
+      examples:
         - example: "그녀의 눈은 마치 암노루의 눈을 닮았다."
           transliteration: "geunyeo-ui nun-eun machi amnoru-ui nun-eul dalmatta."
           translation: "Her eyes were just like the eyes of a female roe deer."
@@ -17082,7 +17082,7 @@ Used to illustrate the degree or intensity of a situation.
   pos: n
   defs:
     - def: "yolk"
-      examples: 
+      examples:
         - example: "노른자위는 둘레의 흰자위보다 걸다."
           transliteration: "Noreunjawineun dulle-ui huinjawiboda geolda."
           translation: "The yolk is more fertile than the surrounding white."
@@ -17211,7 +17211,7 @@ Used to illustrate the degree or intensity of a situation.
   pos: n
   defs:
     - def: "Russian (language)"
-      examples: 
+      examples:
         - example: "노어 사전"
           transliteration: "no-eo sajeon"
           translation: "a Russian dictionary"
@@ -17339,7 +17339,7 @@ Used to illustrate the degree or intensity of a situation.
   pos: n
   defs:
     - def: "the infirmities of old age"
-      examples: 
+      examples:
         - example: "노환으로 죽다"
           transliteration: "nohwaneuro jukda"
           translation: "to die of old age"
@@ -17355,23 +17355,23 @@ Used to illustrate the degree or intensity of a situation.
   pos: v
   defs:
     - def: "to melt"
-      examples: 
+      examples:
         - example: "눈이 벌써 녹기 시작한다."
           transliteration: "Nuni beolsseo nokgi sijakhanda."
           translation: "The snow is starting to melt."
     - def: "to dissolve"
-      examples: 
+      examples:
         - example: "소금은 물에 잘 녹는다."
           transliteration: "Sogeumeun mure jal nongneunda."
           translation: "Salt easily dissolves in water."
     - def: "to warm up, to get warm"
     - def: "to have bitter experiences, to have a bad time"
-      examples: 
+      examples:
         - example: "뱃놀이 갔다가 녹았다."
           transliteration: "Baennori gatdaga nogatda."
           translation: "I went boating and it was just awful!"
     - def: "to be captivated, to be infatuated with"
-      examples: 
+      examples:
         - example: "그녀의 매력에 녹아 떨어졌다."
           transliteration: "Geunyeoui maeryeoge noga tteoreojyeotda."
           translation: "I am stuck by her charms."
@@ -17419,7 +17419,7 @@ Used to illustrate the degree or intensity of a situation.
   defs:
     - def: "to melt"
     - def: "to dissolve"
-      examples: 
+      examples:
         - example: "그녀는 물에 설탕을 타서 녹였다."
           transliteration: "Geunyeoneun mure seoltang-eul taseo nogyeotda."
           translation: "She dissolved sugar in the water."
@@ -17486,7 +17486,7 @@ Used to illustrate the degree or intensity of a situation.
   pos: v
   defs:
     - def: "to discuss (something)"
-      examples: 
+      examples:
         - example: "우리는 이 심각한 문제에 대해서 논의한다."
           transliteration: "Urineun i simgakhan munjee daehaeseo nonuihanda."
           translation: "We discuss about this serious problem."
@@ -17529,7 +17529,7 @@ Used to illustrate the degree or intensity of a situation.
   pos: v
   defs:
     - def: "to play, to frolic"
-      examples: 
+      examples:
         - example: "지난 주말에 친구와 놀았어요."
           transliteration: "Jinan jumare chin-guwa norasseoyo."
           translation: "Last weekend I hung out with friends."
@@ -17542,7 +17542,7 @@ Used to illustrate the degree or intensity of a situation.
   pos: v
   defs:
     - def: "to be surprised"
-      examples: 
+      examples:
         - example: "놀랐지! — 파티구나, 굉장해."
           transliteration: "Nollatji!  patiguna, goengjanghae."
           translation: "Surprise! — A party! Awesome!"
@@ -17582,7 +17582,7 @@ Used to illustrate the degree or intensity of a situation.
   defs:
     - def: "A game."
     - def: "Play; relaxation and entertainment."
-      examples: 
+      examples:
         - example: "그들은 카드 놀이를 하고 있다."
           transliteration: "Geudeureun kadeu norireul hago itda."
           translation: "They are playing cards."
@@ -17657,7 +17657,7 @@ Used to illustrate the degree or intensity of a situation.
   pos: n
   defs:
     - def: "a shade of color"
-      examples: 
+      examples:
         - example: "농담을 조절하다[달리하다]."
           transliteration: "Nongdameul jojeolhada[dallihada]."
           translation: "control[be different] a shade of color"
@@ -17757,7 +17757,7 @@ Used to illustrate the degree or intensity of a situation.
   pos: v
   defs:
     - def: "to lay, put"
-      examples: 
+      examples:
         - example: "테이블 위에 놨어요."
           transliteration: "Teibeul wie nwasseoyo."
           translation: "I left it on the table."
@@ -17776,12 +17776,12 @@ Used to illustrate the degree or intensity of a situation.
   pos: v
   defs:
     - def: "to let something slip, to let something go (intentionally)"
-      examples: 
+      examples:
         - example: "적을 놓쳤다"
           transliteration: "jeogeul notchyeotda"
           translation: "let the enemy escape"
     - def: "to miss, to lose, to waste (unintentionally)"
-      examples: 
+      examples:
         - example: "≈ 잃다 (ilta), 잃어버리다 (ireobeorida)"
         - example: "3분 늦어서 막차를 놓쳤다."
           transliteration: "3bun neujeoseo makchareul notchyeotda."
@@ -17806,7 +17806,7 @@ Used to illustrate the degree or intensity of a situation.
     - def: "put (To lay down somewhere something that one is holding.)"
     - def: "leave (To keep something as it is, not touching it.)"
     - def: "let someone do"
-      examples: 
+      examples:
         - example: "그들은 그들 의견을 가지도록 놔두어라."
           transliteration: "Geudeureun geudeul uigyeoneul gajidorok nwadueora."
           translation: "Let them have their opinions."
@@ -18049,7 +18049,7 @@ Used to illustrate the degree or intensity of a situation.
   defs:
     - def: "eye"
     - def: "vision"
-      examples: 
+      examples:
         - example: "눈이 밝다"
           transliteration: "nuni bakda"
           translation: "to have clear vision"
@@ -18065,7 +18065,7 @@ Used to illustrate the degree or intensity of a situation.
   pos: n
   defs:
     - def: "snow"
-      examples: 
+      examples:
         - example: "눈이 온다"
           transliteration: "nuni onda"
           translation: "It's snowing"
@@ -18152,7 +18152,7 @@ Used to illustrate the degree or intensity of a situation.
   pos: n
   defs:
     - def: "the color of one's eyes, the expression of one's eyes, the glitter of one's eyes"
-      examples: 
+      examples:
         - example: "강렬한 눈빛"
           transliteration: "gangnyeolhan nunbit"
           translation: "a strong expression of one's eyes"
@@ -18231,7 +18231,7 @@ Used to illustrate the degree or intensity of a situation.
   pos: v
   defs:
     - def: "to lie down (on the back)"
-      examples: 
+      examples:
         - example: "나는 침대에 누워 베개와 이불을 덮었다."
           transliteration: "Naneun chimdaee nuwo begaewa ibureul deopeotda."
           translation: "I lay on the bed, put my head on the pillow, and covered myself with a blanket."
@@ -18248,7 +18248,7 @@ Used to illustrate the degree or intensity of a situation.
   pos: v
   defs:
     - def: "to repent, to regret"
-      examples: 
+      examples:
         - example: "뉘우쳤을 때는 이미 늦었었다."
           transliteration: "Nwiuchyeosseul ttaeneun imi neujeosseotda."
           translation: "It was too late for me to be sorry."
@@ -18328,7 +18328,7 @@ Used to illustrate the degree or intensity of a situation.
   pos: suf
   defs:
     - def: "a plain style interrogative suffix"
-      examples: 
+      examples:
         - example: "어디를 가느냐, 토끼야?"
           transliteration: "Eodireul ganeunya, tokkiya?"
           translation: "Where are you headed for, hare?"
@@ -18359,7 +18359,7 @@ Used to illustrate the degree or intensity of a situation.
   pos: n
   defs:
     - def: "wolf"
-      examples: 
+      examples:
         - example: "늑대 떼"
           transliteration: "neukdae tte"
           translation: "a pack of wolves"
@@ -18392,7 +18392,7 @@ Used to illustrate the degree or intensity of a situation.
   pos: suf
   defs:
     - def: "a present tense suffix used to help a verb or one of two adjectives 있다 (itda, “existing”) and 없다 (eopda, “not existing”) to act like a determiner."
-      examples: 
+      examples:
         - example: "딸이 책을 읽는다. (Ttari chaegeul ingneunda., “My daughter reads a book.”) → 딸이 읽는 책 (ttari ingneun chaek, “the book my daughter reads”)"
         - example: "내가 이곳에 산다. (Naega igose sanda., “I live in this place.”) → 내가 사는 곳 (naega saneun got, “the place I live in”)"
         - example: "원천이란 물이 흘러 나오는 곳을 말한다."
@@ -18406,12 +18406,12 @@ Used to illustrate the degree or intensity of a situation.
   pos: suf
   defs:
     - def: "a present tense plain style declarative suffix"
-      examples: 
+      examples:
         - example: "요리사가 잡채를 접시에 담는다."
           transliteration: "Yorisaga japchaereul jeopsie damneunda."
           translation: "The cook is putting japchae on a plate."
     - def: "a plain style monologic interrogative suffix; usually used with interrogative words"
-      examples: 
+      examples:
         - example: "오늘은 저녁에 뭘 먹는다...?"
           transliteration: "Oneureun jeonyeoge mwol meongneunda...?"
           translation: "What would I eat on my dinner today...?"
@@ -18421,7 +18421,7 @@ Used to illustrate the degree or intensity of a situation.
   pos: suf
   defs:
     - def: "mentions relevant circumstances before explaining, commanding, or suggesting"
-      examples: 
+      examples:
         - example: "떡 줄 사람은 생각도 않는데 김칫국부터 마신다."
           transliteration: "Tteok jul sarameun saenggakdo anneunde gimchitgukbuteo masinda."
           translation: "to count one's chickens before they are hatched; (lit.) to drink kimchi soup in advance, while the person, who may give rice cake, is not going to."
@@ -18429,7 +18429,7 @@ Used to illustrate the degree or intensity of a situation.
           transliteration: "Ya, bakke nun oneunde nunssaumhaja!"
           translation: "Hey, it's snowing outside! Let's have a snowball fight!"
     - def: "an intimate style exclamatory or interrogative suffix, expressing unexpectedness or anticipating the listener's responses"
-      examples: 
+      examples:
         - example: "없었는데?"
           transliteration: "Eopseonneunde?"
           translation: "But there was nothing!"
@@ -18442,17 +18442,17 @@ Used to illustrate the degree or intensity of a situation.
   pos: suf
   defs:
     - def: "indirect question marker: whether, if; who, what, where, how ..."
-      examples: 
+      examples:
         - example: "야, 리모컨 어딨는지 (=어디에 있는지) 안 보인다. 좀 도와주라."
           transliteration: "Ya, rimokeon eodinneunji (=eodie inneunji) an boinda. Jom dowajura."
           translation: "Hey, I can't find where the remote is. Give me a favor, please?"
     - def: "vague question"
-      examples: 
+      examples:
         - example: "음식은 입에 맞으시는지요?"
           transliteration: "Eumsigeun ibe majeusineunjiyo?"
           translation: "Is this food to your liking?"
     - def: "because perhaps"
-      examples: 
+      examples:
         - example: "잠이 오는지 연신 고개만 꾸벅인다."
           transliteration: "Jami oneunji yeonsin gogaeman kkubeoginda."
           translation: "He keeps nodding; maybe he's sleepy."
@@ -18507,7 +18507,7 @@ Used to illustrate the degree or intensity of a situation.
   defs:
     - def: "old animal"
     - def: "aged person, dotard"
-      examples: 
+      examples:
         - example: "늙다리 미치광이를 반드시 불로 다스릴것이다."
           transliteration: "Neukdari michigwang-ireul bandeusi bullo daseurilgeosida."
           translation: "I will definitely tame the mentally deranged dotard with fire."
@@ -18517,7 +18517,7 @@ Used to illustrate the degree or intensity of a situation.
   pos: n
   defs:
     - def: "an old person; an aged person; an elder"
-      examples: 
+      examples:
         - example: "내가 늙은이여서 그런지 몸수색을 당하지는 않았다."
           transliteration: "Naega neulgeuniyeoseo geureonji momsusaegeul danghajineun anatda."
           translation: "Probably because I was an old woman, she didn't search my body."
@@ -18557,7 +18557,7 @@ Used to illustrate the degree or intensity of a situation.
   pos: a
   defs:
     - def: "(to be) late"
-      examples: 
+      examples:
         - example: "연설자가 개회식에 늦게 도착하였다."
           transliteration: "Yeonseoljaga gaehoesige neutge dochakhayeotda."
           translation: "The speaker arrived late for the opening session."
@@ -18576,7 +18576,7 @@ Used to illustrate the degree or intensity of a situation.
   pos: n
   defs:
     - def: "oversleep"
-      examples: 
+      examples:
         - example: "늦잠을 자다"
           transliteration: "neutjameul jada"
           translation: "to oversleep"
@@ -18613,12 +18613,12 @@ Used to illustrate the degree or intensity of a situation.
   pos: suf
   defs:
     - def: "because, since"
-      examples: 
+      examples:
         - example: "워낙 배가 고팠다 보니 무엇을 먹어도 맛있었다."
           transliteration: "Wonak baega gopatda boni mueoseul meogeodo masisseotda."
           translation: "Everything tasted so good owing to my great hunger."
     - def: "and then"
-      examples: 
+      examples:
         - example: "바닷가에 다다르니, 마침 하늘도. 바다도, 노을에 가득, 물들던 참이었다."
           transliteration: "Badatga-e dadareuni, machim haneuldo. Badado, no-eure gadeuk, muldeuldeon chamieotda."
           translation: "As we arrived at the seashore, the sky and sea were aglowed with the sunet."
@@ -18627,7 +18627,7 @@ Used to illustrate the degree or intensity of a situation.
   pos: suf
   defs:
     - def: "a plain style interrogative suffix; gives a friendlier impression than 냐 (nya) does"
-      examples: 
+      examples:
         - example: "너 가니?"
           transliteration: "Neo gani?"
           translation: "Do you go?"
@@ -18739,7 +18739,7 @@ Used to illustrate the degree or intensity of a situation.
   pos: n
   defs:
     - def: "Mr., Mrs. More respectful than 씨 (ssi)."
-      examples: 
+      examples:
         - example: "홍길동님"
           transliteration: "honggildongnim"
           translation: "Mr Hong"
@@ -18770,22 +18770,22 @@ Used to illustrate the degree or intensity of a situation.
   pos: adv
   defs:
     - def: "all, completely"
-      examples: 
+      examples:
         - example: "청소를 다 했다."
           transliteration: "Cheongsoreul da haetda."
           translation: "I finished cleaning everything."
     - def: "nearly"
-      examples: 
+      examples:
         - example: "집에 다 와 간다."
           transliteration: "Jibe da wa ganda."
           translation: "I'm nearly home."
     - def: "meaning slight surprise, exclamation, or sarcasm"
-      examples: 
+      examples:
         - example: "이거 원, 별별 사람을 다 보겠네."
           transliteration: "Igeo won, byeolbyeol sarameul da bogenne."
           translation: "Well, I'm gonna see all kinds of people. (You are very peculiar.)"
     - def: "(in past tense) used to say something that became unable to achieve ironically as if it were already achieved."
-      examples: 
+      examples:
         - example: "친구가 놀쟀으니 잠은 다 잤다."
           transliteration: "Chin-guga noljaesseuni jameun da jatda."
           translation: "'Cause my friend told me to play, I've used up all my sleep for today."
@@ -18795,7 +18795,7 @@ Used to illustrate the degree or intensity of a situation.
   pos: n
   defs:
     - def: "(before 이다 (ida, “to be something”) and 아니다 (anida, “not to be something”)) everything, all"
-      examples: 
+      examples:
         - example: "그게 다(이)냐?"
           transliteration: "Geuge da(i)nya?"
           translation: "Is that all?"
@@ -18820,7 +18820,7 @@ Used to illustrate the degree or intensity of a situation.
   pos: suf
   defs:
     - def: "a plain style declarative suffix"
-      examples: 
+      examples:
         - example: "맛있겠다."
           transliteration: "Masitgetda."
           translation: "It looks delicious."
@@ -18834,7 +18834,7 @@ Used to illustrate the degree or intensity of a situation.
   pos: part
   defs:
     - def: "semantic marker of emphasis"
-      examples: 
+      examples:
         - example: "이 그림은 저 벽에다 걸어 주세요. (I geurimeun jeo byeogeda georeo juseyo., “Please hang this picture on that wall.”)"
 
 - word: 다
@@ -18842,17 +18842,17 @@ Used to illustrate the degree or intensity of a situation.
   pos: suf
   defs:
     - def: "and then; but soon; depicts one motion or state stopping and then the other starting"
-      examples: 
+      examples:
         - example: "좋다 말았네."
           transliteration: "Jota maranne."
           translation: "I got excited for a second.."
     - def: "while"
-      examples: 
+      examples:
         - example: "도서관에 공부하러 가다 친구를 만났다."
           transliteration: "Doseogwane gongbuhareo gada chin-gureul mannatda."
           translation: "I ran into my friend when I was going to the library for my study."
     - def: "(in the form of '-다 -다') over and over"
-      examples: 
+      examples:
         - example: "연휴 마지막 날인 오늘, 경부 고속도로 대부분의 구간에서 차량들이 가다 서다를 반복하고 있습니다."
           transliteration: "Yeonhyu majimak narin oneul, gyeongbu gosokdoro daebubunui guganeseo charyangdeuri gada seodareul banbokhago itseumnida."
           translation: "Today, the last day of the holiday, most of the Seoul-Busan highway keeps being stop-and-go."
@@ -18861,7 +18861,7 @@ Used to illustrate the degree or intensity of a situation.
   pos: part
   defs:
     - def: "semantic marker of emphasis"
-      examples: 
+      examples:
         - example: "여기다가 두면 되겠소?"
           transliteration: "Yeogidaga dumyeon doegetso?"
           translation: "Will it be all right if I put this here?"
@@ -18873,7 +18873,7 @@ Used to illustrate the degree or intensity of a situation.
   pos: suf
   defs:
     - def: "and then; but soon; depicts one motion or state stopping and then the other starting"
-      examples: 
+      examples:
         - example: "뭐 하다가 이제 와?"
           transliteration: "Mwo hadaga ije wa?"
           translation: "What made you so late? (lit.) What did you do before coming this late?"
@@ -18881,12 +18881,12 @@ Used to illustrate the degree or intensity of a situation.
           transliteration: "Ga-eul punggyeong-eul geuridaga mundeuk nega saenggangnaseo i geureul bonaenda."
           translation: "When I was drawing the autumn scenery, you suddenly came to my mind, so that I am writing this letter."
     - def: "while"
-      examples: 
+      examples:
         - example: "아무 생각 없이 걷다가 모서리에 부딪혔다."
           transliteration: "Amu saenggak eopsi geotdaga moseorie budichyeotda."
           translation: "I bumped into the edge while walking without thought."
     - def: "(in the form of '-다가 -다가') over and over"
-      examples: 
+      examples:
         - example: "요새 날씨가 덥다가 춥다가 하다 보니 감기가 걸린 것 같다."
           transliteration: "Yosae nalssiga deopdaga chupdaga hada boni gamgiga geollin geot gatda."
           translation: "It seems I caught a cold, due to the changeable weather these days."
@@ -18922,7 +18922,7 @@ Used to illustrate the degree or intensity of a situation.
   pos: n
   defs:
     - def: "refreshments"
-      examples: 
+      examples:
         - example: "회의에 쓸 다과를 주문하고 싶어요."
           transliteration: "Hoe-uie sseul dagwareul jumunhago sipeoyo."
           translation: "I want to order refreshments for a meeting."
@@ -18939,7 +18939,7 @@ Used to illustrate the degree or intensity of a situation.
   pos: v
   defs:
     - def: "to drop in for a short visit, to drop by"
-      examples: 
+      examples:
         - example: "상경하거든 다녀가시오."
           transliteration: "Sanggyeonghageodeun danyeogasio."
           translation: "Drop by when you are in Seoul."
@@ -18957,7 +18957,7 @@ Used to illustrate the degree or intensity of a situation.
   pos: v
   defs:
     - def: "to go somewhere for a purpose; to attend"
-      examples: 
+      examples:
         - example: "우리는 함께 학교를 다녔어요."
           transliteration: "Urineun hamkke hakgyoreul danyeosseoyo."
           translation: "We went to school together."
@@ -18983,7 +18983,7 @@ Used to illustrate the degree or intensity of a situation.
   pos: adv
   defs:
     - def: "everyone"
-      examples: 
+      examples:
         - example: "다들 잘 들어갔어?"
           transliteration: "Dadeul jal deureogasseo?"
           translation: "Did everyone go home well?"
@@ -19218,7 +19218,7 @@ Used to illustrate the degree or intensity of a situation.
   pos: adv
   defs:
     - def: "again, once more"
-      examples: 
+      examples:
         - example: "죄송한데 제가 잘 못 들었거든요, 다시 말씀해 주시겠어요?"
           transliteration: "Joesonghande jega jal mot deureotgeodeunyo, dasi malsseumhae jusigesseoyo?"
           translation: "Sorry, I didn't hear you. Can you say that again please?"
@@ -19280,7 +19280,7 @@ Used to illustrate the degree or intensity of a situation.
   pos: n
   defs:
     - def: "diet"
-      examples: 
+      examples:
         - example: "다이어트 중이다."
           transliteration: "Daieoteu jung-ida."
           translation: "I am on a diet."
@@ -19403,7 +19403,7 @@ Used to illustrate the degree or intensity of a situation.
   pos: v
   defs:
     - def: "to shut up"
-      examples: 
+      examples:
         - example: "입 닥쳐!"
           transliteration: "Ip dakchyeo!"
           translation: "shut up!"
@@ -19547,7 +19547,7 @@ Used to illustrate the degree or intensity of a situation.
   defs:
     - def: "a unit"
     - def: "a counter"
-      examples: 
+      examples:
         - example: "단위 명사"
           transliteration: "danwi myeongsa"
           translation: "counter noun (a type of 의존 명사 (uijon myeongsa, “dependent noun”))"
@@ -19570,7 +19570,7 @@ Used to illustrate the degree or intensity of a situation.
   pos: adv
   defs:
     - def: "just. Only the designated one, not others."
-      examples: 
+      examples:
         - example: "내가 원했던 모든 것은 단지 그녀를 닮는 것이었다."
           transliteration: "Naega wonhaetdeon modeun geoseun danji geunyeoreul damneun geosieotda."
           translation: "All I wanted was to be just like her."
@@ -19605,7 +19605,7 @@ Used to illustrate the degree or intensity of a situation.
   defs:
     - def: "maple, maple tree"
     - def: "autumn leaves, autumn foliage"
-      examples: 
+      examples:
         - example: "단풍 구경"
           transliteration: "danpung gugyeong"
           translation: "viewing autumn foliage"
@@ -19663,7 +19663,7 @@ Used to illustrate the degree or intensity of a situation.
   pos: n
   defs:
     - def: "cart"
-      examples: 
+      examples:
         - example: "소달구지"
           transliteration: "sodalguji"
           translation: "ox cart"
@@ -19824,7 +19824,7 @@ Used to illustrate the degree or intensity of a situation.
   pos: n
   defs:
     - def: "dollar"
-      examples: 
+      examples:
         - example: "10억 달러는 100만 달러보다 1000배 더 많은 액수이다."
           transliteration: "10eok dalleoneun 100man dalleoboda 1000bae deo maneun aeksu-ida."
           translation: "A $1 billion is 1,000 times more than a $1 million."
@@ -19925,7 +19925,7 @@ Used to illustrate the degree or intensity of a situation.
   pos: n
   defs:
     - def: "snail"
-      examples: 
+      examples:
         - example: "달팽이 껍질"
           transliteration: "dalpaeng-i kkeopjil"
           translation: "snail's shell"
@@ -20066,7 +20066,7 @@ Used to illustrate the degree or intensity of a situation.
   defs:
     - def: "tobacco"
     - def: "cigarette"
-      examples: 
+      examples:
         - example: "하루에 담배를 얼마나 피우세요?"
           transliteration: "Harue dambaereul eolmana piuseyo?"
           translation: "How many cigarettes do you smoke a day?"
@@ -20149,7 +20149,7 @@ Used to illustrate the degree or intensity of a situation.
   pos: suf
   defs:
     - def: "Attached after nouns or roots, to form adjectives expressing the sense of “to have the property/feeling of; (already) like a ...; typical of”. Forms p-irregular adjectives."
-      examples: 
+      examples:
         - example: "남자 → 남자답다"
           transliteration: "namja → namjadapda"
           translation: "man → to be manly; masculine"
@@ -20284,7 +20284,7 @@ Used to illustrate the degree or intensity of a situation.
   pos: pron
   defs:
     - def: "second person singular plain (non-polite) pronoun; you"
-      examples: 
+      examples:
         - example: "어느 책이 당신 것인가요?"
           transliteration: "Eoneu chaegi dangsin geodin-gayo?"
           translation: "Which book is yours?"
@@ -20441,7 +20441,7 @@ Used to illustrate the degree or intensity of a situation.
   pos: propn
   defs:
     - def: "Daegu; Taegu (a city in South Korea)"
-      examples: 
+      examples:
         - example: "대구 광역시"
           transliteration: "Daegu gwang-yeoksi"
           translation: "Daegu Metropolitan City"
@@ -20560,7 +20560,7 @@ Used to illustrate the degree or intensity of a situation.
   pos: adv
   defs:
     - def: "very (much), so (much), extremely, exceedingly"
-      examples: 
+      examples:
         - example: "대단히 고맙습니다"
           transliteration: "daedanhi gomapseumnida"
           translation: "Thank you very much / Thank you so much"
@@ -20602,7 +20602,7 @@ Used to illustrate the degree or intensity of a situation.
   pos: adv
   defs:
     - def: "approximately"
-      examples: 
+      examples:
         - example: "관측 가능한 우주 안에는 대략 수백억개의 은하수가 있습니다."
           transliteration: "Gwancheuk ganeunghan uju aneneun daeryak subaegeokgae-ui eunhasuga itseumnida."
           translation: "There are approximately a hundred billion galaxies in the observable universe."
@@ -20813,7 +20813,7 @@ Used to illustrate the degree or intensity of a situation.
   pos: n
   defs:
     - def: "substitution, replacement (with 에 (e), it is often translated as \"instead of\", \"in place of\", etc.)"
-      examples: 
+      examples:
         - example: "가는 대신에 집에서 있었어요."
           transliteration: "Ganeun daesine jibeseo isseosseoyo."
           translation: "[I, you, he/she...] stayed home instead of going."
@@ -20934,7 +20934,7 @@ Used to illustrate the degree or intensity of a situation.
   pos: propn
   defs:
     - def: "Daejeon (a city in South Korea)"
-      examples: 
+      examples:
         - example: "대전 광역시"
           transliteration: "Daejeon gwang-yeoksi"
           translation: "Daejeon Metropolitan City"
@@ -20957,7 +20957,7 @@ Used to illustrate the degree or intensity of a situation.
   defs:
     - def: "crowd; party"
     - def: "the masses; public"
-      examples: 
+      examples:
         - example: "클린턴은, 그녀는 대중이 그녀의 이메일을 봐주기를 원하며 국무부에게 그것들을 공개해 줄 것을 요청하였다고 말했다."
           transliteration: "Keullinteoneun, geunyeoneun daejung-i geunyeoui imeireul bwajugireul wonhamyeo gungmubuege geugeotdeureul gonggaehae jul geoseul yocheonghayeotdago malhaetda."
           translation: "Clinton has said that she wants the public to see her emails and that she asked the State Department to release them."
@@ -21024,7 +21024,7 @@ Used to illustrate the degree or intensity of a situation.
   pos: n
   defs:
     - def: "president of a country"
-      examples: 
+      examples:
         - example: "아니야, 대통령은 국민들에 의해 선출된 한 국가의 수장이야."
           transliteration: "Aniya, daetongnyeong-eun gungmindeure uihae seonchuldoen han gukgaui sujang-iya."
           translation: "No, the president is the head of a country elected by the people."
@@ -21221,7 +21221,7 @@ Used to illustrate the degree or intensity of a situation.
   pos: adv
   defs:
     - def: "more; to a greater extent; -er"
-      examples: 
+      examples:
         - example: "이 그림이 색이 더 밝아요."
           transliteration: "I geurimi saegi deo balgayo."
           translation: "This picture is brighter in color."
@@ -21231,7 +21231,7 @@ Used to illustrate the degree or intensity of a situation.
   pos: suf
   defs:
     - def: "a past tense marker, suggesting that the speaker knows it from one's own experience."
-      examples: 
+      examples:
         - example: "어제 기분 좋아 보이더라. 무슨 좋은 일 있어?"
           transliteration: "Eoje gibun joa boideora. Museun joeun il isseo?"
           translation: "You looked happy yesterday—did something nice happen?"
@@ -21374,7 +21374,7 @@ Used to illustrate the degree or intensity of a situation.
   pos: n
   defs:
     - def: "help, aid, assistance, support, backing"
-      examples: 
+      examples:
         - example: "노력한 덕택으로"
           transliteration: "noryeokhan deoktaegeuro"
           translation: "through hard work"
@@ -21387,7 +21387,7 @@ Used to illustrate the degree or intensity of a situation.
   pos: n
   defs:
     - def: "help, aid, assistance, support, backing"
-      examples: 
+      examples:
         - example: "노력한 덕택으로"
           transliteration: "noryeokhan deoktaegeuro"
           translation: "through hard work"
@@ -21440,7 +21440,7 @@ after adjective stems, indicates a state which no longer exists"
   pos: adv
   defs:
     - def: "less"
-      examples: 
+      examples:
         - example: "오늘은 어제보다 덜 추워요."
           transliteration: "Oneureun eojeboda deol chuwoyo."
           translation: "It is less cold today than yesterday."
@@ -21516,7 +21516,7 @@ after adjective stems, indicates a state which no longer exists"
   pos: n
   defs:
     - def: "trap, snare, noose"
-      examples: 
+      examples:
         - example: "노루를 잡으려 놓은 덫에 토끼가 걸려 들었다. (norureul jaburyeo no-eun deoch-e tokkiga geollyeo deureotta.) A rabbit got caught in the trap which [I] set to catch roe deer."
 
 - word: 덮다
@@ -21525,7 +21525,7 @@ after adjective stems, indicates a state which no longer exists"
   defs:
     - def: "to cover"
     - def: "to close, to shut"
-      examples: 
+      examples:
         - example: "책을 덮으세요."
           transliteration: "Chaegeul deopeuseyo."
           translation: "Please close the book(s)."
@@ -21564,7 +21564,7 @@ after adjective stems, indicates a state which no longer exists"
   pos: v
   defs:
     - def: "to take someone away; to take someone with one"
-      examples: 
+      examples:
         - example: "그 여자애들을 영화관에 데려갈거야."
           transliteration: "Geu yeojaaedeureul yeonghwagwane deryeogalgeoya."
           translation: "We're taking the girls to the movies."
@@ -21661,17 +21661,17 @@ after adjective stems, indicates a state which no longer exists"
   defs:
     - def: "(道) province; way"
     - def: "(度) degree (e.g. of an angle, of intensity)"
-      examples: 
+      examples:
         - example: "각도는 60도다."
           transliteration: "Gakdoneun 60doda."
           translation: "The angle is 60 degrees."
     - def: "(刀) knife."
-      examples: 
+      examples:
         - example: "과도를 가져와라."
           transliteration: "Gwadoreul gajyeowara."
           translation: "Bring the knife."
     - def: "(島) island, islet."
-      examples: 
+      examples:
         - example: "(Administrative divisions of South Korea) 리 (ri), 동 (dong), 면 (myeon), 읍 (eup), 구 (gu), 군 (gun), 시 (si), 도 (do) "
 
 - word: 도
@@ -21679,12 +21679,12 @@ after adjective stems, indicates a state which no longer exists"
   pos: part
   defs:
     - def: "as well; too; either, or (negative) neither, nor"
-      examples: 
+      examples:
         - example: "나도!"
           transliteration: "Nado!"
           translation: "Me too!"
     - def: "even"
-      examples: 
+      examples:
         - example: "하나도 없어."
           transliteration: "Hanado eopseo."
           translation: "There isn't even one."
@@ -21951,7 +21951,7 @@ after adjective stems, indicates a state which no longer exists"
   pos: v
   defs:
     - def: "to help, to assist, to aid, to give (somebody) a hand"
-      examples: 
+      examples:
         - example: "이 보고서 마치는 걸 좀 도와줄 수 있어요?"
           transliteration: "I bogoseo machineun geol jom dowajul su isseoyo?"
           translation: "Can you help me finish this report?"
@@ -22112,7 +22112,7 @@ after adjective stems, indicates a state which no longer exists"
   pos: n
   defs:
     - def: "independence"
-      examples: 
+      examples:
         - example: "사법부의 독립성을 향상시키는 노력의 일환으로, 2002년 9월에 정부는 지방법원을 법무부 관할에서 대법원 관할로 변경하였다."
           transliteration: "Sabeopbuui dongnipseong-eul hyangsangsikineun noryeogui ilhwaneuro, 2002nyeon 9wore jeongbuneun jibangbeobwoneul beommubu gwanhareseo daebeobwon gwanhallo byeon-gyeonghayeotda."
           translation: "In an effort to increase judicial independence, the government transferred local courts from the Ministry of Justice to the SPC in September 2002."
@@ -22153,7 +22153,7 @@ after adjective stems, indicates a state which no longer exists"
   pos: n
   defs:
     - def: "toxin"
-      examples: 
+      examples:
         - example: "몸 속의 독소"
           transliteration: "mom sogui dokso"
           translation: "toxins in bodies"
@@ -22224,7 +22224,7 @@ after adjective stems, indicates a state which no longer exists"
   pos: n
   defs:
     - def: "money"
-      examples: 
+      examples:
         - example: "그 여자는 돈 많은 영화 배우이다."
           transliteration: "Geu yeojaneun don maneun yeonghwa bae-u-ida."
           translation: "She is a film star with a lot of money."
@@ -22237,7 +22237,7 @@ after adjective stems, indicates a state which no longer exists"
   pos: n
   defs:
     - def: "A don (寸), a Korean unit of weight equivalent to about 4 g."
-      examples: 
+      examples:
         - example: "그 반지는 3돈 정도 한다."
           transliteration: "Geu banjineun 3don jeongdo handa."
           translation: "The gold ring weighs about three don."
@@ -22353,7 +22353,7 @@ after adjective stems, indicates a state which no longer exists"
   pos: v
   defs:
     - def: "to revolve, rotate, spin, turn"
-      examples: 
+      examples:
         - example: "오른쪽으로 도세요."
           transliteration: "Oreunjjogeuro doseyo."
           translation: "Please turn right."
@@ -22422,7 +22422,7 @@ after adjective stems, indicates a state which no longer exists"
   defs:
     - def: "to return, to go back"
     - def: "to pass away (to do)"
-      examples: 
+      examples:
         - example: "노환으로 돌아가시다"
           transliteration: "nohwaneuro doragasida"
           translation: "to die of old age"
@@ -22472,7 +22472,7 @@ after adjective stems, indicates a state which no longer exists"
   defs:
     - def: "to turn around"
     - def: "to regain, to recover, to undo"
-      examples: 
+      examples:
         - example: "이미 저지른 일은 돌이킬 수 없다."
           transliteration: "Imi jeojireun ireun dorikil su eopda."
           translation: "What is done cannot be undone."
@@ -22491,7 +22491,7 @@ after adjective stems, indicates a state which no longer exists"
   pos: v
   defs:
     - def: "to help; to contribute"
-      examples: 
+      examples:
         - example: "예, 무엇을 도와드릴까요?"
           transliteration: "Ye, mueoseul dowadeurilkkayo?"
           translation: "Hi. What can I do for you?"
@@ -22518,7 +22518,7 @@ after adjective stems, indicates a state which no longer exists"
   pos: n
   defs:
     - def: "neighborhood (hanja: 洞)"
-      examples: 
+      examples:
         - example: "(Administrative divisions of South Korea) 리 (ri), 동 (dong), 면 (myeon), 읍 (eup), 구 (gu), 군 (gun), 시 (si), 도 (do) "
 
 - word: 동
@@ -22544,7 +22544,7 @@ after adjective stems, indicates a state which no longer exists"
   pos: n
   defs:
     - def: "housemate"
-      examples: 
+      examples:
         - example: "나는 마샤와 함께 살아. 우리는 동거인이야."
           transliteration: "Naneun masyawa hamkke sara. Urineun donggeoiniya."
           translation: "I live with Marsha. We’re roommates."
@@ -22578,7 +22578,7 @@ after adjective stems, indicates a state which no longer exists"
   pos: n
   defs:
     - def: "circle"
-      examples: 
+      examples:
         - example: "동그라미를 치다"
           transliteration: "donggeuramireul chida"
           translation: "to circle"
@@ -22733,7 +22733,7 @@ after adjective stems, indicates a state which no longer exists"
   pos: n
   defs:
     - def: "interval, period of time"
-      examples: 
+      examples:
         - example: "세 시간 동안"
           transliteration: "se sigan dong-an"
           translation: "3 hours' time."
@@ -22932,17 +22932,17 @@ after adjective stems, indicates a state which no longer exists"
   pos: v
   defs:
     - def: "to become"
-      examples: 
+      examples:
         - example: "왕이 되다"
           transliteration: "wang-i doeda"
           translation: "to become king"
     - def: "(of a time) to come, to arrive"
-      examples: 
+      examples:
         - example: "약속한 시간이 되었다."
           transliteration: "Yaksokhan sigani doeeotda."
           translation: "The appointed time has arrived."
     - def: "(as an auxiliary verb after a verb in its —어 (eo), —아 (a), or —해 (hae) form) to be permissible; to be OK; may"
-      examples: 
+      examples:
         - example: "질문 해도 돼요?"
           transliteration: "Jilmun haedo dwaeyo?"
           translation: "May [I] ask a question?"
@@ -22969,17 +22969,17 @@ after adjective stems, indicates a state which no longer exists"
   pos: v
   defs:
     - def: "to become"
-      examples: 
+      examples:
         - example: "왕이 되다"
           transliteration: "wang-i doeda"
           translation: "to become king"
     - def: "to come, to arrive"
-      examples: 
+      examples:
         - example: "약속한 시간이 되었다."
           transliteration: "Yaksokhan sigani doeeotda."
           translation: "The appointed time has arrived."
     - def: "to be permissible; to be OK; may"
-      examples: 
+      examples:
         - example: "질문 해도 돼요?"
           transliteration: "Jilmun haedo dwaeyo?"
           translation: "May [I] ask a question?"
@@ -23012,7 +23012,7 @@ after adjective stems, indicates a state which no longer exists"
   pos: v
   defs:
     - def: "repeat (do or say again)"
-      examples: 
+      examples:
         - example: "같은 말을 되풀이하다"
           transliteration: "gateun mareul doepurihada"
           translation: "to say the same thing over and over"
@@ -23142,7 +23142,7 @@ after adjective stems, indicates a state which no longer exists"
   defs:
     - def: "To put"
     - def: "To leave (behind), let there be"
-      examples: 
+      examples:
         - example: "당신에게 그것들을 남겨 둘까요?"
           transliteration: "Dangsinege geugeotdeureul namgyeo dulkkayo?"
           translation: "Should I just leave them with you?"
@@ -23395,7 +23395,7 @@ after adjective stems, indicates a state which no longer exists"
   pos: n
   defs:
     - def: "two"
-      examples: 
+      examples:
         - example: "그는 또한 러시아어로 시를 쓰는데, 그의 시 중 일부는 에스페란토어와 러시아어 버전 둘 다 존재한다."
           transliteration: "Geuneun ttohan reosia-eoro sireul sseuneunde, geuui si jung ilbuneun eseuperanto-eowa reosia-eo beojeon dul da jonjaehanda."
           translation: "He also writes poetry in Russian, and some poems of his exist in both Esperanto and Russian versions."
@@ -23526,7 +23526,7 @@ after adjective stems, indicates a state which no longer exists"
   pos: n
   defs:
     - def: "toilet"
-      examples: 
+      examples:
         - example: "뒷간에 갈 적 마음 다르고 올 적 마음 다르다."
           transliteration: "Dwitgane gal jeok ma-eum dareugo ol jeok ma-eum dareuda."
           translation: "(Korean saying) Danger past, God forgotten."
@@ -23583,7 +23583,7 @@ after adjective stems, indicates a state which no longer exists"
   pos: adv
   defs:
     - def: "finally, at last"
-      examples: 
+      examples:
         - example: "드디어 남북통일이 되었다."
           transliteration: "deudieo nambuk-tongir-i doe-eotta."
           translation: "North and South were unified at last."
@@ -23648,7 +23648,7 @@ after adjective stems, indicates a state which no longer exists"
   pos: n
   defs:
     - def: "drone (unmanned aerial vehicle)"
-      examples: 
+      examples:
         - example: "한 팀원이 제삼극 위에 카메라 드론을 설치했다."
           transliteration: "Han timwoni jesamgeuk wie kamera deuroneul seolchihaetda."
           translation: "One team member launched a camera drone over the Third Pole."
@@ -23665,7 +23665,7 @@ after adjective stems, indicates a state which no longer exists"
   defs:
     - def: "humble form of 주다 (juda); to offer, to give, to present"
     - def: "humble form of 주다 (juda, “the auxiliary verb”); to do for someone else"
-      examples: 
+      examples:
         - example: "문을 열어 드릴까요?"
           transliteration: "Muneul yeoreo deurilkkayo?"
           translation: "Would you like me to open the door? / Shall I open the door?"
@@ -23683,12 +23683,12 @@ after adjective stems, indicates a state which no longer exists"
   pos: v
   defs:
     - def: "to drink: honorific of 마시다 (masida)"
-      examples: 
+      examples:
         - example: "맛있는 차가 없는데 커피라도 드시겠어요?"
           transliteration: "Masinneun chaga eomneunde keopirado deusigesseoyo?"
           translation: "Would you like to drink coffee or something, since we don't have any good tea?"
     - def: "to eat: honorific of 먹다 (meokda)"
-      examples: 
+      examples:
         - example: "볼가심으로 하나 드시겠습니까?"
           transliteration: "Bolgasimeuro hana deusigetseumnikka?"
           translation: "Would you like one of these to tide your hunger over?"
@@ -23699,7 +23699,7 @@ after adjective stems, indicates a state which no longer exists"
   pos: n
   defs:
     - def: "getting a son"
-      examples: 
+      examples:
         - example: "득남 축하합니다."
           transliteration: "Deungnam chukhahamnida."
           translation: "Congratulations for your new baby boy."
@@ -23709,7 +23709,7 @@ after adjective stems, indicates a state which no longer exists"
   pos: n
   defs:
     - def: "getting a daughter"
-      examples: 
+      examples:
         - example: "득녀 축하합니다."
           transliteration: "Deungnyeo chukhahamnida."
           translation: "Congratulations for your new baby girl."
@@ -23744,7 +23744,7 @@ after adjective stems, indicates a state which no longer exists"
   pos: part
   defs:
     - def: "(semantic marker) Used for enumeration, suggesting that the choice made does not matter."
-      examples: 
+      examples:
         - example: "걸어서든 뛰어서든 제 시간에 와라."
           transliteration: "Georeoseodeun ttwieoseodeun je sigane wara."
           translation: "Just be in time whether by walking or by running - I don't care what you choose."
@@ -23753,7 +23753,7 @@ after adjective stems, indicates a state which no longer exists"
   pos: suf
   defs:
     - def: "Used for enumeration, suggests that anything mentioned can be selected."
-      examples: 
+      examples:
         - example: "노래를 부르든 춤을 추든 마음대로 해."
           transliteration: "Noraereul bureudeun chumeul chudeun ma-eumdaero hae."
           translation: "Do as you please; you can sing or dance."
@@ -23786,7 +23786,7 @@ after adjective stems, indicates a state which no longer exists"
   pos: part
   defs:
     - def: "-s (indicating the plural of a noun)"
-      examples: 
+      examples:
         - example: "사람들"
           transliteration: "saramdeul"
           translation: "people, persons"
@@ -23836,42 +23836,42 @@ after adjective stems, indicates a state which no longer exists"
     - def: "to get on; to take (a certain road.)"
     - def: "(to a place to sleep) to get into"
     - def: "to cost; be spent; be used; be poured; be invested (money, effort, etc.)"
-      examples: 
+      examples:
         - example: "지하철을 타는 데 천원이 들었다."
           transliteration: "Jihacheoreul taneun de cheonwoni deureotda."
           translation: "It cost [me] a thousand Won to ride the subway."
         - example: "Note that the subject is the cost, not the spending entity."
     - def: "(color, flavor, or moisture) to get in; to permeate; to saturate with"
     - def: "to reach; be in; to come in"
-      examples: 
+      examples:
         - example: "계약서에 들어 있습니다."
           transliteration: "Gyeyakseo-e deureo itseumnida."
           translation: "It's in the contract."
     - def: "to enter, to infiltrate, be drawn to; be attracted to"
-      examples: 
+      examples:
         - example: "마음에 들다"
           transliteration: "ma-eume deulda"
           translation: "to like, to be likeable (literally, to enter one’s heart/one’s mind)"
     - def: "to join an organization"
     - def: "to actively strive to do"
     - def: "to stop raining"
-      examples: 
+      examples:
         - example: "날이 들었다."
           transliteration: "Nari deureotda."
           translation: "It stopped raining."
     - def: "to grow older; to age"
-      examples: 
+      examples:
         - example: "나이가 들면 지혜가 생긴다."
           transliteration: "Naiga deulmyeon jihyega saengginda."
           translation: "With aging comes wisdom."
     - def: "to hold; to carry"
     - def: "to raise; to lift"
-      examples: 
+      examples:
         - example: "선생님이 정답을 아는 학생을 부탁하셔서 손을 들었다."
           transliteration: "Seonsaengnimi jeongdabeul aneun haksaeng-eul butakhasyeoseo soneul deureotda."
           translation: "The teacher asked for a student who knows the answer, so (I) raised (my) hand."
     - def: "to eat; to drink"
-      examples: 
+      examples:
         - example: "맛있게 드세요"
           transliteration: "masitge deuseyo"
           translation: "Bon appetit (literally, eat tastefully)"
@@ -23896,7 +23896,7 @@ after adjective stems, indicates a state which no longer exists"
   pos: v
   defs:
     - def: "to stop by"
-      examples: 
+      examples:
         - example: "제가 사무실에 들를게요."
           transliteration: "Jega samusire deulleulgeyo."
           translation: "I'll come by the office."
@@ -23939,7 +23939,7 @@ after adjective stems, indicates a state which no longer exists"
   pos: v
   defs:
     - def: "to go into; to enter"
-      examples: 
+      examples:
         - example: "이제, 그는 너무 멀리 가기 전에, 매우 좁은 통로로 들어갔다."
           transliteration: "Ije, geuneun neomu meolli gagi jeone, mae-u jobeun tongnoro deureogatda."
           translation: "Now, before he had gone far, he entered into a very narrow passage,"
@@ -23947,19 +23947,19 @@ after adjective stems, indicates a state which no longer exists"
           transliteration: "Yereul deulmyeon, maneun jiyeogeseo yeoseongdeuri saramdeurege baeksineul jeopjonghaneunde, geu iyuneun, geudeuri jibe deureogal su itgo, dareun yeoseongdeulgwa yaegireul nanul sudo itgo, tto eorinideuregedo jeopgeuni ganeunghagi ttaemunida."
           translation: "For example, in many places women vaccinate people because they can go into homes, talk to other women and gain access to the children."
     - def: "to go to; to attend (a school, institution etc)"
-      examples: 
+      examples:
         - example: "내년에 대학교에 들어간다."
           transliteration: "Naenyeone daehakgyo-e deureoganda."
           translation: "I will attend university next year."
     - def: "to begin"
-      examples: 
+      examples:
         - example: "일주일 후면 겨울 방학에 들어간다."
           transliteration: "Ilju-il humyeon gyeoul banghage deureoganda."
           translation: "Winter break begins in one week."
     - def: "to be needed, required"
     - def: "to belong to (a species, genus etc.)"
     - def: "to be understood"
-      examples: 
+      examples:
         - example: "머리에 들어가다"
           transliteration: "meorie deureogada"
           translation: "literally, “to enter one's head”"
@@ -23977,7 +23977,7 @@ after adjective stems, indicates a state which no longer exists"
   pos: v
   defs:
     - def: "to enter, to come in"
-      examples: 
+      examples:
         - example: "들어오세요. 아나. 어서오세요. ― 고맙습니다."
           transliteration: "Deureooseyo. Ana. Eoseooseyo. ― gomapseumnida."
           translation: "Come in. … Well, Anna, welcome. ― Thank you."
@@ -24023,7 +24023,7 @@ after adjective stems, indicates a state which no longer exists"
   pos: n
   defs:
     - def: "(dependent) as if; in a manner suggesting that"
-      examples: 
+      examples:
         - example: "저 사람, 어디서 본 듯도 한데..."
           transliteration: "Jeo saram, eodiseo bon deutdo hande..."
           translation: "I suppose I might have seen him somewhere..."
@@ -24031,7 +24031,7 @@ after adjective stems, indicates a state which no longer exists"
           transliteration: "Gang-ajido jotaneun deut kkorireul sallang-inda."
           translation: "The dog gently wags his tail as if saying he's fine with it, too."
     - def: "(in the form of -'~는 듯 마는 듯' and such) leaving it ambiguous whether or not"
-      examples: 
+      examples:
         - example: "비가 내릴 듯 말 듯 우중충한 날씨"
           transliteration: "biga naeril deut mal deut ujungchunghan nalssi"
           translation: "a gloomy weather which threatens to rain or not"
@@ -24041,7 +24041,7 @@ after adjective stems, indicates a state which no longer exists"
   pos: suf
   defs:
     - def: "as, like, in the same way that"
-      examples: 
+      examples:
         - example: "불 보듯 뻔한 일이다."
           transliteration: "Bul bodeut ppeonhan irida."
           translation: "It's as bright as seeing a fire. (It's very obvious.)"
@@ -24058,7 +24058,7 @@ after adjective stems, indicates a state which no longer exists"
   pos: n
   defs:
     - def: "(dependent) as if; in a manner suggesting that"
-      examples: 
+      examples:
         - example: "아이는 뜻밖의 선물에 뛸 듯이 기뻐했다."
           transliteration: "Aineun tteutbakkui seonmure ttwil deusi gippeohaetda."
           translation: "The kid nearly jumped for joy at the unexpected present."
@@ -24071,7 +24071,7 @@ after adjective stems, indicates a state which no longer exists"
   pos: suf
   defs:
     - def: "as, like, in the same way that"
-      examples: 
+      examples:
         - example: "구름에 달 가듯이 / 가는 나그네"
           transliteration: "gureume dal gadeusi / ganeun nageune"
           translation: "The wayfarer goes like the moon passing the clouds."
@@ -24144,7 +24144,7 @@ after adjective stems, indicates a state which no longer exists"
   pos: n
   defs:
     - def: "register (machine)"
-      examples: 
+      examples:
         - example: "금전 등록기"
           transliteration: "geumjeon deungnokgi"
           translation: "cash register"
@@ -24154,7 +24154,7 @@ after adjective stems, indicates a state which no longer exists"
   pos: n
   defs:
     - def: "mountain climbing"
-      examples: 
+      examples:
         - example: "다음날 그 팀은 빙하 위의 다른 연구 장비를 수리하는 동안, 특별한 빙산 등반용 신발을 신어야만 했다."
           transliteration: "Da-eumnal geu timeun bingha wiui dareun yeon-gu jangbireul surihaneun dong-an, teukbyeolhan bingsan deungbanyong sinbareul sineoyaman haetda."
           translation: "The next day, the team had to wear special ice climbing footwear while repairing other research devices on the glacier."
@@ -24378,7 +24378,7 @@ after adjective stems, indicates a state which no longer exists"
   pos: v
   defs:
     - def: "to follow, to imitate, to copy, to repeat(after)"
-      examples: 
+      examples:
         - example: "따라하세요"
           transliteration: "ttarahaseyo"
           translation: "please repeat"
@@ -24394,7 +24394,7 @@ after adjective stems, indicates a state which no longer exists"
   pos: v
   defs:
     - def: "to follow"
-      examples: 
+      examples:
         - example: "우체국에 도착할 때까지 그 길을 따라서 가세요."
           transliteration: "Ucheguge dochakhal ttaekkaji geu gireul ttaraseo gaseyo."
           translation: "Follow the road until you reach the post office."
@@ -24415,7 +24415,7 @@ after adjective stems, indicates a state which no longer exists"
   pos: n
   defs:
     - def: "only, just"
-      examples: 
+      examples:
         - example: "나는 그녀를 만났을 따름이다."
           transliteration: "Naneun geunyeoreul mannasseul ttareumida."
           translation: "I just saw her."
@@ -24515,7 +24515,7 @@ after adjective stems, indicates a state which no longer exists"
   pos: n
   defs:
     - def: "daughter"
-      examples: 
+      examples:
         - example: "딸을 시집보내다"
           transliteration: "ttareul sijipbonaeda"
           translation: "to give one's daughter away in marriage"
@@ -24601,7 +24601,7 @@ after adjective stems, indicates a state which no longer exists"
   defs:
     - def: "time"
     - def: "an occasion, the time when..."
-      examples: 
+      examples:
         - example: "어렸을 때"
           transliteration: "eoryeosseul ttae"
           translation: "when one was young/ when one was a child"
@@ -24616,7 +24616,7 @@ after adjective stems, indicates a state which no longer exists"
   defs:
     - def: "time"
     - def: "an occasion, the time when..."
-      examples: 
+      examples:
         - example: "어렸을 때"
           transliteration: "eoryeosseul ttae"
           translation: "when one was young/ when one was a child"
@@ -24653,7 +24653,7 @@ after adjective stems, indicates a state which no longer exists"
   pos: v
   defs:
     - def: "To beat or strike."
-      examples: 
+      examples:
         - example: "나는 화가 너무 많이 나서 나도 모르게 친구의 얼굴을 때려버렸다. "
           transliteration: "Naneun hwaga neomu mani naseo nado moreuge chin-guui eolgureul ttaeryeobeoryeotda. "
           translation: "I was so mad that I  hit  him in the face before I knew it."
@@ -24664,7 +24664,7 @@ after adjective stems, indicates a state which no longer exists"
   pos: n
   defs:
     - def: "(dependent noun) reason for something, usually in phrase \"...기 때문에\" (...gi ttaemune\")"
-      examples: 
+      examples:
         - example: "전날에 공부를 별로 못 했기 때문에 시험을 못 봤어요."
           transliteration: "Jeonnare gongbureul byeollo mot haetgi ttaemune siheomeul mot bwasseoyo."
           translation: "I failed the test because I couldn't study well the day beforehand."
@@ -24677,7 +24677,7 @@ after adjective stems, indicates a state which no longer exists"
   pos: n
   defs:
     - def: "(dependent noun) reason for something, usually in phrase \"...기 때문에\" (...gi ttaemune\")"
-      examples: 
+      examples:
         - example: "전날에 공부를 별로 못 했기 때문에 시험을 못 봤어요."
           transliteration: "Jeonnare gongbureul byeollo mot haetgi ttaemune siheomeul mot bwasseoyo."
           translation: "I failed the test because I couldn't study well the day beforehand."
@@ -24908,7 +24908,7 @@ after adjective stems, indicates a state which no longer exists"
   defs:
     - def: "also"
     - def: "again"
-      examples: 
+      examples:
         - example: "또 봐!"
           transliteration: "Tto bwa!"
           translation: "See you again!"
@@ -24980,7 +24980,7 @@ after adjective stems, indicates a state which no longer exists"
   pos: n
   defs:
     - def: "faeces, excrements, dung"
-      examples: 
+      examples:
         - example: "똥을 누다"
           transliteration: "ttong-eul nuda"
           translation: "to defecate"
@@ -25119,7 +25119,7 @@ after adjective stems, indicates a state which no longer exists"
   pos: v
   defs:
     - def: "to run"
-      examples: 
+      examples:
         - example: "너는 얼마나 빨리 뛸 수 있니?"
           transliteration: "Neoneun eolmana ppalli ttwil su inni?"
           translation: "How fast can you run?"
@@ -25201,7 +25201,7 @@ after adjective stems, indicates a state which no longer exists"
   pos: v
   defs:
     - def: "to float, to rise"
-      examples: 
+      examples:
         - example: "저녁에는 해가 지고 대신에 달이 뜬다."
           transliteration: "Jeonyeogeneun haega jigo daesine dari tteunda."
           translation: "At night, the sun sets and the moon rises in its place."
@@ -25304,7 +25304,7 @@ after adjective stems, indicates a state which no longer exists"
   pos: n
   defs:
     - def: "someone with the same Chinese zodiac sign; person born in the year of the same zodiac sign"
-      examples: 
+      examples:
         - example: "띠동갑 커플"
           transliteration: "ttidonggap keopeul"
           translation: "couple with the same zodiac sign"
@@ -25331,7 +25331,7 @@ after adjective stems, indicates a state which no longer exists"
   pos: suf
   defs:
     - def: "(formal) a plain style imperative ending"
-      examples: 
+      examples:
         - example: "다음 방정식의 해를 구하라."
           transliteration: "Da-eum bangjeongsigui haereul guhara."
           translation: "Find the solutions of following equations."
@@ -25340,7 +25340,7 @@ after adjective stems, indicates a state which no longer exists"
   pos: part
   defs:
     - def: "used after direct quotation"
-      examples: 
+      examples:
         - example: "아버지는 \"신경 쓸 필요 없다.\"라 일축하곤 하셨다."
           transliteration: "Abeojineun sin-gyeong sseul piryo eopda.ra ilchukhagon hasyeotda."
           translation: "My father often dismissed me saying \"Don't bother with it.\""
@@ -25350,7 +25350,7 @@ after adjective stems, indicates a state which no longer exists"
   defs:
     - def: "(after verb) that sb should ..."
     - def: "(after 이다 to be, 아니다 not to be) that ..."
-      examples: 
+      examples:
         - example: "남들이 뭐라 하든 나는 내 갈 길을 가겠다."
           transliteration: "Namdeuri mwora hadeun naneun nae gal gireul gagetda."
           translation: "I will go my way, not caring what people say."
@@ -25359,7 +25359,7 @@ after adjective stems, indicates a state which no longer exists"
   pos: suf
   defs:
     - def: "(after 이다 to be, 아니다 not to be) because, since"
-      examples: 
+      examples:
         - example: "유기농이라 그런지 많이 비싸다."
           transliteration: "Yuginong-ira geureonji mani bissada."
           translation: "This is very expensive, perhaps because it's organic."
@@ -25368,7 +25368,7 @@ after adjective stems, indicates a state which no longer exists"
   pos: suf
   defs:
     - def: "(after 아니다 (anida, “not to be”)) and, but"
-      examples: 
+      examples:
         - example: "친구가 아니라 원수다, 아주."
           transliteration: "Chin-guga anira wonsuda, aju."
           translation: "You're much like an enemy rather than a friend."
@@ -25387,17 +25387,17 @@ after adjective stems, indicates a state which no longer exists"
   pos: suf
   defs:
     - def: "(indirect quotation) that ... should ..."
-      examples: 
+      examples:
         - example: "빠뜨린 것이 없는지 확인하라고 안내 방송을 하면서, 기차는 역에 멈춰 섰다."
           transliteration: "Ppatteurin geosi eomneunji hwaginharago annae bangsong-eul hamyeonseo, gichaneun yeoge meomchwo seotda."
           translation: "The train stopped at the station, with announcements asking the passengers to check if nothing's missing."
     - def: "(purpose) in order to make somebody do something"
-      examples: 
+      examples:
         - example: "엄마가 이걸 게임하라고 사줬니?"
           transliteration: "Eommaga igeol geimharago sajwonni?"
           translation: "Did I buy this for you just for playing games?"
     - def: "an imperative or interrogative ending used to confirm the instruction that is already said."
-      examples: 
+      examples:
         - example: "그만하라고!"
           transliteration: "Geumanharago!"
           translation: "I said, stop!"
@@ -25405,7 +25405,7 @@ after adjective stems, indicates a state which no longer exists"
           transliteration: "I maneun geol oneul ane da harago?"
           translation: "Did you really say I should finish this much all today?"
     - def: "an ending signifying that the speaker has just realized he or she was misunderstanding what had been ordered."
-      examples: 
+      examples:
         - example: "휴, 난 또 나 보고 하라고."
           transliteration: "Hyu, nan tto na bogo harago."
           translation: "Phew, thought it was me that she commanded!"
@@ -25414,32 +25414,32 @@ after adjective stems, indicates a state which no longer exists"
   pos: suf
   defs:
     - def: "(indirect quotation) that ..."
-      examples: 
+      examples:
         - example: "사실이 아니라고 몇 번을 해명했지만 통하지 않았다."
           transliteration: "Sasiri anirago myeot beoneul haemyeonghaetjiman tonghaji anatda."
           translation: "I explained several times that it's not the fact, but it didn't work."
     - def: "quotes proverbs"
-      examples: 
+      examples:
         - example: "고진감래라고, 지금은 이렇게 힘들어도 나중엔 꼭 보답을 받을 걸세."
           transliteration: "Gojin-gamnaerago, jigeumeun ireoke himdeureodo najung-en kkok bodabeul badeul geolse."
           translation: "Like the proverb saying 'Sweet after bitter,' although the life is tough now, you'll surely get the reward for this."
     - def: "because; just because"
-      examples: 
+      examples:
         - example: "그래도 형이라고 동생 챙겨주는 모습이 보기 좋다."
           transliteration: "Geuraedo hyeong-irago dongsaeng chaenggyeojuneun moseubi bogi jota."
           translation: "It's sweet to see him, being the elder brother nevertheless, take care of his younger brother."
     - def: "an imperative or interrogative ending used to confirm the instruction that is already said."
-      examples: 
+      examples:
         - example: "뭐라고요?"
           transliteration: "Mworagoyo?"
           translation: "What?"
     - def: "an ending signifying that the speaker has just realized he or she was misunderstanding something, or what the speaker had doubted was actually nothing."
-      examples: 
+      examples:
         - example: "나는 뭐, 심각한 일이라고."
           transliteration: "Naneun mwo, simgakhan irirago."
           translation: "Eh...so, it is not a serious problem."
     - def: "a declarative ending for emphasizing the speaker's thoughts."
-      examples: 
+      examples:
         - example: "나도 이젠 한계라고! 나보고 어쩌란 말이야!"
           transliteration: "Nado ijen han-gyerago! Nabogo eojjeoran mariya!"
           translation: "I can't bear it anymore! What do you expect from me!"
@@ -25448,12 +25448,12 @@ after adjective stems, indicates a state which no longer exists"
   pos: part
   defs:
     - def: "used after direct quotation"
-      examples: 
+      examples:
         - example: "\"근로기준법을 준수하라! 우리는 기계가 아니다!\"라고, 한국 노동 운동을 대표하는 전태일 열사는 외쳤었다."
           transliteration: "Geullogijunbeobeul junsuhara! Urineun gigyega anida!rago, han-guk nodong undong-eul daepyohaneun jeontaeil yeolsaneun oechyeosseotda."
           translation: "\"Abide by the Labor Standard Act! We are not machines!\" shouted Martyr Jeon Tae-il, who represents the labor movement in Korea."
     - def: "expresses displeasure from unsatisfactory outcomes, or is implemented to purport that the object is no better than others."
-      examples: 
+      examples:
         - example: "나라고 별 수 있나."
           transliteration: "Narago byeol su inna."
           translation: "Neither do I have any idea..."
@@ -25481,7 +25481,7 @@ after adjective stems, indicates a state which no longer exists"
   pos: suf
   defs:
     - def: "(An expression used to quote someone while modifying the following noun.)"
-      examples: 
+      examples:
         - example: "허우위강이라는 어느 방문객이 말하기를, 그는 기후 변화와 바이수이에의 융해에 대해서 너무 걱정하지는 않는다고 한다."
           transliteration: "Heouwigang-iraneun eoneu bangmun-gaegi malhagireul, geuneun gihu byeonhwawa baisu-ie-ui yunghaee daehaeseo neomu geokjeonghajineun anneundago handa."
           translation: "One visitor named Hou Yugang said he was not too concerned about climate change and Baishui’s melting."
@@ -25536,7 +25536,7 @@ after adjective stems, indicates a state which no longer exists"
   pos: part
   defs:
     - def: "while saying ..."
-      examples: 
+      examples:
         - example: "동생한테 갓 만든 쿠키를 먹였더니 \"오, 끝내준다!\"라며 엄지손가락을 들어 보인다."
           transliteration: "Dongsaenghante gat mandeun kukireul meogyeotdeoni o, kkeunnaejunda!ramyeo eomjison-garageul deureo boinda."
           translation: "I gave freshly baked cookies to my brother, and he raised his thumb saying \"Wow, fantastic!\""
@@ -25555,17 +25555,17 @@ after adjective stems, indicates a state which no longer exists"
   pos: suf
   defs:
     - def: "(after 이다 to be, 아니다 not to be) I heard that sb/sth is ...; is that true?"
-      examples: 
+      examples:
         - example: "야야야, 너 실은 걔랑 아는 사이라며? 얼마나 친해? 응?"
           transliteration: "Yayaya, neo sireun gyaerang aneun sairamyeo? Eolmana chinhae? Eung?"
           translation: "Hey hey hey, I heard you're acquainted with him actually! How close? Eh?"
     - def: "(after 이다 to be, 아니다 not to be) Yet I remember you saying sb/sth is ...? (I feel very unpleasant about that.)"
-      examples: 
+      examples:
         - example: "언제는 날 죽일 거라며? 죽여봐! 왜 못 죽이는데? 죽여봐!"
           transliteration: "Eonjeneun nal jugil georamyeo? Jugyeobwa! Wae mot jugineunde? Jugyeobwa!"
           translation: "I remember that you said you'll kill me before? Kill me! Why aren't you going to? Kill me!"
     - def: "(after verb) Yet I remember you saying sb should ...? (I feel very unpleasant about that.)"
-      examples: 
+      examples:
         - example: "왜, 가라며? 하, 이제는 내가 필요해서 그래?"
           transliteration: "Wae, garamyeo? Ha, ijeneun naega piryohaeseo geurae?"
           translation: "Why? You told me to go, don't you remember? Hah, is that because you need me now?"
@@ -25600,7 +25600,7 @@ after adjective stems, indicates a state which no longer exists"
   pos: suf
   defs:
     - def: "(after 이다 to be, 아니다 not to be) because, since"
-      examples: 
+      examples:
         - example: "학생이라서 할인받을 수 있었어요."
           transliteration: "Haksaeng-iraseo harinbadeul su isseosseoyo."
           translation: "I could get a discount because I was a student."
@@ -25711,7 +25711,7 @@ after adjective stems, indicates a state which no longer exists"
   pos: n
   defs:
     - def: "Latin; Latino"
-      examples: 
+      examples:
         - example: "라틴어"
           transliteration: "ratineo"
           translation: "Latin (language)"
@@ -25869,7 +25869,7 @@ after adjective stems, indicates a state which no longer exists"
   pos: suf
   defs:
     - def: "in order to"
-      examples: 
+      examples:
         - example: "커피 마시러 가자."
           transliteration: "Keopi masireo gaja."
           translation: "Let's get coffee!"
@@ -25976,7 +25976,7 @@ after adjective stems, indicates a state which no longer exists"
   pos: n
   defs:
     - def: "wrestling"
-      examples: 
+      examples:
         - example: "프로 레슬링"
           transliteration: "peuro reseulling"
           translation: "pro wrestling"
@@ -26062,7 +26062,7 @@ after adjective stems, indicates a state which no longer exists"
   pos: n
   defs:
     - def: "leader"
-      examples: 
+      examples:
         - example: "위대한 령도자 김정일 대원수님께서는 다음과 같이 말씀하시였다."
           transliteration: "Widaehan ryeongdoja Gimjeong-il daewonsunimkkeseoneun da-eumgwa gachi malsseumhasiyeotda."
           translation: "Great Leader Generalissimo Kim Jong-il spoke as follows."
@@ -26107,7 +26107,7 @@ after adjective stems, indicates a state which no longer exists"
   pos: n
   defs:
     - def: "logo로고"
-      examples: 
+      examples:
         - example: "그 로고는 약어, 브이아이피(VIP)의 형태를 띈 봉황으로 이루어져 있다."
           transliteration: "Geu rogoneun yageo, beu-iaipi(VIP)ui hyeongtaereul ttuin bonghwang-euro irueojyeo itda."
           translation: "Its logo consists of a phoenix in the form of the acronym VIP."
@@ -26160,7 +26160,7 @@ after adjective stems, indicates a state which no longer exists"
   pos: n
   defs:
     - def: "Romance"
-      examples: 
+      examples:
         - example: "로망스 어파"
           transliteration: "romangseu eopa"
           translation: "Romance languages"
@@ -26511,7 +26511,7 @@ after adjective stems, indicates a state which no longer exists"
   defs:
     - def: "li, a traditional Korean unit of distance equivalent to about 393 m."
     - def: "village, a Korean administrative division covering a small settlement and its surrounding hinterland."
-      examples: 
+      examples:
         - example: "(Administrative divisions of South Korea) 리 (ri), 동 (dong), 면 (myeon), 읍 (eup), 구 (gu), 군 (gun), 시 (si), 도 (do) "
 
 - word: 리
@@ -26872,7 +26872,7 @@ after adjective stems, indicates a state which no longer exists"
   pos: part
   defs:
     - def: "each, every"
-      examples: 
+      examples:
         - example: "날마다"
           transliteration: "nalmada"
           translation: "every day"
@@ -26914,7 +26914,7 @@ after adjective stems, indicates a state which no longer exists"
   pos: a
   defs:
     - def: "(to be) suitable"
-      examples: 
+      examples:
         - example: "마땅한 일거리가 없다."
           transliteration: "Mattanghan ilgeoriga eopda."
           translation: "There are no suitable tasks (for me)."
@@ -26965,7 +26965,7 @@ after adjective stems, indicates a state which no longer exists"
     - def: "to dry up"
     - def: "to become thin"
     - def: "to thirst"
-      examples: 
+      examples:
         - example: "목이 말라요."
           transliteration: "Mogi mallayo."
           translation: "I am thirsty."
@@ -27008,7 +27008,7 @@ after adjective stems, indicates a state which no longer exists"
     - def: "to dry up"
     - def: "to become thin"
     - def: "to thirst"
-      examples: 
+      examples:
         - example: "목이 말라요."
           transliteration: "Mogi mallayo."
           translation: "I am thirsty."
@@ -27191,7 +27191,7 @@ after adjective stems, indicates a state which no longer exists"
   pos: n
   defs:
     - def: "heart (i.e. one's emotions), mind"
-      examples: 
+      examples:
         - example: "마음에 들다"
           transliteration: "ma-eume deulda"
           translation: "to catch one's fancy, to like"
@@ -27279,12 +27279,12 @@ after adjective stems, indicates a state which no longer exists"
   pos: adv
   defs:
     - def: "face to face"
-      examples: 
+      examples:
         - example: "마주 보다"
           transliteration: "maju boda"
           translation: "to face each other"
     - def: "mutually"
-      examples: 
+      examples:
         - example: "마주 팔로우하다"
           transliteration: "maju pallouhada"
           translation: "to both follow each other"
@@ -27344,7 +27344,7 @@ after adjective stems, indicates a state which no longer exists"
   pos: v
   defs:
     - def: "to finish"
-      examples: 
+      examples:
         - example: "저에게는 후원자들이 있습니다. 그들이 제 일을 마치도록 도와줄 겁니다."
           transliteration: "Jeo-egeneun huwonjadeuri itseumnida. Geudeuri je ireul machidorok dowajul geomnida."
           translation: "I have supporters, they'll get my work done."
@@ -27477,7 +27477,7 @@ after adjective stems, indicates a state which no longer exists"
     - def: "To curb, defend, protect"
     - def: "To keep (from doing), hinder, prevent"
     - def: ""
-      examples: 
+      examples:
         - example: "혈관이 막히다."
           transliteration: "Hyeolgwani makhida."
           translation: "The blood vessels get blocked."
@@ -27526,7 +27526,7 @@ after adjective stems, indicates a state which no longer exists"
   pos: part
   defs:
     - def: "only"
-      examples: 
+      examples:
         - example: "(Can we add an example for this sense?)"
     - def: "even"
 
@@ -27555,7 +27555,7 @@ after adjective stems, indicates a state which no longer exists"
   pos: v
   defs:
     - def: "to meet; to see (someone)"
-      examples: 
+      examples:
         - example: "아, 그를 언제 다시 만나 볼 수 있을지는 알지 못한다."
           transliteration: "A, geureul eonje dasi manna bol su isseuljineun alji mothanda."
           translation: "Alas, I do not know when I will see him again."
@@ -27605,7 +27605,7 @@ after adjective stems, indicates a state which no longer exists"
   pos: v
   defs:
     - def: "to make"
-      examples: 
+      examples:
         - example: "종이 비행기를 만들다"
           transliteration: "jong-i bihaenggireul mandeulda"
           translation: "to make a paper airplane"
@@ -27613,7 +27613,7 @@ after adjective stems, indicates a state which no longer exists"
           transliteration: "chin-gureul mandeulda"
           translation: "to make friends"
     - def: "to establish (a law, club, etc.)"
-      examples: 
+      examples:
         - example: "시대에 맞는 헌법을 만들다"
           transliteration: "sidaee manneun heonbeobeul mandeulda"
           translation: "to establish a constitution suited to the times"
@@ -27650,7 +27650,7 @@ after adjective stems, indicates a state which no longer exists"
   pos: n
   defs:
     - def: "If, in the event that."
-      examples: 
+      examples:
         - example: "오늘 저녁에 호텔에 갈 겁니까? 만약 그렇다면 저를 태워 줄 수 있습니까?"
           transliteration: "Oneul jeonyeoge hotere gal geomnikka? Manyak geureotamyeon jeoreul taewo jul su itseumnikka?"
           translation: "Are you going to the hotel this evening? If so, can you give me a lift?"
@@ -27684,7 +27684,7 @@ after adjective stems, indicates a state which no longer exists"
   pos: a
   defs:
     - def: "to be satisfied, happy"
-      examples: 
+      examples:
         - example: "전 저의 직업에 만족해요."
           transliteration: "Jeon jeoui jigeobe manjokhaeyo."
           translation: "I am happy with my job."
@@ -27733,7 +27733,7 @@ after adjective stems, indicates a state which no longer exists"
   pos: n
   defs:
     - def: "comics, manga, manhwa, manhua"
-      examples: 
+      examples:
         - example: "일본의 만화"
           transliteration: "Ilbonui manhwa"
           translation: "Japanese manga"
@@ -27758,7 +27758,7 @@ after adjective stems, indicates a state which no longer exists"
   pos: a
   defs:
     - def: "(to be) many, much, a lot, plentiful"
-      examples: 
+      examples:
         - example: "돈이 많은 사람"
           transliteration: "doni maneun saram"
           translation: "someone who has a lot of money; a rich person"
@@ -27780,7 +27780,7 @@ after adjective stems, indicates a state which no longer exists"
   pos: a
   defs:
     - def: "attributive formal of 많다 (manta) : much, many"
-      examples: 
+      examples:
         - example: "나는 많은 노력을 기울였다."
           transliteration: "Naneun maneun noryeogeul giuryeotda."
           translation: "I made a great effort."
@@ -27793,7 +27793,7 @@ after adjective stems, indicates a state which no longer exists"
   pos: adv
   defs:
     - def: "many, much, a lot, plenty, in abundance"
-      examples: 
+      examples:
         - example: "많이 드세요."
           transliteration: "Mani deuseyo."
           translation: "Eat a lot. (\"dig in\"; \"bon appetit\")"
@@ -27805,7 +27805,7 @@ after adjective stems, indicates a state which no longer exists"
   pos: n
   defs:
     - def: "word, speech, language"
-      examples: 
+      examples:
         - example: "내 말을 주의하여 들어봐."
           transliteration: "Nae mareul juuihayeo deureobwa."
           translation: "Listen to me carefully."
@@ -27879,7 +27879,7 @@ specifically Potamogeton oxyphyllus."
   pos: v
   defs:
     - def: ", used to negate imperatives, with —지 (ji)) to not do something, to stop doing"
-      examples: 
+      examples:
         - example: "잔디에 앉지 마시오."
           transliteration: "Jandie anji masio."
           translation: "Do not sit on lawn."
@@ -27971,7 +27971,7 @@ specifically Potamogeton oxyphyllus."
   pos: v
   defs:
     - def: "to stop, to keep"
-      examples: 
+      examples:
         - example: "싸움을 말리다"
           transliteration: "ssaumeul mallida"
           translation: "to stop a fight"
@@ -27982,7 +27982,7 @@ specifically Potamogeton oxyphyllus."
   pos: v
   defs:
     - def: "to dry"
-      examples: 
+      examples:
         - example: "머리를 말리다"
           transliteration: "meorireul mallida"
           translation: "to dry one's hair"
@@ -28007,7 +28007,7 @@ specifically Potamogeton oxyphyllus."
   pos: n
   defs:
     - def: "one's way of speaking; eloquence"
-      examples: 
+      examples:
         - example: "말솜씨가 좋네요."
           transliteration: "Malsomssiga jonneyo."
           translation: "You have a way with words."
@@ -28023,7 +28023,7 @@ specifically Potamogeton oxyphyllus."
   pos: n
   defs:
     - def: "word or speech"
-      examples: 
+      examples:
         - example: "태초에 말씀이 계시니라, 이 말씀이 하나님과 함께 계셨으니, 이 말씀은 곧 하나님이시니라."
           transliteration: "Taecho-e malsseumi gyesinira, i malsseumi hananimgwa hamkke gyesyeosseuni, i malsseumeun got hananimisinira."
           translation: "In the beginning was the Word, and the Word was with God, and the Word was God."
@@ -28046,7 +28046,7 @@ specifically Potamogeton oxyphyllus."
   pos: n
   defs:
     - def: "word, speech, language"
-      examples: 
+      examples:
         - example: "내 말을 주의하여 들어봐."
           transliteration: "Nae mareul juuihayeo deureobwa."
           translation: "Listen to me carefully."
@@ -28099,7 +28099,7 @@ specifically Potamogeton oxyphyllus."
   pos: v
   defs:
     - def: "to speak, to talk"
-      examples: 
+      examples:
         - example: "한국어로 말하자!"
           transliteration: "Han-gugeoro malhaja!"
           translation: "(colloquial) Let's talk in Korean!"
@@ -28113,7 +28113,7 @@ specifically Potamogeton oxyphyllus."
           transliteration: "Eoje ireun mianhadago malhago sipeoyo.  gwaenchanayo. Ana."
           translation: "I want to say I’m sorry for yesterday. — It’s okay, Anna."
     - def: "to explain (by talking)"
-      examples: 
+      examples:
         - example: "이 상황을 어떻게 말해야지?"
           transliteration: "I sanghwang-eul eotteoke malhaeyaji?"
           translation: "How do I explain this situation? (colloquial)"
@@ -28127,7 +28127,7 @@ specifically Potamogeton oxyphyllus."
   pos: a
   defs:
     - def: "(air, water, material) to be clear, clean, fresh, pure, limpid, transparent"
-      examples: 
+      examples:
         - example: "물이 너무 맑으면 물고기가 못산다."
           transliteration: "Muri neomu malgeumyeon mulgogiga motsanda."
           translation: "Too clear waters breed and feed no fish."
@@ -28148,7 +28148,7 @@ specifically Potamogeton oxyphyllus."
   pos: n
   defs:
     - def: "meal, pap, milk"
-      examples: 
+      examples:
         - example: "아가야, 엄마하고 맘마 먹자."
           transliteration: "Agaya, eommahago mamma meokja."
           translation: "Baby, take the meal that I'm giving (you). Literally, let's take a meal with mom."
@@ -28164,7 +28164,7 @@ specifically Potamogeton oxyphyllus."
   pos: n
   defs:
     - def: "taste, flavor"
-      examples: 
+      examples:
         - example: "맛이 있다"
           transliteration: "masi itda"
           translation: "tasty"
@@ -28303,7 +28303,7 @@ specifically Potamogeton oxyphyllus."
   pos: v
   defs:
     - def: "fail, to go under, to go bankrupt, to go broke"
-      examples: 
+      examples:
         - example: "완전히 망하다."
           transliteration: "Wanjeonhi manghada."
           translation: "to fail completely"
@@ -28315,7 +28315,7 @@ specifically Potamogeton oxyphyllus."
   defs:
     - def: "(to agree, to suit)
 to be correct, right"
-      examples: 
+      examples:
         - example: "네 말이 맞는다"
           transliteration: "ne mari manneunda"
           translation: "You are right."
@@ -28323,7 +28323,7 @@ to be correct, right"
           transliteration: "Yeoboseyo? Ana maja? — geurae, na yeogi isseo."
           translation: "Excuse me? Anna? Is that you? — Oh, yes. I am here!"
     - def: "to be correct, right"
-      examples: 
+      examples:
         - example: "네 말이 맞는다"
           transliteration: "ne mari manneunda"
           translation: "You are right."
@@ -28341,7 +28341,7 @@ to take (a wife), to engage, to invite"
     - def: "to take (a wife), to engage, to invite"
     - def: "(to get, to suffer)
 to get a blow, to be struck"
-      examples: 
+      examples:
         - example: "그는 매일 밤 아버지한테 맞는다."
           transliteration: "Geuneun maeil bam abeojihante manneunda."
           translation: "He gets beaten by his father every night."
@@ -28352,7 +28352,7 @@ to get a blow, to be struck"
           transliteration: "Jusareul matda."
           translation: "have an injection."
     - def: "to get a blow, to be struck"
-      examples: 
+      examples:
         - example: "그는 매일 밤 아버지한테 맞는다."
           transliteration: "Geuneun maeil bam abeojihante manneunda."
           translation: "He gets beaten by his father every night."
@@ -28362,7 +28362,7 @@ to get a blow, to be struck"
     - def: "to be caught in (rain, illness)"
     - def: "to encounter (difficulty), to come across"
     - def: "to get (an injection), to get (a mark, a rating)"
-      examples: 
+      examples:
         - example: "주사를 맞다."
           transliteration: "Jusareul matda."
           translation: "have an injection."
@@ -28407,7 +28407,7 @@ to get a blow, to be struck"
   pos: n
   defs:
     - def: "other side"
-      examples: 
+      examples:
         - example: "헬스클럽은 라운지 맞은편에 있어. 로비 뒤쪽이야."
           transliteration: "Helseukeulleobeun raunji majeunpyeone isseo. Robi dwijjogiya."
           translation: "The gym is across from the lounge. It is behind the lobby."
@@ -28431,7 +28431,7 @@ to get a blow, to be struck"
   pos: v
   defs:
     - def: "to set, adjust, to tune, to adapt"
-      examples: 
+      examples:
         - example: "몸을 옷에 맞추세요!"
           transliteration: "Momeul ose matchuseyo!"
           translation: "Adapt the body to a suit (which may not fit you)!"
@@ -28467,7 +28467,7 @@ to get a blow, to be struck"
   pos: v
   defs:
     - def: "to take on a task or job; to take charge of"
-      examples: 
+      examples:
         - example: "일을 맡다"
           transliteration: "ireul matda"
           translation: "to undertake a job"
@@ -28500,7 +28500,7 @@ to get a blow, to be struck"
   pos: suf
   defs:
     - def: "shape"
-      examples: 
+      examples:
         - example: "몸매 (mommae, “body-shape, figure”)"
         - example: "눈매 (nunmae, “eye-shape, figure”)"
 
@@ -28509,7 +28509,7 @@ to get a blow, to be struck"
   pos: det
   defs:
     - def: "every"
-      examples: 
+      examples:
         - example: "매 월 첫째주"
           transliteration: "mae wol cheotjjaeju"
           translation: "the first week of every month"
@@ -28594,7 +28594,7 @@ to get a blow, to be struck"
   pos: n
   defs:
     - def: "knot, tie"
-      examples: 
+      examples:
         - example: "매듭이 풀렸다"
           transliteration: "maedeubi pullyeotda"
           translation: "The knot came untied"
@@ -28660,7 +28660,7 @@ to get a blow, to be struck"
   pos: adv
   defs:
     - def: "every day"
-      examples: 
+      examples:
         - example: "내가 매일 TV를 봐요."
           transliteration: "Naega maeil TVreul bwayo."
           translation: "I watch TV every day."
@@ -28676,7 +28676,7 @@ to get a blow, to be struck"
   pos: adv
   defs:
     - def: "every day"
-      examples: 
+      examples:
         - example: "내가 매일 TV를 봐요."
           transliteration: "Naega maeil TVreul bwayo."
           translation: "I watch TV every day."
@@ -28759,7 +28759,7 @@ to get a blow, to be struck"
   pos: propn
   defs:
     - def: "Mac"
-      examples: 
+      examples:
         - example: "맥용"
           transliteration: "maegyong"
           translation: "for Macs"
@@ -28833,7 +28833,7 @@ to get a blow, to be struck"
   pos: a
   defs:
     - def: "furious; fierce"
-      examples: 
+      examples:
         - example: "맹렬한 소아마비 바이러스가 아프가니스탄, 파키스탄 및 나이지리아에 여전히 남아 있다."
           transliteration: "Maengnyeolhan soamabi baireoseuga apeuganiseutan, pakiseutan mit naijiria-e yeojeonhi nama itda."
           translation: "The wild polio virus still exists in Afghanistan, Pakistan and Nigeria."
@@ -28912,7 +28912,7 @@ to get a blow, to be struck"
   pos: n
   defs:
     - def: "hair (on a person's head)"
-      examples: 
+      examples:
         - example: "머리카락 색깔"
           transliteration: "meorikarak saekkkal"
           translation: "hair color"
@@ -28958,7 +28958,7 @@ to get a blow, to be struck"
   pos: v
   defs:
     - def: "Alternative form of 머무르다 (meomureuda)"
-      examples: 
+      examples:
         - example: "보안관은, 아침에 그들이 좀더 시야를 확보할 수 있을 때까지 머물도록, 부관을 배치했다."
           transliteration: "Boan-gwaneun, achime geudeuri jomdeo siyareul hwakbohal su isseul ttaekkaji meomuldorok, bugwaneul baechihaetda."
           translation: "The sheriff posted a deputy to stay until they could get a better look in the morning."
@@ -29079,7 +29079,7 @@ to get a blow, to be struck"
   pos: a
   defs:
     - def: "far"
-      examples: 
+      examples:
         - example: "집에서 학교까지 멀어요?"
           transliteration: "Jibeseo hakgyokkaji meoreoyo?"
           translation: "Is it far from (your) home to school?"
@@ -29139,7 +29139,7 @@ to get a blow, to be struck"
   pos: n
   defs:
     - def: "zest, taste, flavour, relish"
-      examples: 
+      examples:
         - example: "멋을 아는 사람"
           transliteration: "meoseul aneun saram"
           translation: "a man of taste"
@@ -29166,7 +29166,7 @@ to get a blow, to be struck"
   pos: a
   defs:
     - def: "to be cool, splendid"
-      examples: 
+      examples:
         - example: "이 다방은 아주 멋지다."
           transliteration: "I dabang-eun aju meotjida."
           translation: "This coffee shop is very nice."
@@ -29189,7 +29189,7 @@ to get a blow, to be struck"
   pos: adv
   defs:
     - def: "with a woof or bow-wow"
-      examples: 
+      examples:
         - example: "그 개는 멍멍 짖었다."
           translation: "Geu gae-neun meongmeong jijeotta."
 
@@ -29294,7 +29294,7 @@ to get a blow, to be struck"
   pos: n
   defs:
     - def: "(literally, \"meadow hopper\") short-horned grasshopper, locust"
-      examples: 
+      examples:
         - example: "메뚜기도 한 철."
           transliteration: "Mettugido han cheol."
           translation: "Grasshoppers have a best season."
@@ -29426,7 +29426,7 @@ to get a blow, to be struck"
   pos: n
   defs:
     - def: "mental breakdown"
-      examples: 
+      examples:
         - example: "나 지금 멘붕 상태야."
           transliteration: "Na jigeum menbung sangtaeya."
           translation: "I'm just in a mental breakdown."
@@ -29520,12 +29520,12 @@ to get a blow, to be struck"
   pos: suf
   defs:
     - def: "enumerates descriptions"
-      examples: 
+      examples:
         - example: "잎은 달걀 모양이며 끝은 길게 뾰족하고 밑은 둥글며 바늘 모양의 톱니가 있다."
           transliteration: "Ipeun dalgyal moyang-imyeo kkeuteun gilge ppyojokhago miteun dunggeulmyeo baneul moyang-ui tomniga itda."
           translation: "The leaf is egg-shaped, and its end is long and sharp, and its bottom is round, and is saw-toothed."
     - def: "as, while, at the same time (that)"
-      examples: 
+      examples:
         - example: "그녀는 숨을 가쁘게 쉬며 강변 산책로를 따라 뛰었다."
           transliteration: "Geunyeoneun sumeul gappeuge swimyeo gangbyeon sanchaengnoreul ttara ttwieotda."
           translation: "She ran along the riverside walk while breathing heavily."
@@ -29534,7 +29534,7 @@ to get a blow, to be struck"
   pos: part
   defs:
     - def: "enumerates items"
-      examples: 
+      examples:
         - example: "무며 오이며 부추며 갖가지 채소로 김치를 담그는 아낙들의 손길이 바쁘다."
           transliteration: "Mumyeo oimyeo buchumyeo gatgaji chaesoro gimchireul damgeuneun anakdeurui son-giri bappeuda."
           translation: "Women are busy making kimchi from various vegetables such as white radishes, cucumbers, and leeks."
@@ -29551,7 +29551,7 @@ to get a blow, to be struck"
   defs:
     - def: "how many days?"
     - def: "which day?, what date?"
-      examples: 
+      examples:
         - example: "생일이 며칠이에요?"
           transliteration: "Saeng-iri myeochirieyo?"
           translation: "What date is your birthday?"
@@ -29576,7 +29576,7 @@ to get a blow, to be struck"
   pos: suf
   defs:
     - def: "if"
-      examples: 
+      examples:
         - example: "suffix for verbs indicating conditional conjunctive"
         - example: "그분이 가시면, 저도 가겠어요."
           transliteration: "Geubuni gasimyeon, jeodo gagesseoyo."
@@ -29589,7 +29589,7 @@ to get a blow, to be struck"
     - def: "cotton"
     - def: "noodles (hanja: 麵)"
     - def: "township (hanja: 面)"
-      examples: 
+      examples:
         - example: "(Administrative divisions of South Korea) 리 (ri), 동 (dong), 면 (myeon), 읍 (eup), 구 (gu), 군 (gun), 시 (si), 도 (do) "
 
 - word: 면도
@@ -29628,12 +29628,12 @@ to get a blow, to be struck"
   pos: suf
   defs:
     - def: "though, yet, notwithstanding, in spite of, for[with] all"
-      examples: 
+      examples:
         - example: "잘 알지도 못하면서 참견은."
           transliteration: "Jal aljido mothamyeonseo chamgyeoneun."
           translation: "So nosy...you even don't know much!"
     - def: "as, while, at the same time (that), with, between, during"
-      examples: 
+      examples:
         - example: "점심은 오면서 간단하게 먹었어."
           transliteration: "Jeomsimeun omyeonseo gandanhage meogeosseo."
           translation: "I had simple lunch while getting here."
@@ -29661,7 +29661,7 @@ to get a blow, to be struck"
   pos: n
   defs:
     - def: "area"
-      examples: 
+      examples:
         - example: "그것은 면적이 약 사백오십(450)만 제곱 킬로미터에 달하고 남극 대륙과 그린랜드에 이어서 세계에서 세번째로 큰 얼음 더미를 차지하고 있다."
           transliteration: "Geugeoseun myeonjeogi yak sabaegosip(450)man jegop killomiteo-e dalhago namgeuk daeryukgwa geurillaendeue ieoseo segyeeseo sebeonjjaero keun eoreum deomireul chajihago itda."
           translation: "It is about 4.5 million square kilometers in area and holds the world’s third largest collection of ice after Antarctica and Greenland."
@@ -29672,7 +29672,7 @@ to get a blow, to be struck"
   defs:
     - def: "face-to-face meeting; meeting in person; personal interview"
     - def: "interview, oral test"
-      examples: 
+      examples:
         - example: "나는 다가오고 있는 면접을 준비하고 있다."
           transliteration: "Naneun dagaogo inneun myeonjeobeul junbihago itda."
           translation: "I am preparing for an upcoming interview."
@@ -29728,7 +29728,7 @@ to get a blow, to be struck"
   defs:
     - def: "a person's name"
     - def: "(dependent noun) counter for people"
-      examples: 
+      examples:
         - example: "식당에 먹으러 가고 외식자 열 명쯤과 이야기를 했다"
           transliteration: "sikdang-e meogeureo gago oesikja yeol myeongjjeumgwa iyagireul haetda"
           translation: "(I) Went to eat at a restaurant and talked with about 10 diners"
@@ -29891,12 +29891,12 @@ to get a blow, to be struck"
   pos: det
   defs:
     - def: "how many"
-      examples: 
+      examples:
         - example: "몇 살이에요?"
           transliteration: "Myeot sarieyo?"
           translation: "How old are you?, How old is (he/she)?"
     - def: "which number"
-      examples: 
+      examples:
         - example: "몇 층에 사세요?"
           transliteration: " Myeot cheung-e saseyo?"
           translation: "What floor do you live on?"
@@ -30255,7 +30255,7 @@ to get a blow, to be struck"
   pos: v
   defs:
     - def: "to gather, to collect"
-      examples: 
+      examples:
         - example: "자료를 모으다"
           transliteration: "jaryoreul mo-euda"
           translation: "to gather data"
@@ -30291,7 +30291,7 @@ to get a blow, to be struck"
   pos: n
   defs:
     - def: "hat, cap"
-      examples: 
+      examples:
         - example: "모자를 쓰다"
           transliteration: "mojareul sseuda"
           translation: "to put on a hat"
@@ -30333,7 +30333,7 @@ to get a blow, to be struck"
   defs:
     - def: "especially"
     - def: "after a long time; long-awaited"
-      examples: 
+      examples:
         - example: "모처럼의 좋은 날씨"
           transliteration: "mocheoreomui joeun nalssi"
           translation: "the long-awaited nice weather"
@@ -30443,7 +30443,7 @@ to get a blow, to be struck"
   pos: n
   defs:
     - def: "necklace (jewelry)"
-      examples: 
+      examples:
         - example: "목걸이를 걸다."
           transliteration: "Mokgeorireul geolda."
           translation: "Put on a necklace/wear a necklace."
@@ -30453,7 +30453,7 @@ to get a blow, to be struck"
   pos: n
   defs:
     - def: "witness"
-      examples: 
+      examples:
         - example: "경찰은 목격자를 찾기 위한 노력으로, 많은 탐문 수사를 했다."
           transliteration: "Gyeongchareun mokgyeokjareul chatgi wihan noryeogeuro, maneun tammun susareul haetda."
           translation: "The police did a lot of legwork in an effort to find an eyewitness."
@@ -30505,7 +30505,7 @@ to get a blow, to be struck"
   pos: a
   defs:
     - def: "(to be) thirsty"
-      examples: 
+      examples:
         - example: "난 너무 목말라서, 오렌지 주스를 세 잔이나 비웠어."
           transliteration: "Nan neomu mongmallaseo, orenji juseureul se janina biwosseo."
           translation: "I was so thirsty that I got through three glasses of orange juice."
@@ -30522,7 +30522,7 @@ to get a blow, to be struck"
   pos: a
   defs:
     - def: "(to be) thirsty"
-      examples: 
+      examples:
         - example: "난 너무 목말라서, 오렌지 주스를 세 잔이나 비웠어."
           transliteration: "Nan neomu mongmallaseo, orenji juseureul se janina biwosseo."
           translation: "I was so thirsty that I got through three glasses of orange juice."
@@ -30569,7 +30569,7 @@ to get a blow, to be struck"
   pos: n
   defs:
     - def: "life"
-      examples: 
+      examples:
         - example: "탈출 계획을 준비한 선견지명 덕분에 그들은 목숨을 구할 수 있었던 것일지도 모른다."
           transliteration: "Talchul gyehoegeul junbihan seon-gyeonjimyeong deokbune geudeureun moksumeul guhal su isseotdeon geodiljido moreunda."
           translation: "Having the foresight to prepare an evacuation plan may have saved their lives."
@@ -30579,7 +30579,7 @@ to get a blow, to be struck"
   pos: propn
   defs:
     - def: "Thursday"
-      examples: 
+      examples:
         - example: "다음 주 목요일에 봐."
           transliteration: "Da-eum ju mogyoire bwa."
           translation: "I'll see you next week Thursday."
@@ -30656,7 +30656,7 @@ to get a blow, to be struck"
   defs:
     - def: "vocal cords"
     - def: "voice, tune (of voice)"
-      examples: 
+      examples:
         - example: "목청을 돋우다"
           transliteration: "mokcheong-eul doduda"
           translation: "to raise one's voice"
@@ -30794,7 +30794,7 @@ to get a blow, to be struck"
   pos: adv
   defs:
     - def: "secretly, in secret"
-      examples: 
+      examples:
         - example: "몰래 만나다"
           transliteration: "mollae mannada"
           translation: "to have a secret meeting, to meet in secret"
@@ -30822,7 +30822,7 @@ to get a blow, to be struck"
   pos: n
   defs:
     - def: "body"
-      examples: 
+      examples:
         - example: "그는 몸이 좋다."
           transliteration: "Geuneun momi jota."
           translation: "He has a nice body."
@@ -30842,7 +30842,7 @@ to get a blow, to be struck"
   pos: n
   defs:
     - def: "gesture, motion"
-      examples: 
+      examples:
         - example: "어린이는 몸짓으로 목이 마르다고 어머니에게 호소했다."
           transliteration: "Eorinineun momjiseuro mogi mareudago eomeoniege hosohaetda."
           translation: "The child gestured to his mother that he was thirsty."
@@ -30885,7 +30885,7 @@ to get a blow, to be struck"
   pos: pref
   defs:
     - def: "cannot; inability"
-      examples: 
+      examples:
         - example: "Used before a 동사 (dongsa, “verb”) to indicate inability."
 
 - word: 못살다
@@ -30908,7 +30908,7 @@ to get a blow, to be struck"
   pos: v
   defs:
     - def: "to be as ... as (shortened form of 못지아니하다)"
-      examples: 
+      examples:
         - example: "오늘도 어제 못지않게 덥다."
           transliteration: "Oneuldo eoje motjianke deopda."
           translation: "Today is just as hot as yesterday."
@@ -30919,12 +30919,12 @@ to get a blow, to be struck"
   pos: v
   defs:
     - def: "(verb-지 못하다) cannot (do); to be unable, or impossible (to do)"
-      examples: 
+      examples:
         - example: "집에 가지 못해요. = 집에 못 가요."
           transliteration: "Jibe gaji mothaeyo. = jibe mot gayo."
           translation: "I cannot go home. = I cannot go home."
     - def: "(를 못하다) not be good at"
-      examples: 
+      examples:
         - example: "나는 노래를 못해요."
           transliteration: "Naneun noraereul mothaeyo."
           translation: "I'm not good at singing."
@@ -31102,7 +31102,7 @@ to get a blow, to be struck"
   pos: adv
   defs:
     - def: "as many as, as much as, whopping (denoting unexpected multitude of entities)"
-      examples: 
+      examples:
         - example: "오늘 운이 좋은 이 어부는 오징어를 무려 열 마리 잡았다."
           transliteration: "Oneul uni joeun i eobuneun ojing-eoreul muryeo yeol mari jabatda."
           translation: "This lucky fisherman caught a whopping batch of ten octopuses today."
@@ -31124,7 +31124,7 @@ to get a blow, to be struck"
   pos: n
   defs:
     - def: "free, at no cost, free of charge"
-      examples: 
+      examples:
         - example: "무료로 보내다"
           transliteration: "muryoro bonaeda"
           translation: "to send for free"
@@ -31164,7 +31164,7 @@ to get a blow, to be struck"
   pos: n
   defs:
     - def: "knee"
-      examples: 
+      examples:
         - example: "무릎까지 내려오는 스커트"
           transliteration: "mureupkkaji naeryeooneun seukeoteu"
           translation: "a skirt of knee length"
@@ -31266,7 +31266,7 @@ to get a blow, to be struck"
   pos: det
   defs:
     - def: "what, what kind of"
-      examples: 
+      examples:
         - example: "무슨 일을 하세요?"
           transliteration: "Museun ireul haseyo?"
           translation: "What kind of work do you do?"
@@ -31291,7 +31291,7 @@ to get a blow, to be struck"
   pos: n
   defs:
     - def: "atheism, antitheism, ignosticism"
-      examples: 
+      examples:
         - example: "소극적/적극적 무신론"
           transliteration: "sogeukjeok/jeokgeukjeok musillon"
           translation: "negative/positive atheism"
@@ -31343,7 +31343,7 @@ to get a blow, to be struck"
   pos: pron
   defs:
     - def: "what - used in questions"
-      examples: 
+      examples:
         - example: "이게 뭐예요?"
           transliteration: "Ige mwoyeyo?"
           translation: "What is this?"
@@ -31351,7 +31351,7 @@ to get a blow, to be struck"
           transliteration: "Mworago haesseoyo?"
           translation: "What did [you] say?"
     - def: "something, anything"
-      examples: 
+      examples:
         - example: "무엇인가가 실제와 다른 것처럼 주장하거나 행동하다."
           transliteration: "Mueodin-gaga siljewa dareun geotcheoreom jujanghageona haengdonghada."
           translation: "to claim that or act as if something is different from what it actually is"
@@ -31445,7 +31445,7 @@ to get a blow, to be struck"
   pos: adv
   defs:
     - def: "very, extremely, extraordinarily, exceedingly"
-      examples: 
+      examples:
         - example: "그는 무척이나 노력하였고 잠시 레버에 매달렸다. 그리고 천천히 엔진은 다시 앞으로 나아갔다."
           transliteration: "Geuneun mucheogina noryeokhayeotgo jamsi rebeo-e maedallyeotda. Geurigo cheoncheonhi enjineun dasi apeuro naagatda."
           translation: "He made a huge effort, hung for a moment on the levers, and slowly the engine came forward again."
@@ -31789,7 +31789,7 @@ to get a blow, to be struck"
   pos: v
   defs:
     - def: "to ask, to inquire"
-      examples: 
+      examples:
         - example: "말씀 좀 묻겠습니다."
           transliteration: "Malsseum jom mutgetseumnida."
           translation: "May I ask you something? (literally, \"I will ask you something\".)"
@@ -31800,12 +31800,12 @@ to get a blow, to be struck"
           transliteration: "Miraee daehaeseo mutda."
           translation: "to ask about one's future"
     - def: "to charge (a person with)"
-      examples: 
+      examples:
         - example: "책임을 묻다"
           transliteration: "chaegimeul mutda"
           translation: "to charge (a person) with irresponsibility"
     - def: "to care"
-      examples: 
+      examples:
         - example: "경험은 묻지 않음"
           transliteration: "gyeongheomeun mutji aneum"
           translation: "no experience required"
@@ -31844,7 +31844,7 @@ to get a blow, to be struck"
   pos: n
   defs:
     - def: "water"
-      examples: 
+      examples:
         - example: "제인, 이 글라디올러스가 왜 시들해지고 있을까?  얼마나 자주 물을 주었지?"
           transliteration: "Jein, i geulladiolleoseuga wae sideulhaejigo isseulkka?  eolmana jaju mureul jueotji?"
           translation: "Jane, why is this gladiolus getting weak? - How often did you give water to it?"
@@ -31879,7 +31879,7 @@ to get a blow, to be struck"
   pos: n
   defs:
     - def: "item, article, thing"
-      examples: 
+      examples:
         - example: "디아이와이를 하는 사람들이 그들 스스로 물건을 만드는 데에 대한 팁을 나누려고 일주일에 한번씩 모인다."
           transliteration: "Diaiwaireul haneun saramdeuri geudeul seuseuro mulgeoneul mandeuneun dee daehan tibeul nanuryeogo ilju-ire hanbeonssik moinda."
           translation: "The DIYers get together once a week to share tips on making things for themselves."
@@ -31948,7 +31948,7 @@ to get a blow, to be struck"
   pos: v
   defs:
     - def: "step aside; step back; move back"
-      examples: 
+      examples:
         - example: "뒤로 물러서요."
           transliteration: "Dwiro mulleoseoyo."
           translation: "You move back."
@@ -31967,7 +31967,7 @@ to get a blow, to be struck"
   pos: v
   defs:
     - def: "to take over; to inherit"
-      examples: 
+      examples:
         - example: "그녀의 파란 눈은 어머니에게서 물려받은 것이다."
           transliteration: "Geunyeoui paran nuneun eomeoniegeseo mullyeobadeun geosida."
           translation: "She inherited her blue eyes from her mother."
@@ -32094,7 +32094,7 @@ to get a blow, to be struck"
     - def: "a substance; a material"
     - def: "wealth; property"
     - def: "material; matter"
-      examples: 
+      examples:
         - example: "독성이 있는 요소나 물질."
           transliteration: "Dokseong-i inneun yosona muljil."
           translation: "A poisonous element or substance."
@@ -32124,7 +32124,7 @@ to get a blow, to be struck"
   pos: n
   defs:
     - def: "(dry) land"
-      examples: 
+      examples:
         - example: "뭍에 오르다"
           transliteration: "mute oreuda"
           translation: "to go ashore"
@@ -32134,7 +32134,7 @@ to get a blow, to be struck"
   pos: pron
   defs:
     - def: "contraction of 무엇 (mueot):  what"
-      examples: 
+      examples:
         - example: "이게 뭐예요?"
           transliteration: "Ige mwoyeyo?"
           translation: "What is this? (polite)"
@@ -32409,7 +32409,7 @@ to get a blow, to be struck"
   pos: n
   defs:
     - def: "A (bright) smile."
-      examples: 
+      examples:
         - example: "미소를 짓다"
           transliteration: "misoreul jitda"
           translation: "to smile"
@@ -32439,7 +32439,7 @@ to get a blow, to be struck"
   pos: n
   defs:
     - def: "art museum, art gallery"
-      examples: 
+      examples:
         - example: "저희 미술관에 오신 것을 환영합니다."
           transliteration: "Jeohui misulgwane osin geoseul hwanyeonghamnida."
           translation: "Welcome to our museum."
@@ -32628,7 +32628,7 @@ to get a blow, to be struck"
   pos: adv
   defs:
     - def: "yet (up to a certain point of event or a certain phase; usually for denoting a consequence of a failed act)"
-      examples: 
+      examples:
         - example: "내가 미처 두부를 살 생각해지 못했다."
           transliteration: "Naega micheo dubureul sal saenggakhaeji mothaetda."
           translation: "I didn't even think of buying tofu."
@@ -32638,7 +32638,7 @@ to get a blow, to be struck"
   pos: v
   defs:
     - def: "to go crazy, to become insane"
-      examples: 
+      examples:
         - example: "너 미쳤어?"
           transliteration: "Neo michyeosseo?"
           translation: "Are you insane? (informal)"
@@ -32657,7 +32657,7 @@ to get a blow, to be struck"
   defs:
     - def: "one who is mentally deranged; a mentally ill or disordered person"
     - def: "lunatic; nutcase"
-      examples: 
+      examples:
         - example: "늙다리 미치광이"
           transliteration: "neukdari michigwang-i"
           translation: "lunatic old man"
@@ -32667,7 +32667,7 @@ to get a blow, to be struck"
   pos: v
   defs:
     - def: "to go crazy, to become insane"
-      examples: 
+      examples:
         - example: "너 미쳤어?"
           transliteration: "Neo michyeosseo?"
           translation: "Are you insane? (informal)"
@@ -32849,7 +32849,7 @@ to get a blow, to be struck"
   pos: n
   defs:
     - def: "people, nation, ethnicity, race, or tribe"
-      examples: 
+      examples:
         - example: "민족 해방"
           transliteration: "minjok haebang"
           translation: "national liberation"
@@ -32903,7 +32903,7 @@ to get a blow, to be struck"
   pos: v
   defs:
     - def: "to believe in something; to trust someone"
-      examples: 
+      examples:
         - example: "逃亡애 命을 믿으며 놀애예 일훔 믿으니.도망애 명을 믿으며 놀애예 일훔 믿으니."
           transliteration: "Domang-ae myeong-eul mideumyeo noraeye ilhum mideuni."
   conj: [믿는다, 믿어, 믿어요, 믿습니다]
@@ -33056,7 +33056,7 @@ to get a blow, to be struck"
   pos: n
   defs:
     - def: "below, bottom, lower, underneath"
-      examples: 
+      examples:
         - example: "침대 밑은 봤어?"
           transliteration: "Chimdae miteun bwasseo?"
           translation: "Did you check under the bed?"
@@ -33066,13 +33066,13 @@ to get a blow, to be struck"
   pos: n
   defs:
     - def: "bar; pub; bar parlour"
-      examples: 
+      examples:
         - example: "⇒ 스탠드바 (seutaendeuba)"
         - example: "그녀는 나를 분위기 좋은 바로 데려갔다."
           transliteration: "Geunyeoneun nareul bunwigi joeun baro deryeogatda."
           translation: "She took me to a bar with a good atmosphere."
     - def: "bar (horizontal pole that must be crossed in high jump and pole vault)"
-      examples: 
+      examples:
         - example: "그는 바를 아슬아슬하게 넘어 우승을 차지했다."
           transliteration: "Geuneun bareul aseuraseulhage neomeo useung-eul chajihaetda."
           translation: "He narrowly crossed the bar and won."
@@ -33084,7 +33084,7 @@ to get a blow, to be struck"
   pos: n
   defs:
     - def: "(straw or hemp) rope; tether"
-      examples: 
+      examples:
         - example: "⇒ 참바 (chamba), 밧줄 (batjul)"
         - example: "여봐라, 저 죄인을 바로 꽁꽁 묶어라."
           transliteration: "Yeobwara, jeo joeineul baro kkongkkong mukkeora."
@@ -33095,7 +33095,7 @@ to get a blow, to be struck"
   pos: n
   defs:
     - def: "fa; F"
-      examples: 
+      examples:
         - example: "≈ 파 (pa)"
         - example: "바장조"
           transliteration: "bajangjo"
@@ -33128,7 +33128,7 @@ to get a blow, to be struck"
   pos: n
   defs:
     - def: "outside; outdoors"
-      examples: 
+      examples:
         - example: "바깥 날씨가 어때요?"
           transliteration: "Bakkat nalssiga eottaeyo?"
           translation: "How is the weather outside?"
@@ -33150,17 +33150,17 @@ to get a blow, to be struck"
   pos: v
   defs:
     - def: "to change [something]; to replace [something] with something else"
-      examples: 
+      examples:
         - example: "전구를 바꾸어 끼우다"
           transliteration: "jeon-gureul bakkueo kkiuda"
           translation: "to change a lightbulb"
     - def: "to exchange [something]; to give [something] and receive something else in return"
-      examples: 
+      examples:
         - example: "지폐를 잔돈으로 바꾸다"
           transliteration: "jipyereul jandoneuro bakkuda"
           translation: "to exchange notes (paper currency) for coins"
     - def: "to change; to make changes; to modify"
-      examples: 
+      examples:
         - example: "원고의 내용을 많이 바꾸어야겠다."
           transliteration: "Won-goui naeyong-eul mani bakkueoyagetda."
           translation: "[You] will have to make a lot of changes to the manuscript."
@@ -33197,7 +33197,7 @@ to get a blow, to be struck"
   defs:
     - def: "needle, pin"
     - def: "(clock) hand"
-      examples: 
+      examples:
         - example: "시계 바늘"
           transliteration: "sigye baneul"
           translation: "clock hand"
@@ -33301,7 +33301,7 @@ to get a blow, to be struck"
   pos: n
   defs:
     - def: "wind, air, draft"
-      examples: 
+      examples:
         - example: "바람이 많이 분다."
           transliteration: "Barami mani bunda."
           translation: "The wind is blowing hard."
@@ -33370,13 +33370,13 @@ to get a blow, to be struck"
   defs:
     - def: "truly, without lie or deception"
     - def: "straight, without curvature"
-      examples: 
+      examples:
         - example: "내 두 눈을 (똑)바로 쳐다보면서 말해라."
           transliteration: "Nae du nuneul (ttok)baro chyeodabomyeonseo malhaera."
           translation: "Look straight into my two eyes while you are talking."
     - def: "in strict accordance with rules"
     - def: "right now"
-      examples: 
+      examples:
         - example: "지금 바로"
           transliteration: "jigeum baro"
           translation: "right now"
@@ -33413,7 +33413,7 @@ to get a blow, to be struck"
   pos: v
   defs:
     - def: "to hang paper; to stick paper, cloth or the like with adhesive to a surface"
-      examples: 
+      examples:
         - example: "벽지를 벽에 바르다"
           transliteration: "byeokjireul byeoge bareuda"
           translation: "to stick wallpaper on a wall"
@@ -33424,7 +33424,7 @@ to get a blow, to be struck"
           transliteration: "Aideul bang-eul yeppeun byeokjiro ballatda."
           translation: "I papered the children's room with pretty wallpaper."
     - def: "to cover, plaster, cement; to attach to the surface of an object dirt, plaster or some other such substance"
-      examples: 
+      examples:
         - example: "흙을 벽에 바르다"
           transliteration: "heulgeul byeoge bareuda"
           translation: "to plaster the wall with dirt"
@@ -33432,7 +33432,7 @@ to get a blow, to be struck"
           transliteration: "Byeogui gumeong-eul heulgeuro ballatda."
           translation: "I plastered the hole in the wall with dirt."
     - def: "to apply, spread, rub, put on; to rub water, paste, medicine, cosmetics, etc. onto a surface"
-      examples: 
+      examples:
         - example: "상처에 약을 바르다"
           transliteration: "sangcheo-e yageul bareuda"
           translation: "to paint a wound"
@@ -33458,7 +33458,7 @@ to get a blow, to be struck"
   pos: v
   defs:
     - def: "to peel, flay; to remove the skin, shell, or outer layer of something to get to what is inside"
-      examples: 
+      examples:
         - example: "밤을 바르다"
           transliteration: "bameul bareuda"
           translation: "to crack a chestnut"
@@ -33466,7 +33466,7 @@ to get a blow, to be struck"
           transliteration: "ssireul bareuda"
           translation: "to remove a seed"
     - def: "to bone, debone; to remove the meat attached to the bone; to remove fishbones"
-      examples: 
+      examples:
         - example: "생선을 발라 먹다"
           transliteration: "saengseoneul balla meokda"
           translation: "to eat fish after deboning it"
@@ -33480,7 +33480,7 @@ to get a blow, to be struck"
   pos: a
   defs:
     - def: "to be straight, upright, erect; without bends or curvature"
-      examples: 
+      examples:
         - example: "길이 바르다."
           transliteration: "Giri bareuda."
           translation: "The road is straight."
@@ -33500,7 +33500,7 @@ to get a blow, to be struck"
           transliteration: "Jangnong-e ibureul bareuge gae neoeora."
           translation: "to fold and put the bed erect in the wardrobe."
     - def: "to be right; to comply with the social norm in one's words or behavior"
-      examples: 
+      examples:
         - example: "예의가 바르다"
           transliteration: "ye-uiga bareuda"
           translation: "to be polite"
@@ -33520,7 +33520,7 @@ to get a blow, to be struck"
           transliteration: "Geuneun hoesa-eseo gajang insaseong-i bareun saramida."
           translation: "He is the most polite person in the company."
     - def: "to be right, correct, honest, frank; to be consistent with the facts"
-      examples: 
+      examples:
         - example: "역사를 바르게 이해하다"
           transliteration: "yeoksareul bareuge ihaehada"
           translation: "to understand history correctly"
@@ -33528,17 +33528,17 @@ to get a blow, to be struck"
           transliteration: "Sumgiji malgo bareuge daedaphasio."
           translation: "Don't hide (the truth), answer honestly."
     - def: "to be sunshiny; to be sunny or bright"
-      examples: 
+      examples:
         - example: "기르던 잉꼬가 죽자 아이들은 양지가 바른 곳에 묻어 주었다."
           transliteration: "Gireudeon ingkkoga jukja aideureun yangjiga bareun gose mudeo jueotda."
           translation: "When the parrot died, the children buried it in a sunny place."
     - def: ""
-      examples: 
+      examples:
         - example: "정답을 아는 학생들은 바른 손을 들어라."
           transliteration: "Jeongdabeul aneun haksaengdeureun bareun soneul deureora."
           translation: "Raise your right hand if you know the answer."
     - def: ""
-      examples: 
+      examples:
         - example: "그는 바른손잡이이다."
           transliteration: "Geuneun bareunsonjabiida."
           translation: "He is right-handed."
@@ -33549,7 +33549,7 @@ to get a blow, to be struck"
   pos: v
   defs:
     - def: "to overwhelm an opponent completely; to overpower or defeat an opponent"
-      examples: 
+      examples:
         - example: "난 그를 완전히 발랐어."
           transliteration: "Nan geureul wanjeonhi ballasseo."
           translation: "I totally defeated him."
@@ -33563,7 +33563,7 @@ to get a blow, to be struck"
   pos: a
   defs:
     - def: "uncommon, insufficient; rarely encountered"
-      examples: 
+      examples:
         - example: " 1992,  “두만강 (Duman-gang) [Tumen River]”, in  조선말대사전 (Joseonmaldaesajeon) [Dictionary of Korean language]:"
           translation: "사랑채는 동향으로 앉아서 여름에는 해가 발랐다.Sarangchaeneun donghyang-euro anjaseo yeoreumeneun haega ballatda.The building used as a salon is placed in the east and the sun was shining in the summer which is uncommon."
   conj: [바른다, 발라, 발라요, 바릅니다]
@@ -33660,7 +33660,7 @@ to get a blow, to be struck"
   pos: n
   defs:
     - def: "rock, boulder, crag"
-      examples: 
+      examples:
         - example: "큰 바위 얼굴"
           transliteration: "keun bawi eolgul"
           translation: "The Great Stone Face"
@@ -33708,7 +33708,7 @@ to get a blow, to be struck"
   pos: n
   defs:
     - def: "pants, trousers"
-      examples: 
+      examples:
         - example: "바지를 입다"
           transliteration: "bajireul ipda"
           translation: "to wear (to put on) trousers."
@@ -33785,7 +33785,7 @@ to get a blow, to be struck"
   pos: propn
   defs:
     - def: "A  surname​."
-      examples: 
+      examples:
         - example: " c. 1280 AD,  Il-yeon, 일연(一然) (iryeon)),  “기이 권제1(紀異卷第一), 신라시조 혁거세왕(新羅始祖 赫居世王) (gii gwonje1, sillasijo hyeokgeosewang(新羅始祖 赫居世王))”, in  Samguk yusa, 삼국유사(三國遺事) (samgugyusa):"
           translation: "사내는 박〔瓠〕과 같이 생긴 알에서 나왔고, 향인들은 박을 박(朴)이라 이르므로, 그 성을 박으로 하였다.(The boy came from an egg that looked like a gourd, and countrymen named him Bak because gourd was called Bak.)Sanaeneun   bak〔瓠〕gwa gachi saenggin areseo nawatgo, hyang-indeureun bageul bagira ireumeuro, geu seong-eul bageuro hayeotda.(The boy came from an egg that looked like a gourd, and countrymen named him Bak because gourd was called Bak.)(please add an English translation of this quote)"
 
@@ -33855,13 +33855,13 @@ to get a blow, to be struck"
     - def: "to articulate words and letters"
     - def: "to put on a list to make enemy"
     - def: "to linger in one's mind or memory"
-      examples: 
+      examples:
         - example: "(The addition of quotations indicative of this usage is being sought):"
     - def: "to write down what is needed for reporting, decision, instruction, command, etc."
-      examples: 
+      examples:
         - example: "(The addition of quotations indicative of this usage is being sought):"
     - def: "to thrust oars into the water"
-      examples: 
+      examples:
         - example: "(The addition of quotations indicative of this usage is being sought):"
   conj: [박는다, 박아, 박아요, 박습니다]
 
@@ -33929,7 +33929,7 @@ to get a blow, to be struck"
   pos: n
   defs:
     - def: "taxidermy, stuffing"
-      examples: 
+      examples:
         - example: "‘박제가 되어 버린 천재’를 아시오?"
           transliteration: "‘bakjega doeeo beorin cheonjae’reul asio?"
           translation: "Do you know 'a stuffed genius'?"
@@ -33964,7 +33964,7 @@ to get a blow, to be struck"
   pos: n
   defs:
     - def: "mint"
-      examples: 
+      examples:
         - example: "나는 박하사탕 특유의 냄새를 좋아한다."
           transliteration: "Naneun bakhasatang teugyuui naemsaereul joahanda."
           translation: "I like the distinctive smell of mint candy."
@@ -33987,7 +33987,7 @@ to get a blow, to be struck"
   pos: n
   defs:
     - def: "outside"
-      examples: 
+      examples:
         - example: "하늘이는 밖에 나갔어요."
           transliteration: "Haneurineun bakke nagasseoyo."
           translation: "Hanueli went outdoors (into the outside)."
@@ -33997,7 +33997,7 @@ to get a blow, to be struck"
   pos: part
   defs:
     - def: "other than"
-      examples: 
+      examples:
         - example: "우리는 당신밖에 모른다"
           transliteration: "Urineun Dangsinbakke Moreunda"
           translation: "\"We Will Follow You Only\" (lit. \"We Know No One but You\")"
@@ -34015,7 +34015,7 @@ to get a blow, to be struck"
   pos: a
   defs:
     - def: "to be glad, happy; pleasant; welcome"
-      examples: 
+      examples:
         - example: "만나서 반갑습니다."
           transliteration: "Mannaseo ban-gapseumnida."
           translation: "Pleased to meet you."
@@ -34036,7 +34036,7 @@ to get a blow, to be struck"
   pos: n
   defs:
     - def: "half price"
-      examples: 
+      examples:
         - example: "모든 것이 반값입니다."
           transliteration: "Modeun geosi ban-gapsimnida."
           translation: "All are half price."
@@ -34316,7 +34316,7 @@ to get a blow, to be struck"
   pos: n
   defs:
     - def: "finger ring, ring"
-      examples: 
+      examples:
         - example: "반지를 끼다"
           transliteration: "banjireul kkida"
           translation: "put on/wear a ring"
@@ -34332,12 +34332,12 @@ to get a blow, to be struck"
   pos: v
   defs:
     - def: "to glitter, sparkle, twinkle"
-      examples: 
+      examples:
         - example: "보석이 반짝인다."
           transliteration: "Boseogi banjjaginda."
           translation: "Jewels are glittering."
     - def: "to shine"
-      examples: 
+      examples:
         - example: "반짝이는 별빛들."
           transliteration: "Banjjagineun byeolbitdeul."
           translation: "Shining Starlight."
@@ -34384,7 +34384,7 @@ to get a blow, to be struck"
   pos: v
   defs:
     - def: "to receive, take, obtain"
-      examples: 
+      examples:
         - example: "내 생일 선물로 부모님에게서 컴퓨터를 받았다."
           transliteration: "Nae saeng-il seonmullo bumonimegeseo keompyuteoreul badatda."
           translation: "I got a computer from my parents for my birthday."
@@ -34439,7 +34439,7 @@ to get a blow, to be struck"
   pos: n
   defs:
     - def: "foot"
-      examples: 
+      examples:
         - example: "레오나르도 다빈치는 인간의 발이 공학의 걸작이며 예술 작품이라고 말한 적이 있었다."
           transliteration: "Re-onareudo dabinchineun in-ganui bari gonghagui geoljagimyeo yesul jakpumirago malhan jeogi isseotda."
           translation: "Leonardo Da Vinci once said that the human foot is a masterpiece of engineering and a work of art."
@@ -34455,7 +34455,7 @@ to get a blow, to be struck"
   pos: n
   defs:
     - def: "toe"
-      examples: 
+      examples:
         - example: "아기들은 자기 발가락을 빠는 경향이 있다."
           transliteration: "Agideureun jagi balgarageul ppaneun gyeonghyang-i itda."
           translation: "Babies tend to suck on their toes."
@@ -34500,7 +34500,7 @@ to get a blow, to be struck"
   pos: n
   defs:
     - def: "erection"
-      examples: 
+      examples:
         - example: "발기를 하게 되면 음경이 커지고 딱딱하게 된다."
           transliteration: "Balgireul hage doemyeon eumgyeong-i keojigo ttakttakhage doenda."
           translation: "When you get an erection, your penis becomes bigger and harder."
@@ -34540,7 +34540,7 @@ to get a blow, to be struck"
   pos: v
   defs:
     - def: "to develop, to improve"
-      examples: 
+      examples:
         - example: "달리기를 열심히 하면 폐 기능이 쉽게 발달할 수 있다."
           transliteration: "Dalligireul yeolsimhi hamyeon pye gineung-i swipge baldalhal su itda."
           translation: "If (you) run on the tracks well, then (your) lung function can improve easily."
@@ -34713,12 +34713,12 @@ to get a blow, to be struck"
   pos: n
   defs:
     - def: "toenail"
-      examples: 
+      examples:
         - example: "발톱을 깎다"
           transliteration: "baltobeul kkakda"
           translation: "to cut toenail"
     - def: "claw, talon"
-      examples: 
+      examples:
         - example: "짐승의 발톱과 송곳니는 공격용으로 쓰이므로 매우 날카롭다."
           transliteration: "Jimseung-ui baltopgwa songgonnineun gonggyeogyong-euro sseu-imeuro mae-u nalkaropda."
           translation: "Claws and cuspids of beasts are very sharp as they are used in attacks."
@@ -34728,7 +34728,7 @@ to get a blow, to be struck"
   pos: n
   defs:
     - def: "presentation; exhibition; announcement; release; roll out"
-      examples: 
+      examples:
         - example: "콜리 박사의 발표는 너무 길었다."
           transliteration: "Kolli baksaui balpyoneun neomu gireotda."
           translation: "Dr. Cawley's presentation took too long."
@@ -34832,7 +34832,7 @@ to get a blow, to be struck"
   pos: v
   defs:
     - def: "to step, tread, trample"
-      examples: 
+      examples:
         - example: "밤길을 걷다가 쇠똥이라도 밟으면 그 물컹한 느낌이 싫었다."
           transliteration: "Bamgireul geotdaga soettong-irado babeumyeon geu mulkeonghan neukkimi sireotda."
           translation: "While I was walking at night, the squashy feeling of stepping on even cow dung would make me nauseous."
@@ -34843,7 +34843,7 @@ to get a blow, to be struck"
   pos: n
   defs:
     - def: "night, evening"
-      examples: 
+      examples:
         - example: "한국전쟁때 북한은 사람들이 밤에 잠을 잔다는 것을 역이용해 새벽에 급습하였다."
           transliteration: "Han-gukjeonjaengttae bukhaneun saramdeuri bame jameul jandaneun geoseul yeogiyonghae saebyeoge geupseuphayeotda."
           translation: "During the Korean war, North Korea attacked South Korea at dawn, taking advantage of the fact that people sleep at night."
@@ -34908,7 +34908,7 @@ to get a blow, to be struck"
   defs:
     - def: "cooked rice, sometimes mixed with some minor cereal such as barley"
     - def: "food, meal"
-      examples: 
+      examples:
         - example: "밥을 먹다"
           transliteration: "babeul meokda"
           translation: "to have a meal"
@@ -35010,7 +35010,7 @@ to get a blow, to be struck"
   pos: n
   defs:
     - def: "fart, wind"
-      examples: 
+      examples:
         - example: "방귀를 뀌다"
           transliteration: "banggwireul kkwida"
           translation: "to pass gas"
@@ -35033,7 +35033,7 @@ to get a blow, to be struck"
   pos: adv
   defs:
     - def: "just a moment ago; just now"
-      examples: 
+      examples:
         - example: "방금 왔어요."
           transliteration: " Banggeum wasseoyo."
           translation: "[He] arrived just a moment ago."
@@ -35074,7 +35074,7 @@ to get a blow, to be struck"
   pos: v
   defs:
     - def: "to visit"
-      examples: 
+      examples:
         - example: "우리는 그 병원의 아동 병동에 있는 그들을 방문하였다."
           transliteration: "Urineun geu byeong-wonui adong byeongdong-e inneun geudeureul bangmunhayeotda."
           translation: "We visited them in the hospital's children's ward."
@@ -35217,7 +35217,7 @@ to get a blow, to be struck"
   pos: n
   defs:
     - def: "drop"
-      examples: 
+      examples:
         - example: "물방울"
           transliteration: "mulbang-ul"
           translation: "water drop"
@@ -35232,7 +35232,7 @@ to get a blow, to be struck"
   pos: propn
   defs:
     - def: "national guard, defense force."
-      examples: 
+      examples:
         - example: "남아프리카 방위군"
           transliteration: "namapeurika bang-wigun"
           translation: "South African Defense Force."
@@ -35298,7 +35298,7 @@ to get a blow, to be struck"
   pos: n
   defs:
     - def: "being bulletproof"
-      examples: 
+      examples:
         - example: "방탄유리"
           transliteration: "bangtanyuri"
           translation: "bulletproof glass"
@@ -35334,7 +35334,7 @@ to get a blow, to be struck"
   pos: n
   defs:
     - def: "direction, orientation"
-      examples: 
+      examples:
         - example: "바람이 불어오고 있는 방향을 향해서"
           transliteration: "barami bureoogo inneun banghyang-eul hyanghaeseo"
           translation: "towards the direction from which the wind is blowing"
@@ -35432,7 +35432,7 @@ to get a blow, to be struck"
   pos: n
   defs:
     - def: "volleyball"
-      examples: 
+      examples:
         - example: "배구하다"
           transliteration: "baeguhada"
           translation: "to play volleyball"
@@ -35469,12 +35469,12 @@ to get a blow, to be struck"
   pos: v
   defs:
     - def: "to soak into; to penetrate"
-      examples: 
+      examples:
         - example: "셔츠에 땀이 배어 있다."
           transliteration: "Syeocheue ttami baeeo itda."
           translation: "My shirt is soaked through with perspiration."
     - def: "to get used to, to get accustomed to"
-      examples: 
+      examples:
         - example: "그의 근면함은 이미 어린 시절부터 몸에 밴 것이다."
           transliteration: "Geuui geunmyeonhameun imi eorin sijeolbuteo mome baen geosida."
           translation: "His diligence is a habit he had acquired since he was young."
@@ -35485,7 +35485,7 @@ to get a blow, to be struck"
   pos: v
   defs:
     - def: "to conceive; to be pregnant (with a child)"
-      examples: 
+      examples:
         - example: "그 여자는 아이를 뱄다."
           transliteration: "Geu yeojaneun aireul baetda."
           translation: "The woman is pregnant."
@@ -35604,7 +35604,7 @@ to get a blow, to be struck"
   pos: v
   defs:
     - def: "to learn"
-      examples: 
+      examples:
         - example: "매일 저는 이 도시에 대해서 더 많이 배우고 있어요."
           transliteration: "Maeil jeoneun i dosie daehaeseo deo mani bae-ugo isseoyo."
           translation: "Every day I learn more about this great city."
@@ -35641,7 +35641,7 @@ to get a blow, to be struck"
   pos: n
   defs:
     - def: "battery (device to store electricity)"
-      examples: 
+      examples:
         - example: "라디오의 배터리를 바꾸다"
           transliteration: "radioui baeteorireul bakkuda"
           translation: "to change the radio battery"
@@ -36097,7 +36097,7 @@ to get a blow, to be struck"
   pos: n
   defs:
     - def: "bus"
-      examples: 
+      examples:
         - example: "버스가 온다."
           transliteration: "Beoseuga onda."
           translation: "Here comes the bus."
@@ -36205,7 +36205,7 @@ to get a blow, to be struck"
   pos: n
   defs:
     - def: "(flash of) lightning, thunderbolt"
-      examples: 
+      examples:
         - example: "번개가 쳤다."
           transliteration: "Beon-gaega chyeotda."
           translation: "There was a flash of lightning."
@@ -36260,7 +36260,7 @@ to get a blow, to be struck"
   pos: n
   defs:
     - def: "number"
-      examples: 
+      examples:
         - example: "전화 번호"
           transliteration: "jeonhwa beonho"
           translation: "phone number"
@@ -36271,7 +36271,7 @@ to get a blow, to be struck"
   defs:
     - def: "field, plain (open area of land)"
     - def: "a set of clothes"
-      examples: 
+      examples:
         - example: "한복 한 벌을."
           transliteration: "Hanbok han beoreul."
           translation: "A set of hanbok."
@@ -36287,7 +36287,7 @@ to get a blow, to be struck"
   pos: n
   defs:
     - def: "bee; wasp; hornet"
-      examples: 
+      examples:
         - example: "벌에 쏘이다"
           transliteration: "beore ssoida"
           translation: "to be stung by a bee"
@@ -36489,7 +36489,7 @@ to get a blow, to be struck"
   pos: n
   defs:
     - def: "law"
-      examples: 
+      examples:
         - example: "독재자는 법도 제 마음대로 수정할 수 있다."
           transliteration: "Dokjaejaneun beopdo je ma-eumdaero sujeonghal su itda."
           translation: "A dictator can modify the law at will."
@@ -36501,7 +36501,7 @@ to get a blow, to be struck"
   pos: suf
   defs:
     - def: "way; method of doing something"
-      examples: 
+      examples:
         - example: "기초 사용법"
           transliteration: "gicho sayongbeop"
           translation: "basic usage"
@@ -36594,7 +36594,7 @@ to get a blow, to be struck"
   pos: n
   defs:
     - def: "mute, speech-impaired person"
-      examples: 
+      examples:
         - example: "벙어리 냉가슴 앓듯."
           transliteration: "Beong-eori naenggaseum alteut."
           translation: "As if suffering in mute silence."
@@ -36622,7 +36622,7 @@ to get a blow, to be struck"
   pos: n
   defs:
     - def: "pillow"
-      examples: 
+      examples:
         - example: "그리고 그것은 베개야."
           transliteration: "Geurigo geugeoseun begaeya."
           translation: "And it is a pillow!"
@@ -36903,7 +36903,7 @@ to get a blow, to be struck"
   pos: n
   defs:
     - def: "wall"
-      examples: 
+      examples:
         - example: "벽을 세우다"
           transliteration: "byeogeul se-uda"
           translation: "erect a wall"
@@ -36926,7 +36926,7 @@ to get a blow, to be struck"
   pos: n
   defs:
     - def: "habit, eccentricity, idiosyncrasy"
-      examples: 
+      examples:
         - example: "내 상사는 화가 나면 무엇이든 집어던지는 벽이 있다."
           transliteration: "Nae sangsaneun hwaga namyeon mueosideun jibeodeonjineun byeogi itda."
           translation: "My boss has the habit of throwing everything when angry."
@@ -37054,7 +37054,7 @@ to get a blow, to be struck"
   pos: n
   defs:
     - def: "star"
-      examples: 
+      examples:
         - example: "하늘에 별따기"
           transliteration: "haneure byeolttagi"
           translation: "(figurative, literally meaning \"picking a star in the sky\") impossibility"
@@ -37083,17 +37083,17 @@ to get a blow, to be struck"
   pos: adv
   defs:
     - def: "very (in a negative context)"
-      examples: 
+      examples:
         - example: "별로 많이 기다리지 않았어요."
           transliteration: " Byeollo mani gidariji anasseoyo."
           translation: "[I] have not been waiting very long."
     - def: "not really (sometimes used with a negative)"
-      examples: 
+      examples:
         - example: "별로 많지 않아요."
           transliteration: " Byeollo manchi anayo."
           translation: "There is really not a lot."
     - def: "not matching"
-      examples: 
+      examples:
         - example: "Person 1: 이거 어때? Person 2:별로."
           transliteration: "Person 1: igeo eottae? Person 2: Byeollo."
           translation: "Person 1: How is this? Person 2: It doesn't really match."
@@ -37146,7 +37146,7 @@ to get a blow, to be struck"
   pos: n
   defs:
     - def: "an unusual event"
-      examples: 
+      examples:
         - example: "별일 없으셨어요."
           translation: "Byeol-il eops-eusyeot-eoyo."
 
@@ -37175,7 +37175,7 @@ to get a blow, to be struck"
   pos: n
   defs:
     - def: "bottle"
-      examples: 
+      examples:
         - example: "병이 깨지다."
           transliteration: "Byeong-i kkaejida."
           translation: "The bottle breaks."
@@ -37333,7 +37333,7 @@ to get a blow, to be struck"
   pos: n
   defs:
     - def: "spread, diffusion, spreading"
-      examples: 
+      examples:
         - example: "초고속 인터넷의 보급"
           transliteration: "chogosok inteonesui bogeup"
           translation: "the spread of high-speed internet"
@@ -37353,12 +37353,12 @@ to get a blow, to be struck"
   pos: v
   defs:
     - def: "to send, to dispatch"
-      examples: 
+      examples:
         - example: "우편을 외국으로 보내다."
           transliteration: "Upyeoneul oegugeuro bonaeda."
           translation: "To send mail to a foreign country."
     - def: "to spend time"
-      examples: 
+      examples:
         - example: "즐거운 시간을 보내세요."
           transliteration: "Jeulgeoun siganeul bonaeseyo."
           translation: "Have a nice time!"
@@ -37387,7 +37387,7 @@ to get a blow, to be struck"
   pos: v
   defs:
     - def: "to see, look at 그들은 여러가지 화초를 보고 있다."
-      examples: 
+      examples:
         - example: "그들은 여러가지 화초를 보고 있다."
           transliteration: "Geudeureun yeoreogaji hwachoreul bogo itda."
           translation: "They are looking at various plants."
@@ -37395,26 +37395,26 @@ to get a blow, to be struck"
           transliteration: "Seoyang-indeureun boneun geoseul mae-u jung-yosihaeseo silmyeong-eun got jugeumgwa machan-gajiin geoseuro saenggakhaetdago handa."
           translation: "Westerners are said to have placed great importance on seeing and thought that being blind was like death."
     - def: "to look after (a baby, child, house, etc.)"
-      examples: 
+      examples:
         - example: "아이를 보다"
           transliteration: "aireul boda"
           translation: "to look after a child"
     - def: "to watch (a film, TV, etc.)"
-      examples: 
+      examples:
         - example: "영화를 보다"
           transliteration: "yeonghwareul boda"
           translation: "to watch a film"
     - def: "to read (a book, newspaper, etc.)"
     - def: "to examine (a document, patient, disorder, etc.)"
     - def: "to take (an examination)"
-      examples: 
+      examples:
         - example: "시험을 잘 보면 좋겠습니다."
           transliteration: "Siheomeul jal bomyeon joketseumnida."
           translation: "I hope to do well on the test. (literally: It will be good if I take the test well.)"
     - def: "to experience (a profit, loss, etc.)"
     - def: "to relieve oneself"
     - def: "to try something; requires a main verb with \"-아/어\" suffix or use attributively with \"적\"."
-      examples: 
+      examples:
         - example: "한번 생각해 볼게요."
           transliteration: "Hanbeon saenggakhae bolgeyo."
           translation: "I will consider it. (Literally, \"I will try thinking about it.\")"
@@ -37486,7 +37486,7 @@ to get a blow, to be struck"
   pos: n
   defs:
     - def: "a bundle, a package"
-      examples: 
+      examples:
         - example: "보따리를 싸다"
           transliteration: "bottarireul ssada"
           translation: "to bundle; to make into a bundle"
@@ -37502,7 +37502,7 @@ to get a blow, to be struck"
   pos: n
   defs:
     - def: "fruitfulness, usefulness (state being of worthy for an action)"
-      examples: 
+      examples:
         - example: "보람이 있다"
           transliteration: "borami itda"
           translation: "to be worthwhile, to be fruitful"
@@ -37555,31 +37555,31 @@ to get a blow, to be struck"
   pos: v
   defs:
     - def: "to see, look at 그들은 여러가지 화초를 보고 있다."
-      examples: 
+      examples:
         - example: "그들은 여러가지 화초를 보고 있다."
           transliteration: "Geudeureun yeoreogaji hwachoreul bogo itda."
           translation: "They are looking at various plants."
     - def: "to look after (a baby, child, house, etc.)"
-      examples: 
+      examples:
         - example: "아이를 보다"
           transliteration: "aireul boda"
           translation: "to look after a child"
     - def: "to watch (a film, TV, etc.)"
-      examples: 
+      examples:
         - example: "영화를 보다"
           transliteration: "yeonghwareul boda"
           translation: "to watch a film"
     - def: "to read (a book, newspaper, etc.)"
     - def: "to examine (a document, patient, disorder, etc.)"
     - def: "to take (an examination)"
-      examples: 
+      examples:
         - example: "시험을 잘 보면 좋겠습니다."
           transliteration: "Siheomeul jal bomyeon joketseumnida."
           translation: "I hope to do well on the test. (literally: It will be good if I take the test well.)"
     - def: "to experience (a profit, loss, etc.)"
     - def: "to relieve oneself"
     - def: "to try something; requires a main verb with \"-아/어\" suffix or use attributively with \"적\"."
-      examples: 
+      examples:
         - example: "한번 생각해 볼게요."
           transliteration: "Hanbeon saenggakhae bolgeyo."
           translation: "I will consider it. (Literally, \"I will try thinking about it.\")"
@@ -37703,7 +37703,7 @@ to get a blow, to be struck"
   defs:
     - def: "to be seen, to be shown"
     - def: "to show, to cause to see"
-      examples: 
+      examples:
         - example: "《지구물리학 연구 잡지》의 올해 보고서는 빙하의 크기가 60퍼센트 감소하였음을 보여 주었다."
           transliteration: "《jigumullihak yeon-gu japji》ui olhae bogoseoneun binghaui keugiga 60peosenteu gamsohayeosseumeul boyeo jueotda."
           translation: "A report this year in the Journal of Geophysical Research showed that the glacier has lost 60 percent of its mass."
@@ -37736,7 +37736,7 @@ to get a blow, to be struck"
   pos: a
   defs:
     - def: "to be worthless, valueless, useless"
-      examples: 
+      examples:
         - example: "보잘것없지만 제 감사의 표시로 받아 주십시오."
           transliteration: "Bojalgeoseopjiman je gamsaui pyosiro bada jusipsio."
           translation: "This is not much but please accept it as a token of my gratitude."
@@ -37765,7 +37765,7 @@ to get a blow, to be struck"
   pos: n
   defs:
     - def: "dimple"
-      examples: 
+      examples:
         - example: "웃으면 보조개가 진다 (usEumyeon bojogae-ga jinda) Dimples appear when [she] smiles."
 
 - word: 보조사
@@ -37825,7 +37825,7 @@ to get a blow, to be struck"
   pos: n
   defs:
     - def: "normality"
-      examples: 
+      examples:
         - example: "보통 명사"
           transliteration: "botong myeongsa"
           translation: "common noun"
@@ -37893,7 +37893,7 @@ to get a blow, to be struck"
   defs:
     - def: "fortune, blessing, luck"
     - def: "a figurative word for a large share of something to be allotted"
-      examples: 
+      examples:
         - example: "당신은 돈복이 많군요."
           transliteration: "Dangsineun donbogi mankunyo."
           translation: "you are blessed with money and fortune."
@@ -37924,7 +37924,7 @@ to get a blow, to be struck"
   pos: n
   defs:
     - def: "lottery (ticket)"
-      examples: 
+      examples:
         - example: "복권에 당첨되다"
           transliteration: "bokgwone dangcheomdoeda"
           translation: "win the lottery"
@@ -37946,7 +37946,7 @@ to get a blow, to be struck"
   pos: n
   defs:
     - def: "welfare; well-being"
-      examples: 
+      examples:
         - example: "복리 후생 제도"
           transliteration: "bongni husaeng jedo"
           translation: "benefits package"
@@ -38152,7 +38152,7 @@ to get a blow, to be struck"
   pos: n
   defs:
     - def: "main, primary, principle"
-      examples: 
+      examples:
         - example: "본 회관"
           transliteration: "bon hoegwan"
           translation: "main place of meeting"
@@ -38163,7 +38163,7 @@ to get a blow, to be struck"
   pos: n
   defs:
     - def: "principal"
-      examples: 
+      examples:
         - example: "본전 (bonjeon)(本錢) principal, original amount of your money"
 
 - word: 본
@@ -38183,7 +38183,7 @@ to get a blow, to be struck"
   pos: det
   defs:
     - def: "attributive formal of 보다 (boda)"
-      examples: 
+      examples:
         - example: "한국에 가 본 적있어요?"
           transliteration: "Han-guge ga bon jeogisseoyo?"
           translation: "Have you ever been to (South) Korea?"
@@ -38581,7 +38581,7 @@ to get a blow, to be struck"
   pos: n
   defs:
     - def: "real estate"
-      examples: 
+      examples:
         - example: "부동산은 대체 투자의 범주에 들어간다."
           transliteration: "Budongsaneun daeche tujaui beomjue deureoganda."
           translation: "Real estate falls into the category of alternative investment."
@@ -38674,7 +38674,7 @@ to get a blow, to be struck"
   pos: a
   defs:
     - def: "to be greatly satisfied, having nothing to envy"
-      examples: 
+      examples:
         - example: "세상에 부럼없어라"
           transliteration: "sesang-e bureomeopseora"
           translation: "We Have Nothing to Envy in the World "
@@ -38709,17 +38709,17 @@ to get a blow, to be struck"
   pos: v
   defs:
     - def: "To call, name"
-      examples: 
+      examples:
         - example: "제가 당신의 상사, 케이시 위버입니다. 그렇지만, 그저 저를 케이시라고 불러주세요. ― 감사합니다. 위버 님. ― 그저 케이시요. ― 네. 위버 님. ― 그럼, 알겠어요."
           transliteration: "Jega dangsinui sangsa, keisi wibeoimnida. Geureochiman, geujeo jeoreul keisirago bulleojuseyo. ― gamsahamnida. Wibeo nim. ― geujeo keisiyo. ― ne. Wibeo nim. ― geureom, algesseoyo."
           translation: "I am your boss, Caty Weaver. But, please call me Caty. ― Thank you, Ms. Weaver. ― Just Caty. ― Sure thing, Ms. Weaver. ― Okay then."
     - def: "To bid, offer (price)"
-      examples: 
+      examples:
         - example: "부르는 게 값"
           transliteration: "bureuneun ge gap"
           translation: "Whatever is offered is the price. (as when supply of goods is extremely limited)"
     - def: "To cry, shout, yell"
-      examples: 
+      examples:
         - example: "난 그녀의 이름을 불렀다."
           transliteration: "Nan geunyeoui ireumeul bulleotda."
           translation: "I called out her name."
@@ -38740,7 +38740,7 @@ to get a blow, to be struck"
   pos: n
   defs:
     - def: "God's calling, a divine summons"
-      examples: 
+      examples:
         - example: "부르심을 받다 (bureusimeul batda)"
           translation: "be summoned"
 
@@ -38784,7 +38784,7 @@ to get a blow, to be struck"
   defs:
     - def: "a beak"
     - def: "a pointed end like a beak or a tip"
-      examples: 
+      examples:
         - example: "총부리"
           transliteration: "chongburi"
           translation: "muzzle of a gun"
@@ -38820,7 +38820,7 @@ to get a blow, to be struck"
   pos: n
   defs:
     - def: "parents"
-      examples: 
+      examples:
         - example: "부모님은 어디 계세요?"
           transliteration: "Bumonimeun eodi gyeseyo?"
           translation: "Where do your parents live (lit.: are staying)?"
@@ -38861,7 +38861,7 @@ to get a blow, to be struck"
   pos: propn
   defs:
     - def: "Busan (a city in South Korea)"
-      examples: 
+      examples:
         - example: "부산 광역시"
           transliteration: "Busan gwang-yeoksi"
           translation: "Busan Metropolitan City"
@@ -38871,7 +38871,7 @@ to get a blow, to be struck"
   pos: n
   defs:
     - def: "injury; wound"
-      examples: 
+      examples:
         - example: "우리는 누구도 부상당하는 걸 원치 않습니다."
           transliteration: "Urineun nugudo busangdanghaneun geol wonchi anseumnida."
           translation: "We don't want anyone to injure themselves."
@@ -38970,7 +38970,7 @@ to get a blow, to be struck"
   pos: v
   defs:
     - def: "to grant; give ; accord"
-      examples: 
+      examples:
         - example: "난민은 [...] 공업소유권의 보호[...]에 관하여, 상거소를 가지는 국가에서 그 국가의 국민에게 부여되는 보호와 동일한 보호를 부여받는다."
           transliteration: "Nanmineun [...] gong-eopsoyugwonui boho[...]e gwanhayeo, sanggeosoreul gajineun gukga-eseo geu gukgaui gungminege buyeodoeneun bohowa dong-ilhan bohoreul buyeobanneunda."
           translation: "In respect of the protection of industrial property, […] a refugee shall be accorded in the country in which he has his habitual residence the same protection as is accorded to nationals of that country."
@@ -39110,7 +39110,7 @@ to get a blow, to be struck"
   pos: n
   defs:
     - def: "negation"
-      examples: 
+      examples:
         - example: "이중 부정"
           transliteration: "ijung bujeong"
           translation: "double negative"
@@ -39270,7 +39270,7 @@ to get a blow, to be struck"
   pos: n
   defs:
     - def: "request; favor"
-      examples: 
+      examples:
         - example: "부탁이 있는데요."
           transliteration: "Butagi inneundeyo."
           translation: "I have a favor to ask. (Literally, \"A favor exists (in my experience).\")"
@@ -39280,7 +39280,7 @@ to get a blow, to be struck"
   pos: v
   defs:
     - def: "to ask to do well, to ask to handle well"
-      examples: 
+      examples:
         - example: "간곡히 부탁하다"
           transliteration: "gan-gokhi butakhada"
           translation: "to plead with"
@@ -39330,7 +39330,7 @@ to get a blow, to be struck"
   defs:
     - def: "Used to show when or where an action or situation started.
 Used to illustrate the time that a certain action or situation began or will begin: (start) from; (start) at"
-      examples: 
+      examples:
         - example: "나는 한 시부터 늦게까지 공부했어요."
           transliteration: "Naneun han sibuteo neutgekkaji gongbuhaesseoyo."
           translation: "I studied (starting) from one o’clock until late."
@@ -39350,12 +39350,12 @@ Used to illustrate the time that a certain action or situation began or will beg
           transliteration: "Hal iri manaseo mueotbuteo haeya halji moreugesseoyo."
           translation: "I have so much work, I do not know where to start from."
     - def: "Used to illustrate the time that a certain action or situation began or will begin: (start) from; (start) at"
-      examples: 
+      examples:
         - example: "나는 한 시부터 늦게까지 공부했어요."
           transliteration: "Naneun han sibuteo neutgekkaji gongbuhaesseoyo."
           translation: "I studied (starting) from one o’clock until late."
     - def: "Used to illustrate the place that a certain action began or will begin: from. Can be used after 에서 (eseo) 로 (ro) also together meaning \"from\"."
-      examples: 
+      examples:
         - example: "시험은 범위가 15 (십오)쪽부터 56 (오십육)쪽까지예요."
           transliteration: "Siheomeun beomwiga 15 (sibo)jjokbuteo 56 (osibyuk)jjokkkajiyeyo."
           translation: "Speaking of the test, it covers from page 15 to page 56."
@@ -39363,7 +39363,7 @@ Used to illustrate the time that a certain action or situation began or will beg
           transliteration: "Maeriga Busaneseobuteo yeolchareul tasseoyo."
           translation: "Mary rode the train (starting) from Busan."
     - def: "Used to illustrate an order of a series of actions."
-      examples: 
+      examples:
         - example: "손부터 씻고 먹어요."
           transliteration: "Sonbuteo ssitgo meogeoyo."
           translation: "Wash your hands before you eat."
@@ -39745,7 +39745,7 @@ Used to illustrate the time that a certain action or situation began or will beg
   pos: n
   defs:
     - def: "watershed; divide"
-      examples: 
+      examples:
         - example: "그 팀은 시내를 건너고 빙하의 깊고 좁은 분수령을 뛰어 넘었다."
           transliteration: "Geu timeun sinaereul geonneogo binghaui gipgo jobeun bunsuryeong-eul ttwieo neomeotda."
           translation: "The team crossed streams and jumped across deep, narrow divides in the glacier."
@@ -39780,7 +39780,7 @@ Used to illustrate the time that a certain action or situation began or will beg
     - def: "molecule"
     - def: "numerator"
     - def: "element, faction"
-      examples: 
+      examples:
         - example: "당내의 반동 분자를 일소해야 한다."
           transliteration: "Dangnae-ui bandong bunjareul ilsohaeya handa."
           translation: "We must cleanse the party of its reactionary element."
@@ -39855,7 +39855,7 @@ Used to illustrate the time that a certain action or situation began or will beg
   defs:
     - def: "fire, flame"
     - def: "light"
-      examples: 
+      examples:
         - example: "스튜디오의 불이 켜진 때에는 내가 저녁 프로그램을 녹음하고 있다는 거야."
           transliteration: "Seutyudioui buri kyeojin ttaeeneun naega jeonyeok peurogeuraemeul nogeumhago itdaneun geoya."
           translation: "When the studio light is on, I am recording my evening show."
@@ -40014,7 +40014,7 @@ Used to illustrate the time that a certain action or situation began or will beg
   pos: v
   defs:
     - def: "to castrate an animal"
-      examples: 
+      examples:
         - example: "불깐 말"
           transliteration: "bulkkan mal"
           translation: "castrated horse"
@@ -40106,7 +40106,7 @@ Used to illustrate the time that a certain action or situation began or will beg
   pos: n
   defs:
     - def: "dissatisfaction; discontent"
-      examples: 
+      examples:
         - example: "우리는 화장품에 관한 모든 불만을 처리할 것이다."
           transliteration: "Urineun hwajangpume gwanhan modeun bulmaneul cheorihal geosida."
           translation: "We will take care of all the complaint regarding cosmetic products."
@@ -40134,7 +40134,7 @@ Used to illustrate the time that a certain action or situation began or will beg
   pos: n
   defs:
     - def: "light, beam"
-      examples: 
+      examples:
         - example: "도시의 불빛"
           transliteration: "dosiui bulbit"
           translation: "city lights"
@@ -40144,7 +40144,7 @@ Used to illustrate the time that a certain action or situation began or will beg
   pos: n
   defs:
     - def: "phoenix"
-      examples: 
+      examples:
         - example: "충실한 친구는 불사조와 같다."
           transliteration: "Chungsilhan chin-guneun bulsajowa gatda."
           translation: "Faithful friend is like a phoenix."
@@ -40200,7 +40200,7 @@ Used to illustrate the time that a certain action or situation began or will beg
   pos: n
   defs:
     - def: "French (language)"
-      examples: 
+      examples:
         - example: "불어 사전"
           transliteration: "bureo sajeon"
           translation: "a French dictionary"
@@ -40232,7 +40232,7 @@ Used to illustrate the time that a certain action or situation began or will beg
   pos: v
   defs:
     - def: "to castrate an animal"
-      examples: 
+      examples:
         - example: "불친 말"
           transliteration: "bulchin mal"
           translation: "castrated horse"
@@ -40366,7 +40366,7 @@ Used to illustrate the time that a certain action or situation began or will beg
   pos: v
   defs:
     - def: "to blush, to turn red"
-      examples: 
+      examples:
         - example: "얼굴을 붉히다"
           transliteration: "eolgureul bulkida"
           translation: "to blush"
@@ -40383,7 +40383,7 @@ Used to illustrate the time that a certain action or situation began or will beg
   pos: v
   defs:
     - def: "to pour"
-      examples: 
+      examples:
         - example: "Larry는 신의 축복을 받기 위해 신탁에 가 빈 그릇에 와인잔을 부었다."
           transliteration: "Larryneun sinui chukbogeul batgi wihae sintage ga bin geureuse wainjaneul bueotda."
           translation: "Larry went to the oracle and poured a glass of wine into empty vessel to receive God's blessing."
@@ -40438,13 +40438,13 @@ Used to illustrate the time that a certain action or situation began or will beg
   defs:
     - def: "to stick to, adhere to, cling to"
     - def: "to pass the exam or test"
-      examples: 
+      examples:
         - example: "시험에 붙다."
           transliteration: "Siheome butda."
           translation: "To pass the test."
     - def: "to be near"
     - def: "to catch fire"
-      examples: 
+      examples:
         - example: "담배에 불을 붙이다."
           transliteration: "Dambaee bureul buchida."
           translation: "to light a cigarette"
@@ -40452,7 +40452,7 @@ Used to illustrate the time that a certain action or situation began or will beg
     - def: "to be named after"
     - def: "to gain, gather"
     - def: "to be charged, earn"
-      examples: 
+      examples:
         - example: "3개월동안 연체했더니 이자가 붙었다."
           transliteration: "3gaewoldong-an yeonchehaetdeoni ijaga buteotda."
           translation: "charged interest on three-month late payment."
@@ -40464,7 +40464,7 @@ Used to illustrate the time that a certain action or situation began or will beg
   pos: v
   defs:
     - def: "to affix or attach; to stick"
-      examples: 
+      examples:
         - example: "사탕알이 막대기로부터 분리되서 내가 다시 붙여줬다."
           transliteration: "Satang-ari makdaegirobuteo bullidoeseo naega dasi butyeojwotda."
           translation: "The candy eggs were separated from the stick, so I put them back on."
@@ -40638,7 +40638,7 @@ Used to illustrate the time that a certain action or situation began or will beg
   pos: n
   defs:
     - def: "briefing (a short and concise summary of a situation)"
-      examples: 
+      examples:
         - example: "기자회견장에 들어가기 전에 대통령은 그 상황에 대한 브리핑을 받았다."
           transliteration: "Gijahoegyeonjang-e deureogagi jeone daetongnyeong-eun geu sanghwang-e daehan beuriping-eul badatda."
           translation: "The president received a briefing on the situation before going to the press conference."
@@ -40704,7 +40704,7 @@ Used to illustrate the time that a certain action or situation began or will beg
   pos: n
   defs:
     - def: "rain"
-      examples: 
+      examples:
         - example: "밖에 비가 와요."
           transliteration: "Bakke biga wayo."
           translation: "Outside, rain is falling."
@@ -40730,7 +40730,7 @@ Used to illustrate the time that a certain action or situation began or will beg
   pos: n
   defs:
     - def: "note"
-      examples: 
+      examples:
         - example: "비고를 참조하시오."
           transliteration: "Bigoreul chamjohasio."
           translation: "Refer to the notes."
@@ -40965,7 +40965,7 @@ Used to illustrate the time that a certain action or situation began or will beg
   pos: n
   defs:
     - def: "fertilizer"
-      examples: 
+      examples:
         - example: "비료는 얼마나 자주 줬어?"
           transliteration: "Biryoneun eolmana jaju jwosseo?"
           translation: "How often did you fertilize it?"
@@ -41211,7 +41211,7 @@ Used to illustrate the time that a certain action or situation began or will beg
   pos: n
   defs:
     - def: "visa (travel permit)"
-      examples: 
+      examples:
         - example: "비자를 받다"
           transliteration: "bijareul batda"
           translation: "to receive/get a visa"
@@ -41267,7 +41267,7 @@ Used to illustrate the time that a certain action or situation began or will beg
   pos: v
   defs:
     - def: "step aside; step back"
-      examples: 
+      examples:
         - example: "길을 비켜 주세요."
           transliteration: "Gireul bikyeo juseyo."
           translation: "Please make your way."
@@ -41347,7 +41347,7 @@ Used to illustrate the time that a certain action or situation began or will beg
   pos: n
   defs:
     - def: "a critic; reviewer"
-      examples: 
+      examples:
         - example: "비평가들은 잊어라."
           transliteration: "Bipyeonggadeureun ijeora."
           translation: "Forget the critics."
@@ -41370,7 +41370,7 @@ Used to illustrate the time that a certain action or situation began or will beg
   pos: n
   defs:
     - def: "flight"
-      examples: 
+      examples:
         - example: "저는 12(십이)월 20(이십)일에 파리로 가는 비행편에 자리를 하나 예약했어요."
           transliteration: "Jeoneun 12(sibi)wol 20(isip)ire pariro ganeun bihaengpyeone jarireul hana yeyakhaesseoyo."
           translation: "I reserved a seat on the flight to Paris on December 20th."
@@ -41386,7 +41386,7 @@ Used to illustrate the time that a certain action or situation began or will beg
   pos: n
   defs:
     - def: "flight data recorder"
-      examples: 
+      examples:
         - example: "그 공무원은 비행기록장치가 복원되었다고 말한다."
           transliteration: "Geu gongmuwoneun bihaenggirokjangchiga bogwondoeeotdago malhanda."
           translation: "The official says the flight data recorders have been recovered."
@@ -41551,7 +41551,7 @@ Used to illustrate the time that a certain action or situation began or will beg
   pos: n
   defs:
     - def: "broom"
-      examples: 
+      examples:
         - example: "그는 바닥을 가로질러 빗자루를 밀고 있다."
           transliteration: "Geuneun badageul garojilleo bitjarureul milgo itda."
           translation: "He's pushing a broom across the floor."
@@ -41591,7 +41591,7 @@ Used to illustrate the time that a certain action or situation began or will beg
   pos: n
   defs:
     - def: "glacier"
-      examples: 
+      examples:
         - example: "왕시진은 빙하 전문가이자 위롱 설산 빙하 및 환경 감시 연구소의 이사이다."
           transliteration: "Wangsijineun bingha jeonmun-gaija wirong seolsan bingha mit hwan-gyeong gamsi yeon-gusoui isaida."
           translation: "Wang Shijin is a glacier expert and director of the Yulong Snow Mountain Glacial and Environmental Observation Research Station."
@@ -41616,7 +41616,7 @@ Used to illustrate the time that a certain action or situation began or will beg
   pos: n
   defs:
     - def: "light, gleam, glow, gloss, glaze"
-      examples: 
+      examples:
         - example: "불빛이 너무 강렬해서 눈이 부시다."
           transliteration: "Bulbichi neomu gangnyeolhaeseo nuni busida."
           translation: "The light is so bright that my eyes dazzle."
@@ -41634,7 +41634,7 @@ Used to illustrate the time that a certain action or situation began or will beg
   pos: v
   defs:
     - def: "To shine."
-      examples: 
+      examples:
         - example: "너의 눈이 달빛 밑에 빛나."
           transliteration: "Neoui nuni dalbit mite binna."
           translation: "Your eyes are shining underneath the moonlight"
@@ -41646,7 +41646,7 @@ Used to illustrate the time that a certain action or situation began or will beg
   defs:
     - def: "to make (something) shine"
     - def: "to give lustre to, to glorify"
-      examples: 
+      examples:
         - example: "자리를 빛내다"
           transliteration: "jarireul binnaeda"
           translation: "to honour the occasion with one's presence"
@@ -41660,7 +41660,7 @@ Used to illustrate the time that a certain action or situation began or will beg
   pos: a
   defs:
     - def: "(to be) fast, quick, soon, early"
-      examples: 
+      examples:
         - example: "빠른 시일 내에"
           transliteration: "ppareun siil naee"
           translation: "as soon as possible"
@@ -41699,7 +41699,7 @@ Used to illustrate the time that a certain action or situation began or will beg
   defs:
     - def: "to fall into (especially of water)"
     - def: "to lapse or sink into a state (e.g. love, drunkenness)"
-      examples: 
+      examples:
         - example: "사랑에 빠지다"
           transliteration: "sarang-e ppajida"
           translation: "to be in love"
@@ -41716,7 +41716,7 @@ Used to illustrate the time that a certain action or situation began or will beg
   pos: n
   defs:
     - def: "red (color)"
-      examples: 
+      examples:
         - example: "빨간색은 피와 불과 비슷한 색깔을 말한다."
           transliteration: "Ppalgansaegeun piwa bulgwa biseuthan saekkkareul malhanda."
           translation: "Red is a color similar to blood and fire."
@@ -41792,7 +41792,7 @@ Used to illustrate the time that a certain action or situation began or will beg
   pos: adv
   defs:
     - def: "quickly, without delay; often used when urging someone to hurry"
-      examples: 
+      examples:
         - example: "가능한 한 빨리 우리에게 알려 주세요."
           transliteration: "Ganeunghan han ppalli uriege allyeo juseyo."
           translation: "Please let us know as soon as possible."
@@ -41806,7 +41806,7 @@ Used to illustrate the time that a certain action or situation began or will beg
   defs:
     - def: "to take/eat/drink by sucking, to suck"
     - def: "to extort, to squeeze, to exploit, to sponge"
-      examples: 
+      examples:
         - example: "그들은 거머리처럼 그의 재산을 송두리째 빨아먹었다."
           transliteration: "Geudeureun geomeoricheoreom geuui jaesaneul songdurijjae pparameogeotda."
           translation: "They leeched him until his entire fortune was exhausted."
@@ -42016,7 +42016,7 @@ Used to illustrate the time that a certain action or situation began or will beg
   defs:
     - def: "be haughty; be proud; be pompous"
     - def: "to show off; brag"
-      examples: 
+      examples:
         - example: "그들은 그들의 책을 출판하고 지루한 모임에서 그것을 뽐냈다."
           transliteration: "Geudeureun geudeurui chaegeul chulpanhago jiruhan moimeseo geugeoseul ppomnaetda."
           translation: "They published their books and bragged about them at tedious party."
@@ -42248,7 +42248,7 @@ Used to illustrate the time that a certain action or situation began or will beg
   pos: v
   defs:
     - def: "to apologize"
-      examples: 
+      examples:
         - example: "오늘 저는 제 동료들에게 사과하고 싶어요."
           transliteration: "Oneul jeoneun je dongnyodeurege sagwahago sipeoyo."
           translation: "Today I want to apologize to my co-workers."
@@ -42266,7 +42266,7 @@ Used to illustrate the time that a certain action or situation began or will beg
   defs:
     - def: "to date, to go out"
     - def: "to get along, to get close to, to associate with"
-      examples: 
+      examples:
         - example: "친구를 사귀다"
           transliteration: "chin-gureul sagwida"
           translation: "to make friends"
@@ -42351,7 +42351,7 @@ Used to illustrate the time that a certain action or situation began or will beg
   pos: v
   defs:
     - def: "to buy"
-      examples: 
+      examples:
         - example: "뭐 좀 살 게 있어서 시장에 가고 있어요. / 아 그러세요, 저도 시장에 가야 해요."
           transliteration: "Mwo jom sal ge isseoseo sijang-e gago isseoyo. / a geureoseyo, jeodo sijang-e gaya haeyo."
           translation: "I'm going to the market. I need to buy something. / Really? I need to go to the market too."
@@ -42418,7 +42418,7 @@ Used to illustrate the time that a certain action or situation began or will beg
   defs:
     - def: "animals that think, use language, make tools, and live in society."
     - def: "human; person; people"
-      examples: 
+      examples:
         - example: "영국 사람"
           transliteration: "Yeongguk saram"
           translation: "the British"
@@ -42439,7 +42439,7 @@ Used to illustrate the time that a certain action or situation began or will beg
   pos: n
   defs:
     - def: "plural of 사람 (saram): people, persons"
-      examples: 
+      examples:
         - example: "그러나 소수의 사람들만이 그것이 실제로 무엇을 하는지를 안다."
           transliteration: "Geureona sosuui saramdeulmani geugeosi siljero mueoseul haneunjireul anda."
           translation: "Yet few people know what it actually does."
@@ -42475,7 +42475,7 @@ Used to illustrate the time that a certain action or situation began or will beg
   pos: v
   defs:
     - def: "to love"
-      examples: 
+      examples:
         - example: "사랑해"
           transliteration: "saranghae"
           translation: "I love you"
@@ -42640,7 +42640,7 @@ Used to illustrate the time that a certain action or situation began or will beg
   pos: n
   defs:
     - def: "history, historic"
-      examples: 
+      examples:
         - example: "사상 최저"
           transliteration: "sasang choejeo"
           translation: "a historic low"
@@ -42656,7 +42656,7 @@ Used to illustrate the time that a certain action or situation began or will beg
   pos: n
   defs:
     - def: "history, historic"
-      examples: 
+      examples:
         - example: "사상 최저"
           transliteration: "sasang choejeo"
           translation: "a historic low"
@@ -42776,7 +42776,7 @@ Used to illustrate the time that a certain action or situation began or will beg
   pos: n
   defs:
     - def: "technical specifications"
-      examples: 
+      examples:
         - example: "다양한 첨단사양"
           transliteration: "dayanghan cheomdansayang"
 
@@ -42785,7 +42785,7 @@ Used to illustrate the time that a certain action or situation began or will beg
   pos: n
   defs:
     - def: "polite refusal"
-      examples: 
+      examples:
         - example: "사양은 미덕이지만, 때로는 남의 호의를 무시하는 것으로 해석된다."
           transliteration: "Sayang-eun mideogijiman, ttaeroneun namui houireul musihaneun geoseuro haeseokdoenda."
 
@@ -42795,7 +42795,7 @@ Used to illustrate the time that a certain action or situation began or will beg
   defs:
     - def: "setting sun"
     - def: "that which is declining in the face of something new"
-      examples: 
+      examples:
         - example: "사양 산업"
           transliteration: "sayang saneop"
 
@@ -42804,7 +42804,7 @@ Used to illustrate the time that a certain action or situation began or will beg
   pos: v
   defs:
     - def: "to refuse courteously, to decline"
-      examples: 
+      examples:
         - example: "제안을 정중히 사양하다."
           transliteration: "Jeaneul jeongjunghi sayanghada."
   conj: [사양한다, 사양해, 사양해요, 사양합니다]
@@ -42814,7 +42814,7 @@ Used to illustrate the time that a certain action or situation began or will beg
   pos: n
   defs:
     - def: "business"
-      examples: 
+      examples:
         - example: "밥과 앤디는 사업 관계를 맺었다."
           transliteration: "Bapgwa aendineun sa-eop gwan-gyereul maejeotda."
           translation: "Bob and Andy went into business together."
@@ -42852,7 +42852,7 @@ Used to illustrate the time that a certain action or situation began or will beg
   pos: v
   defs:
     - def: "to use"
-      examples: 
+      examples:
         - example: "여러 가지 프로그램을 잘 사용할 줄 압니다."
           transliteration: "Yeoreo gaji peurogeuraemeul jal sayonghal jul amnida."
           translation: "I know how to use many computer programs."
@@ -42967,17 +42967,17 @@ Used to illustrate the time that a certain action or situation began or will beg
   pos: n
   defs:
     - def: "signature"
-      examples: 
+      examples:
         - example: "계약서에 사인을 했다."
           transliteration: "Gyeyakseo-e saineul haetda."
           translation: "I put my signature to contract."
     - def: "autograph"
-      examples: 
+      examples:
         - example: "어제 유명 배우의 사인을 받았다."
           transliteration: "Eoje yumyeong bae-uui saineul badatda."
           translation: "I got the autograph of famous actor yesterday."
     - def: "signal"
-      examples: 
+      examples:
         - example: "감독이 선수에게 손으로 사인을 보냈다."
           transliteration: "Gamdogi seonsuege soneuro saineul bonaetda."
           translation: "The coach sent a signal to the athlete by hand."
@@ -42987,7 +42987,7 @@ Used to illustrate the time that a certain action or situation began or will beg
   pos: n
   defs:
     - def: "cause of death"
-      examples: 
+      examples:
         - example: "사인을 밝히다"
           transliteration: "saineul balkida"
           translation: "be discovered cause of death"
@@ -43040,7 +43040,7 @@ Used to illustrate the time that a certain action or situation began or will beg
   pos: n
   defs:
     - def: "dictionary"
-      examples: 
+      examples:
         - example: "사전을 찾아보다"
           transliteration: "sajeoneul chajaboda"
           translation: "to search [for a word in] a dictionary"
@@ -43316,7 +43316,7 @@ Used to illustrate the time that a certain action or situation began or will beg
   pos: n
   defs:
     - def: "socialism, socialist"
-      examples: 
+      examples:
         - example: "사회주의 조선의 힘을 재웠다!"
           transliteration: "Sahoejuui joseonui himeul jaewotda!"
           translation: "Taste the power of socialist Korea!"
@@ -43908,17 +43908,17 @@ Used to illustrate the time that a certain action or situation began or will beg
   pos: v
   defs:
     - def: "To swallow. (to cause to pass from the mouth into the stomach)"
-      examples: 
+      examples:
         - example: "아이가 무엇을 삼켰는지 자꾸 토한다."
           transliteration: "Aiga mueoseul samkyeonneunji jakku tohanda."
           translation: "The kid keeps gagging, like he swallowed something."
     - def: "To suppress or stifle an expression of emotion."
-      examples: 
+      examples:
         - example: "막 쏟아지려는 눈물을 못내 삼키며 집을 뛰쳐나갔다."
           transliteration: "Mak ssodajiryeoneun nunmureul monnae samkimyeo jibeul ttwichyeonagatda."
           translation: "I ran out of the house, holding back the tears that were ready to flow."
     - def: "To secretly make something one's own; to steal."
-      examples: 
+      examples:
         - example: "남의 돈을 슬쩍 삼키고는 오리발을 내밀었다."
           transliteration: "Namui doneul seuljjeok samkigoneun oribareul naemireotda."
           translation: "He secretly took someone else's money and played innocent."
@@ -43940,7 +43940,7 @@ Used to illustrate the time that a certain action or situation began or will beg
   pos: n
   defs:
     - def: "insert song"
-      examples: 
+      examples:
         - example: "영화 삽입곡"
           transliteration: "yeonghwa sabipgok"
           translation: "insert song in a film"
@@ -44097,7 +44097,7 @@ Used to illustrate the time that a certain action or situation began or will beg
   pos: a
   defs:
     - def: "detailed"
-      examples: 
+      examples:
         - example: "상세한 정보가 모두 들어 있습니다."
           transliteration: "Sangsehan jeongboga modu deureo itseumnida."
           translation: "It has all the detailed information."
@@ -44125,7 +44125,7 @@ Used to illustrate the time that a certain action or situation began or will beg
   pos: n
   defs:
     - def: "loss"
-      examples: 
+      examples:
         - example: "다른 지역에서는 빙하의 상실이 제삼극 전역에 걸쳐 건기라는 심각한 위험을 야기한다고 왕 씨는 말한다."
           transliteration: "Dareun jiyeogeseoneun binghaui sangsiri jesamgeuk jeonyeoge geolchyeo geon-giraneun simgakhan wiheomeul yagihandago wang ssineun malhanda."
           translation: "In other areas, glacier loss creates serious risk of a dry period across the Third Pole, Wang said."
@@ -44159,7 +44159,7 @@ Used to illustrate the time that a certain action or situation began or will beg
   pos: v
   defs:
     - def: "to discuss"
-      examples: 
+      examples:
         - example: "당신과 상의하고 싶은 것이 있습니다."
           transliteration: "Dangsin-gwa sang-uihago sipeun geosi itseumnida."
           translation: "There's something I'd like to discuss with you."
@@ -44270,7 +44270,7 @@ Used to illustrate the time that a certain action or situation began or will beg
   pos: v
   defs:
     - def: "To be repaid; be redeemed"
-      examples: 
+      examples:
         - example: "네, 그것들은 다시 상환됩니다."
           transliteration: "Ne, geugeotdeureun dasi sanghwandoemnida."
           translation: "Yes, they’ll get reimbursed."
@@ -44309,7 +44309,7 @@ Used to illustrate the time that a certain action or situation began or will beg
   pos: det
   defs:
     - def: "new"
-      examples: 
+      examples:
         - example: "새 집으로 벌써 이사했어요?"
           transliteration: "Sae jibeuro beolsseo isahaesseoyo?"
           translation: "Did you already move into your new house?"
@@ -44398,7 +44398,7 @@ Used to illustrate the time that a certain action or situation began or will beg
   pos: a
   defs:
     - def: "to be new"
-      examples: 
+      examples:
         - example: "혹시 새로운 직원을 채용하고 있는지요?"
           transliteration: "Hoksi saeroun jigwoneul chaeyonghago inneunjiyo?"
           translation: "Are you by any chance looking for a new staff member?"
@@ -44421,7 +44421,7 @@ Used to illustrate the time that a certain action or situation began or will beg
   pos: n
   defs:
     - def: "dawn; daybreak; cockcrow (also used to indicate time of the day, approximately from 1:00 a.m. to 3:00 a.m.)"
-      examples: 
+      examples:
         - example: "새벽 세 시에"
           transliteration: "saebyeok se sie"
           translation: "at three a.m."
@@ -44534,7 +44534,7 @@ Used to illustrate the time that a certain action or situation began or will beg
   pos: n
   defs:
     - def: "sexual urge, sexual desire, lust, carnal desire"
-      examples: 
+      examples:
         - example: "색정을 도발하다"
           transliteration: "saekjeong-eul dobalhada"
           translation: "excite/stimulate one's sexual desire"
@@ -44644,7 +44644,7 @@ Used to illustrate the time that a certain action or situation began or will beg
   pos: v
   defs:
     - def: "to think"
-      examples: 
+      examples:
         - example: "왜 그렇게 생각하는데요?"
           transliteration: "Wae geureoke saenggakhaneundeyo?"
           translation: "What makes you think so?"
@@ -44661,7 +44661,7 @@ Used to illustrate the time that a certain action or situation began or will beg
   pos: v
   defs:
     - def: "to think"
-      examples: 
+      examples:
         - example: "왜 그렇게 생각하는데요?"
           transliteration: "Wae geureoke saenggakhaneundeyo?"
           translation: "What makes you think so?"
@@ -44895,7 +44895,7 @@ Used to illustrate the time that a certain action or situation began or will beg
   pos: n
   defs:
     - def: "shower (device for bathing)"
-      examples: 
+      examples:
         - example: "아내는 샤워를 합니다."
           transliteration: "Anaeneun syaworeul hamnida."
           translation: "My wife is taking a shower."
@@ -45063,7 +45063,7 @@ Used to illustrate the time that a certain action or situation began or will beg
   pos: n
   defs:
     - def: "document"
-      examples: 
+      examples:
         - example: "서류가 책상 위에 높게 쌓여 있다."
           transliteration: "Seoryuga chaeksang wie nopge ssayeo itda."
           translation: "Papers are piled high on the desk."
@@ -45187,7 +45187,7 @@ Used to illustrate the time that a certain action or situation began or will beg
   defs:
     - def: "description, depiction, narration"
     - def: "predication"
-      examples: 
+      examples:
         - example: "서술부어"
           transliteration: "seosulbueo"
           translation: "sentence predicate (literally, \"predication part\")"
@@ -45228,7 +45228,7 @@ Used to illustrate the time that a certain action or situation began or will beg
   pos: n
   defs:
     - def: "capital; large city"
-      examples: 
+      examples:
         - example: "파리는 프랑스의 서울이다."
           transliteration: "Parineun Peurangseuui seourida."
           translation: "Paris is the capital of France."
@@ -45241,7 +45241,7 @@ Used to illustrate the time that a certain action or situation began or will beg
   pos: propn
   defs:
     - def: "Seoul (the capital city of South Korea)"
-      examples: 
+      examples:
         - example: "서울에 가요."
           transliteration: "Seoure gayo."
           translation: "(I am, you are, he is, etc.) going to Seoul."
@@ -45300,7 +45300,7 @@ Used to illustrate the time that a certain action or situation began or will beg
   pos: a
   defs:
     - def: "to be unskillful, inexperienced, unhandy"
-      examples: 
+      examples:
         - example: "서투른 도둑이 첫날밤에 들킨다."
           transliteration: "Seotureun dodugi cheonnalbame deulkinda."
           translation: "An unskillful thief will get caught on their first day. "
@@ -45392,7 +45392,7 @@ Used to illustrate the time that a certain action or situation began or will beg
   pos: n
   defs:
     - def: "oil, petroleum"
-      examples: 
+      examples:
         - example: "당신이 일상생활에서 쓰고, 보고, 만지는 물건 중에 석유가 안들어간 제품은 거의 없다."
           transliteration: "Dangsini ilsangsaenghwareseo sseugo, bogo, manjineun mulgeon jung-e seogyuga andeureogan jepumeun geoui eopda."
           translation: "Few items you use, watch, or touch in your daily life are without petroleum."
@@ -45449,7 +45449,7 @@ Used to illustrate the time that a certain action or situation began or will beg
   pos: n
   defs:
     - def: "mission; missionary work"
-      examples: 
+      examples:
         - example: "그는 선교를 했다."
           translation: "He did missionary work."
 
@@ -45606,7 +45606,7 @@ Used to illustrate the time that a certain action or situation began or will beg
   pos: n
   defs:
     - def: "selection; choice; option"
-      examples: 
+      examples:
         - example: "이메일 (선택): 당신의 메일 주소를 공개하지 않고 다른 사용자들과 이야기를 할 수 있습니다."
           transliteration: "Imeil (seontaek): dangsinui meil jusoreul gonggaehaji anko dareun sayongjadeulgwa iyagireul hal su itseumnida."
           translation: "Email (option): This provides a way for other users to contact [you] without revealing your email address."
@@ -45724,7 +45724,7 @@ Used to illustrate the time that a certain action or situation began or will beg
   pos: adv
   defs:
     - def: "surely (in a negative context)"
-      examples: 
+      examples:
         - example: "설마 비가 안 오겠어요."
           transliteration: "Seolma biga an ogesseoyo."
           translation: "Surely it will not rain."
@@ -45740,7 +45740,7 @@ Used to illustrate the time that a certain action or situation began or will beg
   pos: n
   defs:
     - def: "explanation"
-      examples: 
+      examples:
         - example: "어디서부터 설명을 시작해야 할지 모르겠네요."
           transliteration: "Eodiseobuteo seolmyeong-eul sijakhaeya halji moreugenneyo."
           translation: "I don't know where to begin the explanation."
@@ -45750,7 +45750,7 @@ Used to illustrate the time that a certain action or situation began or will beg
   pos: v
   defs:
     - def: "to explain"
-      examples: 
+      examples:
         - example: "면접관은 내 경력을 간단히 설명해 보라고 요청했다."
           transliteration: "Myeonjeopgwaneun nae gyeongnyeogeul gandanhi seolmyeonghae borago yocheonghaetda."
           translation: "The interviewer asked me to explain my career briefly."
@@ -45785,7 +45785,7 @@ Used to illustrate the time that a certain action or situation began or will beg
   pos: n
   defs:
     - def: "creation; setup; establishment; fixing"
-      examples: 
+      examples:
         - example: "사용자 환경 설정"
           transliteration: "sayongja hwan-gyeong seoljeong"
           translation: "user environment creation"
@@ -45801,7 +45801,7 @@ Used to illustrate the time that a certain action or situation began or will beg
   pos: v
   defs:
     - def: "to be installed"
-      examples: 
+      examples:
         - example: "에어컨이 설치되었습니다."
           transliteration: "Eeokeoni seolchidoeeotseumnida."
           translation: "The air conditioner was installed. (formal)"
@@ -45890,7 +45890,7 @@ Used to illustrate the time that a certain action or situation began or will beg
   pos: n
   defs:
     - def: "Celsius; centigrade"
-      examples: 
+      examples:
         - example: "오늘날의 지구는 전(前)산업화 시기보다도 섭씨 일(1)도가 더 더워졌다."
           transliteration: "Oneullarui jiguneun jeonsaneophwa sigibodado seopssi il(1)doga deo deowojyeotda."
           translation: "Earth is one degree Centigrade hotter today than in pre-industrial times."
@@ -46001,7 +46001,7 @@ Used to illustrate the time that a certain action or situation began or will beg
   pos: a
   defs:
     - def: "(to be) successful"
-      examples: 
+      examples:
         - example: "성공하기 힘들다"
           transliteration: "seonggonghagi himdeulda"
           translation: "It is difficult to be successful"
@@ -46190,7 +46190,7 @@ Used to illustrate the time that a certain action or situation began or will beg
   pos: n
   defs:
     - def: "surname, last name, family name"
-      examples: 
+      examples:
         - example: "나는 내 성씨가 자랑스럽다."
           transliteration: "Naneun nae seongssiga jarangseureopda."
           translation: "I'm proud of my last name."
@@ -46320,7 +46320,7 @@ Used to illustrate the time that a certain action or situation began or will beg
   pos: n
   defs:
     - def: "A term of respectful address for a pope."
-      examples: 
+      examples:
         - example: "교황 성하"
           transliteration: "gyohwang seongha"
           translation: "Holy father, His Holiness, Your Holiness"
@@ -46342,7 +46342,7 @@ Used to illustrate the time that a certain action or situation began or will beg
   pos: det
   defs:
     - def: "three (of something)."
-      examples: 
+      examples:
         - example: "학생 세 명"
           transliteration: "haksaeng se myeong"
           translation: "three students"
@@ -46361,7 +46361,7 @@ Used to illustrate the time that a certain action or situation began or will beg
   pos: n
   defs:
     - def: "the world"
-      examples: 
+      examples:
         - example: "그녀는, 제삼극이 세계에서 가장 큰, 신선한 식수원 중의 하나라고 말한다."
           transliteration: "Geunyeoneun, jesamgeugi segyeeseo gajang keun, sinseonhan siksuwon jung-ui hanarago malhanda."
           translation: "She says the Third Pole is one of the world’s largest sources of fresh drinking water."
@@ -46390,7 +46390,7 @@ Used to illustrate the time that a certain action or situation began or will beg
   pos: n
   defs:
     - def: "world peace"
-      examples: 
+      examples:
         - example: "세계평화를 위하여"
           transliteration: "segyepyeonghwareul wihayeo"
           translation: "for the sake of world peace"
@@ -46469,7 +46469,7 @@ Used to illustrate the time that a certain action or situation began or will beg
   pos: n
   defs:
     - def: "height, length, vertical direction"
-      examples: 
+      examples:
         - example: "세로로 줄을 긋다"
           transliteration: "seroro jureul geutda"
           translation: "to draw a vertical line"
@@ -46569,7 +46569,7 @@ Used to illustrate the time that a certain action or situation began or will beg
   pos: suf
   defs:
     - def: "a polite style present tense declarative, interrogative, imperative, suggestive ending"
-      examples: 
+      examples:
         - example: "여기서는 담배 피우지 마세요."
           transliteration: "Yeogiseoneun dambae piuji maseyo."
           translation: "Do not smoke here, please."
@@ -46586,7 +46586,7 @@ Used to illustrate the time that a certain action or situation began or will beg
   pos: v
   defs:
     - def: "to be founded, be constructed; be built; go up (passive form of 세우다)"
-      examples: 
+      examples:
         - example: "빌딩이 세워졌다."
           transliteration: "Bilding-i sewojyeotda."
           translation: "A building was constructed."
@@ -46883,7 +46883,7 @@ Used to illustrate the time that a certain action or situation began or will beg
   pos: n
   defs:
     - def: "salt; table salt; sodium chloride"
-      examples: 
+      examples:
         - example: "한 줌의 소금"
           transliteration: "han jumui sogeum"
           translation: "a pinch of salt"
@@ -47126,7 +47126,7 @@ Used to illustrate the time that a certain action or situation began or will beg
   pos: n
   defs:
     - def: "belonging to"
-      examples: 
+      examples:
         - example: "어느 팀 소속이에요?"
           transliteration: "Eoneu tim sosogieyo?"
           translation: "Which team do you belong to?"
@@ -47154,7 +47154,7 @@ Used to illustrate the time that a certain action or situation began or will beg
   pos: n
   defs:
     - def: "minority race; minor ethnic group"
-      examples: 
+      examples:
         - example: "보안요원 양샤오펑은 그 지방의 나시 소수민족에 속한다."
           transliteration: "Boanyowon yangsyaopeong-eun geu jibang-ui nasi sosuminjoge sokhanda."
           translation: "Security guard Yang Shaofeng is a member of the local Naxi minority community."
@@ -47188,7 +47188,7 @@ Used to illustrate the time that a certain action or situation began or will beg
   pos: n
   defs:
     - def: "use; good"
-      examples: 
+      examples:
         - example: "그런 걸 배워도 아무 소용이 없다."
           transliteration: "Geureon geol baewodo amu soyong-i eopda."
           translation: "It's no use learning such a thing."
@@ -47325,7 +47325,7 @@ Used to illustrate the time that a certain action or situation began or will beg
   pos: n
   defs:
     - def: "effects, personal belongings"
-      examples: 
+      examples:
         - example: "소지품 다 챙겼나요?"
           transliteration: "Sojipum da chaenggyeonnayo?"
           translation: "Have you brought all your things with you?"
@@ -47477,7 +47477,7 @@ Used to illustrate the time that a certain action or situation began or will beg
   pos: n
   defs:
     - def: "speed"
-      examples: 
+      examples:
         - example: "빠른 속도로"
           transliteration: "ppareun sokdoro"
           translation: "very quickly"
@@ -47542,7 +47542,7 @@ Used to illustrate the time that a certain action or situation began or will beg
   pos: v
   defs:
     - def: "to deceive, to trick, to cheat, to fool"
-      examples: 
+      examples:
         - example: "그는 50년동안 너네들을 속여왔다."
           transliteration: "Geuneun 50nyeondong-an neonedeureul sogyeowatda."
           translation: "He's been fooling you for 50 years."
@@ -47604,7 +47604,7 @@ Used to illustrate the time that a certain action or situation began or will beg
   pos: n
   defs:
     - def: "palm (inner, concave part of hand)"
-      examples: 
+      examples:
         - example: "박수는 손바닥 두개를 마주치면서 치는 것이다."
           transliteration: "Baksuneun sonbadak dugaereul majuchimyeonseo chineun geosida."
           translation: "When you clap, you hit palms of your hands together."
@@ -47620,7 +47620,7 @@ Used to illustrate the time that a certain action or situation began or will beg
   pos: v
   defs:
     - def: "to damage; injure; impair (To break or hurt a certain object.)"
-      examples: 
+      examples:
         - example: "추운 날씨, 거센 비, 낙석, 강풍과 빙하 운동이 장비를 손상시킬 수 있다."
           transliteration: "Chuun nalssi, geosen bi, nakseok, gangpunggwa bingha undong-i jangbireul sonsangsikil su itda."
           translation: "Cold temperatures, heavy rain, falling rocks, strong winds and glacier movement can damage the equipment."
@@ -47713,7 +47713,7 @@ Used to illustrate the time that a certain action or situation began or will beg
   pos: a
   defs:
     - def: "to take an interest in"
-      examples: 
+      examples:
         - example: "귀가 솔깃해지는 조건"
           transliteration: "gwiga solgithaejineun jogeon"
           translation: "a tempting offer"
@@ -47823,7 +47823,7 @@ Used to illustrate the time that a certain action or situation began or will beg
   pos: n
   defs:
     - def: "a bunch of flowers, grapes, mushrooms; a flake of snow"
-      examples: 
+      examples:
         - example: "포도 송이"
           transliteration: "podo song-i"
           translation: "a bunch of grapes"
@@ -48068,7 +48068,7 @@ Used to illustrate the time that a certain action or situation began or will beg
   pos: v
   defs:
     - def: "to work hard, to take trouble"
-      examples: 
+      examples:
         - example: "수고하십니다."
           transliteration: "Sugohasimnida."
           translation: "May I interrupt you?"
@@ -48112,7 +48112,7 @@ Used to illustrate the time that a certain action or situation began or will beg
   pos: n
   defs:
     - def: "talkativeness; prattle"
-      examples: 
+      examples:
         - example: "수다를 떨다"
           transliteration: "sudareul tteolda"
           translation: "to have a chat"
@@ -48281,7 +48281,7 @@ Used to illustrate the time that a certain action or situation began or will beg
   pos: n
   defs:
     - def: "repairing something broken."
-      examples: 
+      examples:
         - example: "저는 차를 수리 맡겨야 해요."
           transliteration: "Jeoneun chareul suri matgyeoya haeyo."
           translation: "I need to get my car repaired."
@@ -48404,7 +48404,7 @@ Used to illustrate the time that a certain action or situation began or will beg
   pos: a
   defs:
     - def: "suspicious"
-      examples: 
+      examples:
         - example: "경비원은 정문 옆에 수상하게 보이는 가방이 있음을 보고했다."
           transliteration: "Gyeongbiwoneun jeongmun yeope susanghage boineun gabang-i isseumeul bogohaetda."
           translation: "The guard reported a dodgy-looking bag by the main entrance."
@@ -48529,7 +48529,7 @@ Used to illustrate the time that a certain action or situation began or will beg
   pos: n
   defs:
     - def: "a class"
-      examples: 
+      examples:
         - example: "오늘 수업 있으세요?"
           transliteration: "Oneul sueop isseuseyo?"
           translation: "Do you have class today?"
@@ -48559,7 +48559,7 @@ Used to illustrate the time that a certain action or situation began or will beg
   pos: n
   defs:
     - def: "swimming"
-      examples: 
+      examples:
         - example: "내 친구는 마치 물개처럼 수영을 잘 한다."
           transliteration: "Nae chin-guneun machi mulgaecheoreom suyeong-eul jal handa."
           translation: "My friend swims just like [just as well as] a seal."
@@ -48594,7 +48594,7 @@ Used to illustrate the time that a certain action or situation began or will beg
   pos: propn
   defs:
     - def: "Wednesday"
-      examples: 
+      examples:
         - example: "수요일에, 애니멀 플래닛은 2016년 퍼피볼의 선발 선수 명단을 발표했습니다."
           transliteration: "Suyoire, aenimeol peullaeniseun 2016nyeon peopiborui seonbal seonsu myeongdaneul balpyohaetseumnida."
           translation: "On Wednesday, Animal Planet announced the starting lineup for the 2016 Puppy Bowl."
@@ -48708,7 +48708,7 @@ Used to illustrate the time that a certain action or situation began or will beg
   pos: v
   defs:
     - def: "to collect; gather"
-      examples: 
+      examples:
         - example: "그 팀은 온도, 풍속 및 강우량에 관한 데이터를 수집하기 위해서 특별한 장비를 사용한다."
           transliteration: "Geu timeun ondo, pungsok mit gang-uryang-e gwanhan deiteoreul sujiphagi wihaeseo teukbyeolhan jangbireul sayonghanda."
           translation: "The team uses special equipment to collect data on temperature, wind speed and rainfall."
@@ -48749,7 +48749,7 @@ Used to illustrate the time that a certain action or situation began or will beg
   pos: n
   defs:
     - def: "male animal"
-      examples: 
+      examples:
         - example: "당신의 개는 수컷인가요, 암컷인가요?"
           transliteration: "Dangsinui gaeneun sukeodin-gayo, amkeodin-gayo?"
           translation: "Is your dog a he or a she?"
@@ -49113,17 +49113,17 @@ Used to illustrate the time that a certain action or situation began or will beg
   pos: n
   defs:
     - def: "hide and seek"
-      examples: 
+      examples:
         - example: "아이들은 달빛보다 밝은 가로등 밑에 모여 재미난 숨바꼭질도 하고 고무줄넘기도 하며 밤 늦게까지 놀았다."
           transliteration: "Aideureun dalbitboda balgeun garodeung mite moyeo jaeminan sumbakkokjildo hago gomujulleomgido hamyeo bam neutgekkaji noratda."
           translation: "Gathering under streetlamps which are brighter than moonlight, children jollily played hide-and-seek and rubber jump rope until late at night."
     - def: "appearing and disappearing; being sometimes visible and sometimes invisible"
-      examples: 
+      examples:
         - example: "풀솜 같은 구름 속으로 숨바꼭질을 하는 달을 보며 소희는 고향을 떠올렸다."
           transliteration: "Pulsom gateun gureum sogeuro sumbakkokjireul haneun dareul bomyeo sohuineun gohyang-eul tteoollyeotda."
           translation: "Sight of the flickering moon in the puffy clouds made Sohui reminisce about her hometown."
     - def: "hide and seek; evading"
-      examples: 
+      examples:
         - example: "우리는 단속원들과 숨바꼭질을 하면서 장사를 하는 노점상들을 쉽게 찾아볼 수 있다."
           transliteration: "Urineun dansogwondeulgwa sumbakkokjireul hamyeonseo jangsareul haneun nojeomsangdeureul swipge chajabol su itda."
           translation: "We can easily find street vendors in business who are playing hide-and-seek with the street wardens."
@@ -49166,7 +49166,7 @@ Used to illustrate the time that a certain action or situation began or will beg
   pos: n
   defs:
     - def: "charcoal"
-      examples: 
+      examples:
         - example: "숯(불)을 피우다"
           transliteration: "sut(bul)eul piuda"
           translation: "to make charcoal fire"
@@ -49275,7 +49275,7 @@ Used to illustrate the time that a certain action or situation began or will beg
   pos: n
   defs:
     - def: "supermarket (a store)"
-      examples: 
+      examples:
         - example: "우리 동네에 큰 슈퍼마켓이 있어."
           transliteration: "Uri dongnee keun syupeomakesi isseo."
           translation: "There is a big supermarket on our street."
@@ -49315,7 +49315,7 @@ Used to illustrate the time that a certain action or situation began or will beg
   pos: suf
   defs:
     - def: "Attached after nouns or roots, to form adjectives expressing the sense of \"to have the property/feeling of\". Forms p-irregular adjectives."
-      examples: 
+      examples:
         - example: "바보 → 바보스럽다"
           transliteration: "babo → baboseureopda"
           translation: "fool → foolish"
@@ -49341,7 +49341,7 @@ Used to illustrate the time that a certain action or situation began or will beg
   pos: v
   defs:
     - def: "to permeate, to percolate, to infiltrate"
-      examples: 
+      examples:
         - example: "지붕의 기왓장이 깨져 빗물이 천장으로 스며들었다."
           transliteration: "Jibung-ui giwatjang-i kkaejyeo binmuri cheonjang-euro seumyeodeureotda."
           translation: "The roof tiles have been broken and rainwater leaked from the ceiling."
@@ -49369,7 +49369,7 @@ Used to illustrate the time that a certain action or situation began or will beg
 - word: 스무
   romaja: seumu
   pos: num
-  defs: 
+  defs:
     - def: twenty (years old)
   notes: "When 스물 (twenty) is followed by 살 (years of age), the final ㄹ is dropped."
   tags: [topik1]
@@ -49391,17 +49391,17 @@ Used to illustrate the time that a certain action or situation began or will beg
   pos: v
   defs:
     - def: "to soak into, to permeate; to ooze"
-      examples: 
+      examples:
         - example: "빗물이 벽에 스미어 벽지가 얼룩졌다."
           transliteration: "Binmuri byeoge seumieo byeokjiga eollukjyeotda."
           translation: "Rain has wetted the wall and the wallpaper became stained."
     - def: "to blow into, to penetrate through"
-      examples: 
+      examples:
         - example: "문틈으로 스미는 찬바람에 방안이 썰렁하니 추웠다."
           transliteration: "Munteumeuro seumineun chanbarame bang-ani sseolleonghani chuwotda."
           translation: "The cold wind entered through the crack in the door, making the room chilly and cold."
     - def: "to sink into, to be imbued"
-      examples: 
+      examples:
         - example: "우리 민요에는 조상의 숨결이 스며 있다."
           transliteration: "Uri minyo-eneun josang-ui sumgyeori seumyeo itda."
           translation: "Our folksongs are imbued with the life breath of our ancestors."
@@ -49888,7 +49888,7 @@ Used to illustrate the time that a certain action or situation began or will beg
   pos: a
   defs:
     - def: "to be sad"
-      examples: 
+      examples:
         - example: "“위로 올라가야지만 그것을 볼 수 있어요”라고 그는 슬프게 말했다."
           transliteration: "“wiro ollagayajiman geugeoseul bol su isseoyo”rago geuneun seulpeuge malhaetda."
           translation: "“Only when we climb up can we see it,” he said sadly."
@@ -49936,7 +49936,7 @@ Used to illustrate the time that a certain action or situation began or will beg
   pos: suf
   defs:
     - def: "Interrogative suffix for sentence-final verbs in the 하십시오체 (hasipsioche, “formal polite”) speech level."
-      examples: 
+      examples:
         - example: "서울은 오늘 춥습니까?"
           transliteration: "Seoureun oneul chupseumnikka?"
           translation: "Is Seoul cold today?"
@@ -49946,7 +49946,7 @@ Used to illustrate the time that a certain action or situation began or will beg
   pos: suf
   defs:
     - def: "Declarative suffix for sentence-final verbs in the 하십시오체 (hasipsioche, “formal polite”) speech level."
-      examples: 
+      examples:
         - example: "고맙습니다."
           transliteration: "Gomapseumnida."
           translation: "Thank you."
@@ -50075,7 +50075,7 @@ Used to illustrate the time that a certain action or situation began or will beg
   defs:
     - def: "town, city"
     - def: "an administrative region, a division of a province having a population of over 150,000"
-      examples: 
+      examples:
         - example: "(Administrative divisions of South Korea) 리 (ri), 동 (dong), 면 (myeon), 읍 (eup), 구 (gu), 군 (gun), 시 (si), 도 (do) "
 
 - word: 시
@@ -50149,7 +50149,7 @@ Used to illustrate the time that a certain action or situation began or will beg
   pos: n
   defs:
     - def: "a timepiece"
-      examples: 
+      examples:
         - example: "시계가 12시(열두시)를 울림과 동시에, 나는 첫 울음소리를 냈다고 한다."
           transliteration: "Sigyega 12si(yeoldusi)reul ullimgwa dongsie, naneun cheot ureumsorireul naetdago handa."
           translation: "It was remarked that the clock began to strike, and I began to cry, simultaneously."
@@ -50171,7 +50171,7 @@ Used to illustrate the time that a certain action or situation began or will beg
   pos: n
   defs:
     - def: "a time, especially a time for doing something:"
-      examples: 
+      examples:
         - example: "하기에 좋은 시기 - hagie joeun sigi"
         - example: "a good time for doing something"
 
@@ -50188,7 +50188,7 @@ Used to illustrate the time that a certain action or situation began or will beg
   pos: a
   defs:
     - def: "to be loud, to be noisy"
-      examples: 
+      examples:
         - example: "시끄러워!"
           transliteration: "Sikkeureowo!"
           translation: "Shut up!"
@@ -50212,7 +50212,7 @@ Used to illustrate the time that a certain action or situation began or will beg
   pos: n
   defs:
     - def: "downtown, city centre"
-      examples: 
+      examples:
         - example: "지금 시내에 가요."
           transliteration: "Jigeum sinaee gayo."
           translation: "I'm going to the city now."
@@ -50402,7 +50402,7 @@ Used to illustrate the time that a certain action or situation began or will beg
   pos: n
   defs:
     - def: "one's gaze; the direction of one's vision"
-      examples: 
+      examples:
         - example: "그러나 오늘 소셜 미디어의 트윗과 포스트들에서는 또다른 볼 게임, 즉 퍼피 볼에 시선이 쏠렸다."
           transliteration: "Geureona oneul sosyeol midieoui teuwitgwa poseuteudeureseoneun ttodareun bol geim, jeuk peopi bore siseoni ssollyeotda."
           translation: "But on social media today, tweets and posts were directed at another bowl game -- the Puppy Bowl!"
@@ -50581,7 +50581,7 @@ Used to illustrate the time that a certain action or situation began or will beg
   pos: n
   defs:
     - def: "a period of time"
-      examples: 
+      examples:
         - example: "니콜 키드만은 초등학교 시절에 \"레인 코브 퍼블릭 스쿨\"을 다녔다."
           transliteration: "Nikol kideumaneun chodeunghakgyo sijeore rein kobeu peobeullik seukureul danyeotda."
           translation: "Nicole Kidman attended Lane Cove Public School in her primary years."
@@ -50643,7 +50643,7 @@ Used to illustrate the time that a certain action or situation began or will beg
   pos: n
   defs:
     - def: "one's husband's home; the family a woman marries into"
-      examples: 
+      examples:
         - example: "시집을 가다"
           transliteration: "sijibeul gada"
           translation: "(of a woman) to get married to (a person)"
@@ -50653,7 +50653,7 @@ Used to illustrate the time that a certain action or situation began or will beg
   pos: v
   defs:
     - def: "to give one's daughter away in a marriage; to marry off one's daughter"
-      examples: 
+      examples:
         - example: "그 부부는 딸을 부잣집에 시집보내고 싶었다."
           transliteration: "Geu bubuneun ttareul bujatjibe sijipbonaego sipeotda."
           translation: "That couple wanted to marry their daughter off to a rich family."
@@ -50720,7 +50720,7 @@ Used to illustrate the time that a certain action or situation began or will beg
   pos: n
   defs:
     - def: "game, contest, match"
-      examples: 
+      examples:
         - example: "우리는 그 시합에서 참패했다."
           transliteration: "Urineun geu sihabeseo champaehaetda."
           translation: "We were completely defeated in the match."
@@ -50940,7 +50940,7 @@ Used to illustrate the time that a certain action or situation began or will beg
   defs:
     - def: "god, God"
     - def: "spirit, departed soul"
-      examples: 
+      examples:
         - example: "땅이 混沌하고 空虛하며 黑暗이 깊음 위에 있고 하나님의 神은 水面에 運行하시니라땅이 혼돈하고 공허하며; 흑암이 깊음 위에 있고. 하나님의 신은 수면에 운행하시니라."
           transliteration: "Ttang-i hondonhago gongheohamyeo; heugami gipeum wie itgo. Hananimui sineun sumyeone unhaenghasinira."
           translation: "And the earth was without form, and void; and darkness was upon the face of the deep. And the Spirit of God moved upon the face of the waters."
@@ -50950,7 +50950,7 @@ Used to illustrate the time that a certain action or situation began or will beg
   pos: n
   defs:
     - def: "joy, delight, amusement"
-      examples: 
+      examples:
         - example: "관중들은 아주 신이 났었다."
           transliteration: "Gwanjungdeureun aju sini nasseotda."
           translation: "The audience was frantic with joy."
@@ -50960,7 +50960,7 @@ Used to illustrate the time that a certain action or situation began or will beg
   pos: n
   defs:
     - def: "scene"
-      examples: 
+      examples:
         - example: "감동적인 신이었다."
           transliteration: "Gamdongjeogin sinieotda."
           translation: "It was a moving scene."
@@ -50970,7 +50970,7 @@ Used to illustrate the time that a certain action or situation began or will beg
   pos: n
   defs:
     - def: "footgear, footwear, shoes"
-      examples: 
+      examples:
         - example: "신을 벗고 들어가시오."
           transliteration: "Sineul beotgo deureogasio."
           translation: "Do not enter with shoes on."
@@ -50993,7 +50993,7 @@ Used to illustrate the time that a certain action or situation began or will beg
   defs:
     - def: "nerves"
     - def: "one's feelings on a subject"
-      examples: 
+      examples:
         - example: "신경이 쓰이다"
           transliteration: "sin-gyeong-i sseu-ida"
           translation: "weigh upon one's mind (colloquial)"
@@ -51044,7 +51044,7 @@ Used to illustrate the time that a certain action or situation began or will beg
   pos: v
   defs:
     - def: "to feel elated, to be thrilled, to be excited"
-      examples: 
+      examples:
         - example: "나는 해외에서 근무한다는 기대로 정말 신난다."
           transliteration: "Naneun hae-oeeseo geunmuhandaneun gidaero jeongmal sinnanda."
           translation: "I'm really excited at the prospect of working abroad."
@@ -51124,7 +51124,7 @@ Used to illustrate the time that a certain action or situation began or will beg
   pos: n
   defs:
     - def: "newspaper"
-      examples: 
+      examples:
         - example: "신문 가판대"
           transliteration: "sinmun gapandae"
           translation: "news stand"
@@ -51243,7 +51243,7 @@ Used to illustrate the time that a certain action or situation began or will beg
   pos: n
   defs:
     - def: "credit, credibility, confidence, trust"
-      examples: 
+      examples:
         - example: "신용 카드"
           transliteration: "sinyong kadeu"
           translation: "credit card"
@@ -51342,7 +51342,7 @@ Used to illustrate the time that a certain action or situation began or will beg
   pos: n
   defs:
     - def: "applicant, claimant, subscriber"
-      examples: 
+      examples:
         - example: "신청자(申請者)가 넘치다"
           transliteration: "sincheongjaga neomchida"
           translation: "overflow with applicants"
@@ -51470,7 +51470,7 @@ Used to illustrate the time that a certain action or situation began or will beg
   pos: n
   defs:
     - def: "rudeness"
-      examples: 
+      examples:
         - example: "실례합니다."
           transliteration: "Sillyehamnida."
           translation: "Excuse me (literally: I have been rude)."
@@ -51480,7 +51480,7 @@ Used to illustrate the time that a certain action or situation began or will beg
   pos: n
   defs:
     - def: "a real example, a concrete example, an actual case of something"
-      examples: 
+      examples:
         - example: "실례를 들어 설명하다."
           transliteration: "Sillyereul deureo seolmyeonghada."
           translation: "Explain by giving concrete examples."
@@ -51490,7 +51490,7 @@ Used to illustrate the time that a certain action or situation began or will beg
   pos: v
   defs:
     - def: "to be rude"
-      examples: 
+      examples:
         - example: "실례합니다."
           transliteration: "Sillyehamnida."
           translation: "Excuse me (literally: I have been rude)."
@@ -51566,7 +51566,7 @@ Used to illustrate the time that a certain action or situation began or will beg
   pos: v
   defs:
     - def: "to make a mistake"
-      examples: 
+      examples:
         - example: "아, 제가 실수했네요."
           transliteration: "A, jega silsuhaenneyo."
           translation: "Oh, I made a mistake."
@@ -51660,7 +51660,7 @@ Used to illustrate the time that a certain action or situation began or will beg
   pos: n
   defs:
     - def: "substance, entity"
-      examples: 
+      examples:
         - example: "인간의 정신과 반대되는 개념으로, 객관적으로 존재하는 실체."
           transliteration: "In-ganui jeongsin-gwa bandaedoeneun gaenyeomeuro, gaekgwanjeogeuro jonjaehaneun silche."
           translation: "A substance that exists objectively, which is an idea opposite to the human mind."
@@ -51677,7 +51677,7 @@ Used to illustrate the time that a certain action or situation began or will beg
   pos: n
   defs:
     - def: "reality (in terms of a real-life current condition, usually used in news or business reports)"
-      examples: 
+      examples:
         - example: "하 교수는 금융 사기의 실태를 연구한다."
           transliteration: "Ha gyosuneun geumyung sagiui siltaereul yeon-guhanda."
           translation: "Professor Ha studies the current trend of financial frauds."
@@ -51731,7 +51731,7 @@ Used to illustrate the time that a certain action or situation began or will beg
   pos: v
   defs:
     - def: "to hate; to dislike"
-      examples: 
+      examples:
         - example: "저는 그것을 싫어합니다."
           transliteration: "Jeoneun geugeoseul  sireohamnida."
           translation: "I don't like that one"
@@ -51751,7 +51751,7 @@ Used to illustrate the time that a certain action or situation began or will beg
   pos: a
   defs:
     - def: "to be severe, profound"
-      examples: 
+      examples:
         - example: "와 노래 심각하게 좋다."
           transliteration: "Wa norae simgakhage jota."
           translation: "Wow, this song is seriously good."
@@ -51768,12 +51768,12 @@ Used to illustrate the time that a certain action or situation began or will beg
   pos: v
   defs:
     - def: "To plant, sow (seed or plants)"
-      examples: 
+      examples:
         - example: "정원에 사과나무를 심다"
           transliteration: "jeong-wone sagwanamureul simda"
           translation: "to plant an apple tree in a garden"
     - def: "To plant, implant, instill, inculcate (a thought or a sentiment)"
-      examples: 
+      examples:
         - example: "나는 학생들에게 올바른 사상을 심어 주려고 했다."
           transliteration: "Naneun haksaengdeurege olbareun sasang-eul simeo juryeogo haetda."
           translation: "I tried to inculcate a right thought in [my] student."
@@ -52065,7 +52065,7 @@ Used to illustrate the time that a certain action or situation began or will beg
   pos: a
   defs:
     - def: "to be desirous of; to want (requires a main verb with suffix -고 (go))"
-      examples: 
+      examples:
         - example: "가고 싶다."
           transliteration: "Gago sipda."
           translation: "[I] want to go."
@@ -52082,7 +52082,7 @@ Used to illustrate the time that a certain action or situation began or will beg
   pos: a
   defs:
     - def: "to be desirous of; to want (requires a main verb with suffix -고 (go))"
-      examples: 
+      examples:
         - example: "가고 싶다."
           transliteration: "Gago sipda."
           translation: "[I] want to go."
@@ -52133,7 +52133,7 @@ Used to illustrate the time that a certain action or situation began or will beg
   pos: n
   defs:
     - def: "fighting, fight, quarrel, battle, contest"
-      examples: 
+      examples:
         - example: "싸움을 걸다"
           transliteration: "ssaumeul geolda"
           translation: "to pick a fight"
@@ -52219,7 +52219,7 @@ Used to illustrate the time that a certain action or situation began or will beg
   pos: n
   defs:
     - def: "pair"
-      examples: 
+      examples:
         - example: "눈 한 쌍"
           transliteration: "nun han ssang"
           translation: "a pair of eyes"
@@ -52267,7 +52267,7 @@ Used to illustrate the time that a certain action or situation began or will beg
   pos: n
   defs:
     - def: "both parties, both sides"
-      examples: 
+      examples:
         - example: "그것은 쌍방에 모두 득이 되는 합의였어요."
           transliteration: "Geugeoseun ssangbang-e modu deugi doeneun habuiyeosseoyo."
           translation: "It was a mutually beneficial arrangement."
@@ -52310,7 +52310,7 @@ Used to illustrate the time that a certain action or situation began or will beg
   pos: n
   defs:
     - def: "teacher"
-      examples: 
+      examples:
         - example: "학생은 그들의 선생님을 잘 알아서 \"쌤\"이라고 부른다."
           transliteration: "Haksaeng-eun geudeurui seonsaengnimeul jal araseo ssaemirago bureunda."
           translation: "The students call their teacher \"ssaem\" because they know them well."
@@ -52408,7 +52408,7 @@ Used to illustrate the time that a certain action or situation began or will beg
   pos: v
   defs:
     - def: "to shoot (to fire a shot)"
-      examples: 
+      examples:
         - example: "총을 쏘다."
           transliteration: "Chong-eul ssoda."
           translation: "to shoot a gun."
@@ -52516,7 +52516,7 @@ Used to illustrate the time that a certain action or situation began or will beg
   pos: v
   defs:
     - def: "to write"
-      examples: 
+      examples:
         - example: "뭐 하고 있어요? ― 아 네, 글을 쓰고 있어요. ― 글을 쓰고 있군요. 글을 많이 쓰고 있네요."
           transliteration: "Mwo hago isseoyo? ― a ne, geureul sseugo isseoyo. ― geureul sseugo itgunyo. Geureul mani sseugo inneyo."
           translation: "What are you doing? ― Um, I’m writing. ― You are writing! You are writing a lot!"
@@ -52527,7 +52527,7 @@ Used to illustrate the time that a certain action or situation began or will beg
   pos: v
   defs:
     - def: "to use"
-      examples: 
+      examples:
         - example: "컴퓨터를 쓰다"
           transliteration: "keompyuteoreul sseuda"
           translation: "to use a computer."
@@ -52634,7 +52634,7 @@ Used to illustrate the time that a certain action or situation began or will beg
   pos: n
   defs:
     - def: "use; service"
-      examples: 
+      examples:
         - example: "쓸데없는 소리 마셔!"
           transliteration: "Sseuldeeomneun sori masyeo!"
           translation: "Stop this nonsense!"
@@ -52651,7 +52651,7 @@ Used to illustrate the time that a certain action or situation began or will beg
   pos: n
   defs:
     - def: "use"
-      examples: 
+      examples:
         - example: "쓸모가 있다"
           transliteration: "sseulmoga itda"
           translation: "be useful; be of use"
@@ -52692,7 +52692,7 @@ Used to illustrate the time that a certain action or situation began or will beg
   pos: n
   defs:
     - def: "sir or madam, Mr. or Ms."
-      examples: 
+      examples:
         - example: "안녕하십니까, 찬호씨?"
           transliteration: "Annyeonghasimnikka, Chanhossi?"
           translation: "How are you, Mr. Chanho?"
@@ -52703,7 +52703,7 @@ Used to illustrate the time that a certain action or situation began or will beg
   pos: intj
   defs:
     - def: "shit"
-      examples: 
+      examples:
         - example: "아 추워 씨!"
           transliteration: "A chuwo ssi!"
           translation: "Oh shit, it's cold!"
@@ -52795,17 +52795,17 @@ Used to illustrate the time that a certain action or situation began or will beg
   pos: suf
   defs:
     - def: "and then, after"
-      examples: 
+      examples:
         - example: "책을 찾아 그에게 가져다 주었다."
           transliteration: "Chaegeul chaja geuege gajyeoda jueotda."
           translation: "I found the book and then gave it to him."
     - def: "and therefore, because"
-      examples: 
+      examples:
         - example: "꽃이 많아 기분이 좋다."
           transliteration: "Kkochi mana gibuni jota."
           translation: "I feel good because here are many flowers."
     - def: "by, by -ing; through"
-      examples: 
+      examples:
         - example: "우리는 전속력으로 뛰어 기차역으로 갔다."
           transliteration: "Urineun jeonsongnyeogeuro ttwieo gichayeogeuro gatda."
           translation: "We ran at full speed to the station."
@@ -52814,7 +52814,7 @@ Used to illustrate the time that a certain action or situation began or will beg
   pos: suf
   defs:
     - def: "makes the infinitive form"
-      examples: 
+      examples:
         - example: "The infinitive form can be used to join a main verb and its auxiliary verb."
         - example: "책은 이미 찾아 놓았다."
           transliteration: "Chaegeun imi chaja noatda."
@@ -52823,7 +52823,7 @@ Used to illustrate the time that a certain action or situation began or will beg
           transliteration: "Kkochi manajyeotda."
           translation: "Here are more flowers than before."
     - def: "an intimate style declarative, interrogative, hortative, or imperative suffix"
-      examples: 
+      examples:
         - example: "음, 싫어? 미안하지만 싫어도 어쩔 수 없어."
           transliteration: "Eum, sireo? Mianhajiman sireodo eojjeol su eopseo."
           translation: "Hmm, you don't want to? I'm sorry but you can't avoid it even though you don't like it."
@@ -52832,7 +52832,7 @@ Used to illustrate the time that a certain action or situation began or will beg
   pos: part
   defs:
     - def: "vocative case marker"
-      examples: 
+      examples:
         - example: "멍멍아, 어디 있니?"
           transliteration: "Meongmeong-a, eodi inni?"
           translation: "Doggy, where are you?"
@@ -52977,7 +52977,7 @@ Used to illustrate the time that a certain action or situation began or will beg
   pos: v
   defs:
     - def: "to know, understand (To have information or knowledge about an object or situation through education, experience, thoughts, etc.)"
-      examples: 
+      examples:
         - example: "난 그들이 알고 있는 것이 무엇인지 안다."
           transliteration: "Nan geudeuri algo inneun geosi mueodinji anda."
           translation: "I know just what they know."
@@ -53012,7 +53012,7 @@ Used to illustrate the time that a certain action or situation began or will beg
   pos: a
   defs:
     - def: "to be not (something)"
-      examples: 
+      examples:
         - example: "사람은 짐승이 아니다."
           transliteration: "Sarameun jimseung-i anida."
           translation: "People are not beasts."
@@ -53030,7 +53030,7 @@ Used to illustrate the time that a certain action or situation began or will beg
   pos: intj
   defs:
     - def: "no"
-      examples: 
+      examples:
         - example: "아니야, 날 기다리지 말고 먼저 가게."
           transliteration: "Aniya, nal gidariji malgo meonjeo gage."
           translation: "No, don't wait for me; go first."
@@ -53070,17 +53070,17 @@ Used to illustrate the time that a certain action or situation began or will beg
   pos: suf
   defs:
     - def: "even if, although"
-      examples: 
+      examples:
         - example: "나는 봐도 무슨 내용인지 모르겠더라."
           transliteration: "Naneun bwado museun naeyong-inji moreugetdeora."
           translation: "I didn't understand what it was saying even though I watched it."
     - def: "if; no matter ..."
-      examples: 
+      examples:
         - example: "해도 되고 안 해도 되고."
           transliteration: "Haedo doego an haedo doego."
           translation: "It doesn't matter if you do it or not."
     - def: "Emphasizes the extent."
-      examples: 
+      examples:
         - example: "여기는 사람이 많아도 너무 많다."
           transliteration: "Yeogineun sarami manado neomu manta."
           translation: "The people here are too many."
@@ -53108,12 +53108,12 @@ Used to illustrate the time that a certain action or situation began or will beg
   pos: suf
   defs:
     - def: "(informal) a plain style imperative ending"
-      examples: 
+      examples:
         - example: "너 그렇게 살지 마라. 나중에 후회한다."
           transliteration: "Neo geureoke salji mara. Najung-e huhoehanda."
           translation: "Don't live like that. You'll regret this later."
     - def: "(dated) an exclamatory ending"
-      examples: 
+      examples:
         - example: "아이, 좋아라."
           transliteration: "Ai, joara."
           translation: "Oh, I feel good!"
@@ -53165,7 +53165,7 @@ Used to illustrate the time that a certain action or situation began or will beg
   pos: n
   defs:
     - def: "below, bottom, lower, underneath"
-      examples: 
+      examples:
         - example: "책을 책상 아래에 두세요."
           transliteration: "Chaegeul chaeksang araee duseyo."
           translation: "Lay the book under the desk."
@@ -53193,7 +53193,7 @@ Used to illustrate the time that a certain action or situation began or will beg
   pos: a
   defs:
     - def: "to be vague"
-      examples: 
+      examples:
         - example: "바람에 지는 아련한 사랑."
           transliteration: "Barame jineun aryeonhan sarang."
           translation: "A vague love which disappears with the wind."
@@ -53335,7 +53335,7 @@ Used to illustrate the time that a certain action or situation began or will beg
   pos: adv
   defs:
     - def: "maybe"
-      examples: 
+      examples:
         - example: "좋아, 나중에 봐, 아마도. — 아마도, 나중에 봐."
           transliteration: "Joa, najung-e bwa, amado.  amado, najung-e bwa."
           translation: "Okay. See you later, maybe. — Maybe I’ll see you later."
@@ -53427,7 +53427,7 @@ Used to illustrate the time that a certain action or situation began or will beg
   defs:
     - def: "unspecific (as in being in an undefined, unspecific, or unimportant situation)"
     - def: "careless (as in doing something in a careless manner or on a whim)"
-      examples: 
+      examples:
         - example: "야! 바지를 아무렇게나 벗어 놓지마!"
           transliteration: "Ya! Bajireul amureokena beoseo nochima!"
           translation: "Hey! Don't take off you pants carelessly! (casual speech)"
@@ -53498,7 +53498,7 @@ Used to illustrate the time that a certain action or situation began or will beg
   pos: n
   defs:
     - def: "father (parent)"
-      examples: 
+      examples:
         - example: "아버지가 이번 주에 런던으로 오실거야. 6월 17일 다음 주 목요일에 널 데리러 가야할 것 같아."
           transliteration: "Abeojiga ibeon jue reondeoneuro osilgeoya. 6wol 17il da-eum ju mogyoire neol derireo gayahal geot gata."
           translation: "Father is going to London this week, and I shall call for you on Thursday week, June 17th."
@@ -53605,17 +53605,17 @@ Used to illustrate the time that a certain action or situation began or will beg
   pos: suf
   defs:
     - def: "and then, after"
-      examples: 
+      examples:
         - example: "근데 가서 뭐 하지?"
           transliteration: "Geunde gaseo mwo haji?"
           translation: "What to do after I get there, by the way?"
     - def: "and therefore, because"
-      examples: 
+      examples:
         - example: "날이 추워서 집에만 있는다."
           transliteration: "Nari chuwoseo jibeman inneunda."
           translation: "I stay home due to the cold weather."
     - def: "by; by -ing"
-      examples: 
+      examples:
         - example: "참기름을 넣어서 더 맛있게 만들었다."
           transliteration: "Chamgireumeul neoeoseo deo masitge mandeureotda."
           translation: "I made it more delicious by adding sesame oil."
@@ -53756,7 +53756,7 @@ Used to illustrate the time that a certain action or situation began or will beg
   pos: suf
   defs:
     - def: "a polite style declarative, interrogative, hortative, and imperative ending"
-      examples: 
+      examples:
         - example: "엄마! 나 배고파요. 떡볶이 먹을래, 떡볶이!"
           transliteration: "Eomma! Na baegopayo. Tteokbokki meogeullae, tteokbokki!"
           translation: "Mommy, I'm hungry! Gimme topokki, topokki!"
@@ -53895,7 +53895,7 @@ Used to illustrate the time that a certain action or situation began or will beg
   pos: intj
   defs:
     - def: "An interjection expressing encouragement."
-      examples: 
+      examples:
         - example: "넌 잘할 수 있으니 힘내! 아자!"
           transliteration: "Neon jalhal su isseuni himnae! Aja!"
           translation: "You can do it well, come on!"
@@ -53931,7 +53931,7 @@ Used to illustrate the time that a certain action or situation began or will beg
   pos: adv
   defs:
     - def: "very"
-      examples: 
+      examples:
         - example: "덕택에 저는 아주 잘 지내고 있습니다. 감사해요."
           transliteration: "Deoktaege jeoneun aju jal jinaego itseumnida. Gamsahaeyo."
           translation: "It's going very well, thank you."
@@ -53991,7 +53991,7 @@ Used to illustrate the time that a certain action or situation began or will beg
   pos: adv
   defs:
     - def: "still"
-      examples: 
+      examples:
         - example: "\"아직도 한참 남은 일이라서, 지금은 그것에 대해서 생각하지 않고 있어요\"라고 그는 말했다."
           transliteration: "Ajikdo hancham nameun iriraseo, jigeumeun geugeose daehaeseo saenggakhaji anko isseoyorago geuneun malhaetda."
           translation: "“I don’t think about it now because it still has a long way to go,” he said."
@@ -54034,7 +54034,7 @@ Used to illustrate the time that a certain action or situation began or will beg
   pos: n
   defs:
     - def: "morning"
-      examples: 
+      examples:
         - example: "저는 아침에 일찍 일어나요."
           transliteration: "Jeoneun achime iljjik ireonayo."
           translation: "I wake up early in the morning."
@@ -54115,7 +54115,7 @@ Used to illustrate the time that a certain action or situation began or will beg
   defs:
     - def: "apartment building, block of flats"
     - def: "an apartment, a flat"
-      examples: 
+      examples:
         - example: "난 조나단이야. 난 아파트 b4호에 살아. — 난 아파트 c2에 살아."
           transliteration: "Nan jonadaniya. Nan apateu b4ho-e sara.  nan apateu c2e sara."
           translation: "I am Jonathan. I am in apartment B4. — I am in apartment C2."
@@ -54143,7 +54143,7 @@ Used to illustrate the time that a certain action or situation began or will beg
   pos: a
   defs:
     - def: "to be painful, to hurt"
-      examples: 
+      examples:
         - example: "머리가 아파요."
           transliteration: "Meoriga apayo."
           translation: "[My] head hurts."
@@ -54345,7 +54345,7 @@ Used to illustrate the time that a certain action or situation began or will beg
   pos: adv
   defs:
     - def: "not"
-      examples: 
+      examples:
         - example: "안 먹어?"
           transliteration: "An meogeo?"
           translation: "Won’t [you] eat?"
@@ -54433,7 +54433,7 @@ Used to illustrate the time that a certain action or situation began or will beg
   pos: intj
   defs:
     - def: "hello"
-      examples: 
+      examples:
         - example: "안녕하세요? — 안녕? 마샤니? 나 아나야. —  죄송합니다만, 전화 잘못 거셨네요."
           transliteration: "Annyeonghaseyo? — annyeong? Masyani? Na anaya. —  joesonghamnidaman, jeonhwa jalmot geosyeonneyo."
           translation: "Hello. —  Hello. Is this Marsha? It is Anna. —   I am sorry. You have the wrong number."
@@ -54555,7 +54555,7 @@ Used to illustrate the time that a certain action or situation began or will beg
   pos: n
   defs:
     - def: "appreciative eye (for); discerning eye (for); sense of discrimination"
-      examples: 
+      examples:
         - example: "안목이 있네요."
           transliteration: "Anmogi inneyo."
           translation: "You have good taste."
@@ -54577,7 +54577,7 @@ Used to illustrate the time that a certain action or situation began or will beg
   pos: n
   defs:
     - def: "perfect fitting; perfection; ideal place or object"
-      examples: 
+      examples:
         - example: "이것은 네게 안성맞춤인 일이다."
           transliteration: "Igeoseun nege anseongmatchumin irida."
           translation: "This is the perfect job for you."
@@ -54636,7 +54636,7 @@ Used to illustrate the time that a certain action or situation began or will beg
   pos: n
   defs:
     - def: "safety first"
-      examples: 
+      examples:
         - example: "우리 회사는 각 사업장의 안전제일에 중점을 두고 있다."
           transliteration: "Uri hoesaneun gak sa-eopjang-ui anjeonjeire jungjeomeul dugo itda."
           translation: "Our company places primary focus on safety in all the workplaces."
@@ -54753,7 +54753,7 @@ Used to illustrate the time that a certain action or situation began or will beg
   pos: v
   defs:
     - def: "to sit; to squat"
-      examples: 
+      examples:
         - example: "그는 앉았다."
           transliteration: "Geuneun anjatda."
           translation: "He sat down."
@@ -54774,7 +54774,7 @@ Used to illustrate the time that a certain action or situation began or will beg
   pos: a
   defs:
     - def: "not"
-      examples: 
+      examples:
         - example: "어렵지 않다."
           transliteration: "Eoryeopji anta."
           translation: "It's not hard."
@@ -54785,12 +54785,12 @@ Used to illustrate the time that a certain action or situation began or will beg
   pos: v
   defs:
     - def: "not"
-      examples: 
+      examples:
         - example: "사지 않았습니다."
           transliteration: "Saji anatseumnida."
           translation: "(I) didn't buy (it)."
     - def: "not to do something"
-      examples: 
+      examples:
         - example: "공부를 않는다."
           transliteration: "Gongbureul anneunda."
           translation: "(I) don't study."
@@ -54801,7 +54801,7 @@ Used to illustrate the time that a certain action or situation began or will beg
   pos: a
   defs:
     - def: "(adjective-지 않다)  not"
-      examples: 
+      examples:
         - example: "어렵지 않다."
           transliteration: "Eoryeopji anta."
           translation: "It's not hard."
@@ -54812,12 +54812,12 @@ Used to illustrate the time that a certain action or situation began or will beg
   pos: v
   defs:
     - def: "(verb-지 않다)  not"
-      examples: 
+      examples:
         - example: "사지 않았습니다."
           transliteration: "Saji anatseumnida."
           translation: "(I) didn't buy (it)."
     - def: "(를 않다) not to do something"
-      examples: 
+      examples:
         - example: "공부를 않는다."
           transliteration: "Gongbureul anneunda."
           translation: "(I) don't study."
@@ -54853,7 +54853,7 @@ Used to illustrate the time that a certain action or situation began or will beg
   pos: v
   defs:
     - def: "to know, understand (To have information or knowledge about an object or situation through education, experience, thoughts, etc.)"
-      examples: 
+      examples:
         - example: "난 그들이 알고 있는 것이 무엇인지 안다."
           transliteration: "Nan geudeuri algo inneun geosi mueodinji anda."
           translation: "I know just what they know."
@@ -54865,12 +54865,12 @@ Used to illustrate the time that a certain action or situation began or will beg
     - def: "to know; realize; realize the fun in"
     - def: "to care about"
     - def: "will; say yes"
-      examples: 
+      examples:
         - example: "그녀에게 당신이 여기 있다고 말해요. — 알겠어요. 고마워요. 피트"
           transliteration: "Geunyeo-ege dangsini yeogi itdago malhaeyo. — algesseoyo. Gomawoyo. Piteu"
           translation: "Tell her you’re here.—Right, thanks, Pete."
     - def: "to know (To have met someone before or get along with him/her as an acquaintance.)"
-      examples: 
+      examples:
         - example: "마샤가 제 룸메이트이에요.  — 저는 마샤를 알고 지내요. 좋은 분이지요."
           transliteration: "Masyaga je rummeiteu-ieyo.  — jeoneun masyareul algo jinaeyo. Joeun bunijiyo."
           translation: "Marsha is my roommate. — I know Marsha. She is nice."
@@ -55347,7 +55347,7 @@ Used to illustrate the time that a certain action or situation began or will beg
   pos: n
   defs:
     - def: "fore, former, front"
-      examples: 
+      examples:
         - example: "앞으로 나오세요."
           transliteration: "Apeuro naoseyo."
           translation: "Come to the front."
@@ -55414,7 +55414,7 @@ Used to illustrate the time that a certain action or situation began or will beg
   defs:
     - def: "anxiety; impatience"
     - def: "trouble; effort"
-      examples: 
+      examples:
         - example: "그리고는 그는 혼자 지탱하려고 무진 애를 썼다."
           transliteration: "Geurigoneun geuneun honja jitaengharyeogo mujin aereul sseotda."
           translation: "Then with a big effort he took hold of himself."
@@ -55682,12 +55682,12 @@ Used to illustrate the time that a certain action or situation began or will beg
   pos: intj
   defs:
     - def: "hey!"
-      examples: 
+      examples:
         - example: "야! 니 전화번호 까먹었단 말이야!"
           transliteration: "Ya! Ni jeonhwabeonho kkameogeotdan mariya!"
           translation: "Hey! I forgot your phone number! (familiar and emotional)"
     - def: "hey you, hey kid (rude or familiar)"
-      examples: 
+      examples:
         - example: "야! 너 일로 와봐."
           transliteration: "Ya! Neo illo wabwa."
           translation: "Hey! Come here (rude or familiar)"
@@ -55697,7 +55697,7 @@ Used to illustrate the time that a certain action or situation began or will beg
   pos: part
   defs:
     - def: "vocative case marker"
-      examples: 
+      examples:
         - example: "꼬마야, 뭐 하니?"
           transliteration: "Kkomaya, mwo hani?"
           translation: "What are you doing kid?"
@@ -55707,7 +55707,7 @@ Used to illustrate the time that a certain action or situation began or will beg
   pos: part
   defs:
     - def: "semantic marker of emphasis"
-      examples: 
+      examples:
         - example: "그야 모를 일이지."
           transliteration: "Geuya moreul iriji."
           translation: "Well, I doubt."
@@ -55717,7 +55717,7 @@ Used to illustrate the time that a certain action or situation began or will beg
   pos: suf
   defs:
     - def: "an intimate style declarative and interrogative suffix"
-      examples: 
+      examples:
         - example: "저기 책상 위에 저건 뭐야?"
           transliteration: "Jeogi chaeksang wie jeogeon mwoya?"
           translation: "What's that on the desk there?"
@@ -55829,7 +55829,7 @@ Used to illustrate the time that a certain action or situation began or will beg
   pos: n
   defs:
     - def: "vegetable"
-      examples: 
+      examples:
         - example: "야채와 과일에는 비타민이 많이 들어 있다."
           transliteration: " Yachaewa gwaireneun bitamini mani deureo itda."
           translation: "There are many vitamins in vegetables and fruit."
@@ -55852,7 +55852,7 @@ Used to illustrate the time that a certain action or situation began or will beg
   defs:
     - def: "to be showy, garish, loud"
     - def: "to be gaudy, sexy, indecent"
-      examples: 
+      examples:
         - example: "– 혹시 티팬티 있어요?– 야한 팬티 없어."
           transliteration: "– hoksi tipaenti isseoyo?– yahan paenti eopseo."
           translation: "– Do you, per chance, have thongs (t-panties)?– No, (we) don't have erotic panties."
@@ -55911,7 +55911,7 @@ Used to illustrate the time that a certain action or situation began or will beg
   pos: adv
   defs:
     - def: "a little, a bit; somewhat"
-      examples: 
+      examples:
         - example: "다리가 아직도 아픈가요?  지금은 아주 약간이요."
           transliteration: "Dariga ajikdo apeun-gayo?  Jigeumeun aju yakganiyo."
           translation: "Does your leg still hurt? - Just a bit now."
@@ -55940,7 +55940,7 @@ Used to illustrate the time that a certain action or situation began or will beg
   pos: n
   defs:
     - def: "miscellaneous symbols"
-      examples: 
+      examples:
         - example: "KS약물"
           transliteration: "KSyangmul"
 
@@ -55962,7 +55962,7 @@ Used to illustrate the time that a certain action or situation began or will beg
   pos: v
   defs:
     - def: "to promise"
-      examples: 
+      examples:
         - example: "그 여자는 친구에게 무엇을 약속하는가?"
           transliteration: "Geu yeojaneun chin-guege mueoseul yaksokhaneun-ga?"
           translation: "What does the woman promise her friend?"
@@ -56092,7 +56092,7 @@ Used to illustrate the time that a certain action or situation began or will beg
   pos: num
   defs:
     - def: "10"
-      examples: 
+      examples:
         - example: "(The addition of quotations indicative of this usage is being sought):"
 
 - word: 양
@@ -56176,7 +56176,7 @@ Used to illustrate the time that a certain action or situation began or will beg
   pos: n
   defs:
     - def: "Western clothing; a suit; a dress"
-      examples: 
+      examples:
         - example: "새 양복을 사고 싶다."
           transliteration: "Sae yangbogeul sago sipda."
           translation: "I want to get a new suit."
@@ -56217,7 +56217,7 @@ Used to illustrate the time that a certain action or situation began or will beg
   pos: n
   defs:
     - def: "A bisexual person"
-      examples: 
+      examples:
         - example: "제 아들은 양성애자입니다."
           transliteration: "Je adeureun yangseong-aejaimnida."
           translation: "My son is bisexual."
@@ -56312,7 +56312,7 @@ Used to illustrate the time that a certain action or situation began or will beg
   pos: n
   defs:
     - def: "both sides, both parties"
-      examples: 
+      examples:
         - example: "양쪽 얘기 모두 들어봐야 돼요."
           transliteration: "Yangjjok yaegi modu deureobwaya dwaeyo."
           translation: "There are two sides to every story."
@@ -56374,7 +56374,7 @@ Used to illustrate the time that a certain action or situation began or will beg
   pos: pron
   defs:
     - def: "this kid; he or she or you"
-      examples: 
+      examples:
         - example: "얘들아!"
           transliteration: "Yaedeura!"
           translation: "Hey kids!"
@@ -56384,7 +56384,7 @@ Used to illustrate the time that a certain action or situation began or will beg
   pos: n
   defs:
     - def: "contraction of 이야기 (iyagi): talk, story"
-      examples: 
+      examples:
         - example: "난 네가 무슨 얘기를 하는지 모르겠어."
           transliteration: "Nan nega museun yaegireul haneunji moreugesseo."
           translation: "I don't know  what you're talking about."
@@ -56394,7 +56394,7 @@ Used to illustrate the time that a certain action or situation began or will beg
   pos: v
   defs:
     - def: "to talk, to have a conversation"
-      examples: 
+      examples:
         - example: "잠깐 얘기하자."
           transliteration: "Jamkkan yaegihaja."
           translation: "Let's talk for a short time. (informal)"
@@ -56422,17 +56422,17 @@ Used to illustrate the time that a certain action or situation began or will beg
   pos: suf
   defs:
     - def: "and then, after"
-      examples: 
+      examples:
         - example: "포장을 뜯어 탁자 위에 올려 놓았다."
           transliteration: "Pojang-eul tteudeo takja wie ollyeo noatda."
           translation: "I removed the packaging and placed it on the table."
     - def: "and therefore, because"
-      examples: 
+      examples:
         - example: "꽃이 피어 기분이 좋다."
           transliteration: "Kkochi pieo gibuni jota."
           translation: "I feel good because the flower bloomed."
     - def: "by, by -ing; throughout"
-      examples: 
+      examples:
         - example: "색종이를 접어 돛단배를 만들어 봅시다."
           transliteration: "Saekjong-ireul jeobeo dotdanbaereul mandeureo bopsida."
           translation: "Let's make a sailing boat by folding colored paper!"
@@ -56442,7 +56442,7 @@ Used to illustrate the time that a certain action or situation began or will beg
   pos: suf
   defs:
     - def: "makes the infinitive form"
-      examples: 
+      examples:
         - example: "The infinitive form can be used to join a main verb and its auxiliary verb."
         - example: "꽃이 피어 있다."
           transliteration: "Kkochi pieo itda."
@@ -56451,7 +56451,7 @@ Used to illustrate the time that a certain action or situation began or will beg
           transliteration: "Naneun han-gugeoreul baewo ganda."
           translation: "I continue to learn Korean."
     - def: "an intimate style declarative, interrogative, hortative or imperative suffix"
-      examples: 
+      examples:
         - example: "안 받고 뭐 해? 받아."
           transliteration: "An batgo mwo hae? Bada."
           translation: "Why don't you receive it? Get it!"
@@ -56519,7 +56519,7 @@ Used to illustrate the time that a certain action or situation began or will beg
   pos: det
   defs:
     - def: "which"
-      examples: 
+      examples:
         - example: "어느 쪽이 당신의 자전거인가요?"
           transliteration: "Eoneu jjogi dangsinui jajeon-geoin-gayo?"
           translation: "Which is your bicycle?"
@@ -56527,7 +56527,7 @@ Used to illustrate the time that a certain action or situation began or will beg
           transliteration: "Eoneu sajeoneul joahasimnikka?"
           translation: "Which dictionary do you favour?"
     - def: "a certain, one, some"
-      examples: 
+      examples:
         - example: "형사는 그 아이가 자정이 지난 어느 시점에 유기된 것이라고 말했다."
           transliteration: "Hyeongsaneun geu aiga jajeong-i jinan eoneu sijeome yugidoen geosirago malhaetda."
           translation: "The detective said that the baby had been abandoned sometime after midnight."
@@ -56555,17 +56555,17 @@ Used to illustrate the time that a certain action or situation began or will beg
   pos: suf
   defs:
     - def: "even if, although"
-      examples: 
+      examples:
         - example: "죽어도 여한이 없다."
           transliteration: "Jugeodo yeohani eopda."
           translation: "I have no regrets even if I die."
     - def: "if; no matter"
-      examples: 
+      examples:
         - example: "뭘 해도 예쁘다."
           transliteration: "Mwol haedo yeppeuda."
           translation: "She's pretty whatever she does."
     - def: "Emphasizes the extent."
-      examples: 
+      examples:
         - example: "매워도 매워도 이렇게 매울 줄은!"
           transliteration: "Maewodo maewodo ireoke mae-ul jureun!"
           translation: "Didn't know it was hot this much!"
@@ -56589,7 +56589,7 @@ Used to illustrate the time that a certain action or situation began or will beg
   pos: pron
   defs:
     - def: "where"
-      examples: 
+      examples:
         - example: "공항까지 지하철을 타면 될 것 같은데 혹시 지하철이 어디 있는지 아세요?"
           transliteration: "Gonghangkkaji jihacheoreul tamyeon doel geot gateunde hoksi jihacheori eodi inneunji aseyo?"
           translation: "I think I can take the subway to the airport. Do you know where the subway is?"
@@ -56640,7 +56640,7 @@ Used to illustrate the time that a certain action or situation began or will beg
   pos: v
   defs:
     - def: "(what is one supposed to do)"
-      examples: 
+      examples:
         - example: "나 어떡해요?"
           transliteration: "Na eotteokhaeyo?"
           translation: "What am I going to do?"
@@ -56652,12 +56652,12 @@ Used to illustrate the time that a certain action or situation began or will beg
   defs:
     - def: "what kind of"
     - def: "some, any"
-      examples: 
+      examples:
         - example: "어떤 것이든 투자에는 위험 요소가 수반된다."
           transliteration: "Eotteon geosideun tuja-eneun wiheom yosoga subandoenda."
           translation: "Any investment involves an element of risk."
     - def: "certain, of a certain kind"
-      examples: 
+      examples:
         - example: "어떤 사물이나 일의 실제 모습이나 상태."
           transliteration: "Eotteon samurina irui silje moseubina sangtae."
           translation: "The true nature or state of a certain object or affair."
@@ -56667,7 +56667,7 @@ Used to illustrate the time that a certain action or situation began or will beg
   pos: adv
   defs:
     - def: "how; adverbial form of 어떻다 (eotteota)"
-      examples: 
+      examples:
         - example: "내가 그 시험에 어떻게 통과하지?"
           transliteration: "Naega geu siheome eotteoke tonggwahaji?"
           translation: "How can I pass the exam?"
@@ -56675,7 +56675,7 @@ Used to illustrate the time that a certain action or situation began or will beg
           transliteration: "Annyeong, piteu. Eotteoke jinae? Annyeong ana. Joa. Neon eotteoke jinae? Goengjanghi jal jinae."
           translation: "Oh, hi, Pete. How’s it going? —  Hi, Anna. It’s going great. How’s it going with you? — Things are awesome!"
     - def: "(어떻게 되다) what is … ?"
-      examples: 
+      examples:
         - example: "성함이 어떻게 되세요?"
           transliteration: "Seonghami eotteoke doeseyo?"
           translation: "What is your name?"
@@ -56691,7 +56691,7 @@ Used to illustrate the time that a certain action or situation began or will beg
   pos: a
   defs:
     - def: "(to be) in what state; (to be) how"
-      examples: 
+      examples:
         - example: "어떻습니까?"
           transliteration: "Eotteoseumnikka?"
           translation: "How is that?"
@@ -56708,12 +56708,12 @@ Used to illustrate the time that a certain action or situation began or will beg
   pos: suf
   defs:
     - def: "(informal) a plain style imperative ending"
-      examples: 
+      examples:
         - example: "천천히 먹어라. 체할라."
           transliteration: "Cheoncheonhi meogeora. Chehalla."
           translation: "Slow down; you may suffer from indigestion."
     - def: "(dated) an exclamatory ending"
-      examples: 
+      examples:
         - example: "어머, 귀여워라. 너 몇 살이니?"
           transliteration: "Eomeo, gwiyeowora. Neo myeot sarini?"
           translation: "Oh, so cute! How old are you, kid?"
@@ -56741,7 +56741,7 @@ Used to illustrate the time that a certain action or situation began or will beg
   pos: a
   defs:
     - def: "difficult, hard"
-      examples: 
+      examples:
         - example: "시험이 어려웠니?"
           transliteration: "Siheomi eoryeowonni?"
           translation: "Was the examination difficult?"
@@ -56847,7 +56847,7 @@ Used to illustrate the time that a certain action or situation began or will beg
   pos: intj
   defs:
     - def: "oh, my goodness (usually used by women)"
-      examples: 
+      examples:
         - example: "어머, 머릿결이 참 좋네요."
           transliteration: "Eomeo, meoritgyeori cham jonneyo."
           translation: "Oh, my goodness, the condition of your hair is great."
@@ -56857,7 +56857,7 @@ Used to illustrate the time that a certain action or situation began or will beg
   pos: intj
   defs:
     - def: "oh, my!"
-      examples: 
+      examples:
         - example: "어머나, 이게 너야?!"
           transliteration: "Eomeona, ige neoya?!"
           translation: "Oh my!, is that you?!"
@@ -56879,17 +56879,17 @@ Used to illustrate the time that a certain action or situation began or will beg
   pos: n
   defs:
     - def: "mother"
-      examples: 
+      examples:
         - example: "어미 속 좀 그만 썩여라."
           transliteration: "Eomi sok jom geuman sseogyeora."
           translation: "Don't make mum worry too much."
     - def: "A casual way used by a father to address his wife in front of elders."
-      examples: 
+      examples:
         - example: "영철이 어미는 도대체 어디를 나갔습니까?"
           transliteration: "Yeongcheori eomineun dodaeche eodireul nagatseumnikka?"
           translation: "Wifey, where the hell did Yeongcheol go?"
     - def: "dam; mother animal"
-      examples: 
+      examples:
         - example: "어미 호랑이"
           transliteration: "eomi horang-i"
           translation: "mother tiger"
@@ -56945,17 +56945,17 @@ Used to illustrate the time that a certain action or situation began or will beg
   pos: suf
   defs:
     - def: "and then"
-      examples: 
+      examples:
         - example: "살아서 봅시다."
           transliteration: "Saraseo bopsida."
           translation: "See you alive!"
     - def: "and therefore, because"
-      examples: 
+      examples:
         - example: "아유, 없어서 못 먹지."
           transliteration: "Ayu, eopseoseo mot meokji."
           translation: "Aw, he doesn't eat it only when there's nothing."
     - def: "by; by -ing"
-      examples: 
+      examples:
         - example: "학교요? 걸어서 가는데요."
           transliteration: "Hakgyoyo? Georeoseo ganeundeyo."
           translation: "School? I go there on foot."
@@ -56965,10 +56965,10 @@ Used to illustrate the time that a certain action or situation began or will beg
   pos: suf
   defs:
     - def: "Only when ... (A connective ending used when the preceding statement is an essential condition for the following statement.)"
-      examples: 
+      examples:
         - example: "건강하게 먹어야 행복하게 산다. (Geon-ganghage meogeoya haengbokhage sanda., “You live happy only when you eat healthy.”)"
     - def: "Even when ... (A connective ending used when the preceding assumption has no influence in the end.)"
-      examples: 
+      examples:
         - example: "길어야 1년을 안 넘길 테니 걱정할 것 없어. (Gireoya 1nyeoneul an neomgil teni geokjeonghal geot eopseo., “You don't have to worry since it won't take more than a year even when the longest.”)"
 
 - word: 어여머리
@@ -56996,7 +56996,7 @@ Used to illustrate the time that a certain action or situation began or will beg
   pos: suf
   defs:
     - def: "a polite style declarative, interrogative, hortative, and imperative ending"
-      examples: 
+      examples:
         - example: "이 집 고기가 그렇게 부드러울 수가 없어요. 안 먹어 보면 후회할지도 몰라요?"
           transliteration: "I jip gogiga geureoke budeureoul suga eopseoyo. An meogeo bomyeon huhoehaljido mollayo?"
           translation: "The meat here is impossibly tender! You may regret it if you don't have a try!"
@@ -57040,7 +57040,7 @@ Used to illustrate the time that a certain action or situation began or will beg
   pos: intj
   defs:
     - def: "hey! (for calling a person of the same status or lower in an informal way)"
-      examples: 
+      examples:
         - example: "어이, 나 좀 도와줘."
           transliteration: " Eoi, na jom dowajwo."
           translation: "Hey, help me out a bit."
@@ -57083,7 +57083,7 @@ Used to illustrate the time that a certain action or situation began or will beg
   pos: n
   defs:
     - def: "language family"
-      examples: 
+      examples:
         - example: "인도유럽 어족"
           transliteration: "indoyureop eojok"
           translation: "Indo-European language family"
@@ -57142,7 +57142,7 @@ Used to illustrate the time that a certain action or situation began or will beg
   pos: adv
   defs:
     - def: "How, in what way or for what purpose."
-      examples: 
+      examples:
         - example: "아나: 피트 안녕. 안녕. 우리 여기 있어. — 피트: 안녕, 아나. 안녕. 마샤. —아나: 안녕. —피트: 너희 둘은 어찌 지내? —마샤: 난 좋아."
           transliteration: "Ana: piteu annyeong. Annyeong. Uri yeogi isseo.  piteu: annyeong, ana. Annyeong. Masya. Ana: annyeong. Piteu: neohui dureun eojji jinae? Masya: nan joa."
           translation: "Anna: Pete, hi! Hi, we are here! —Pete: Hi, Anna! Hi, Marsha! —Anna: Hi! —Pete: How are you two? —Marsha: I am great!"
@@ -57171,7 +57171,7 @@ Used to illustrate the time that a certain action or situation began or will beg
   pos: n
   defs:
     - def: "branch/group of languages"
-      examples: 
+      examples:
         - example: "슬라브 어파"
           transliteration: "seullabeu eopa"
           translation: "Slavic languages"
@@ -57224,7 +57224,7 @@ Used to illustrate the time that a certain action or situation began or will beg
   pos: v
   defs:
     - def: "to mention; state; talk about"
-      examples: 
+      examples:
         - example: "왕 씨는 한때 얼음으로 뒤덮였던 지역에 꽃이 뿌리를 내리고 자란다고 언급한다."
           transliteration: "Wang ssineun hanttae eoreumeuro dwideopyeotdeon jiyeoge kkochi ppurireul naerigo jarandago eon-geuphanda."
           translation: "Wang notes that flowers have rooted and grow in the area once covered with ice."
@@ -57289,7 +57289,7 @@ Used to illustrate the time that a certain action or situation began or will beg
   pos: n
   defs:
     - def: "language"
-      examples: 
+      examples:
         - example: "몇 가지 언어를 하실 수 있으세요?"
           transliteration: "Myeot gaji eoneoreul hasil su isseuseyo?"
           translation: "How many languages do you speak?"
@@ -57305,7 +57305,7 @@ Used to illustrate the time that a certain action or situation began or will beg
   pos: pron
   defs:
     - def: "When"
-      examples: 
+      examples:
         - example: "언제가 네 생일이니?"
           transliteration: " Eonjega ne saeng-irini?"
           translation: "When is your birthday?"
@@ -57316,7 +57316,7 @@ Used to illustrate the time that a certain action or situation began or will beg
   defs:
     - def: "when"
     - def: "sometime, any time"
-      examples: 
+      examples:
         - example: "언제 한 번 만나 소주 한 잔 합시다."
           transliteration: " Eonje han beon manna soju han jan hapsida."
           translation: "Let's get together and have a glass of soju some time."
@@ -57359,7 +57359,7 @@ Used to illustrate the time that a certain action or situation began or will beg
   pos: v
   defs:
     - def: "to get, to receive, to obtain, to have (an object)"
-      examples: 
+      examples:
         - example: "그는 런던에 새로 문을 여는 한 회사에서 광고 부문 중역으로서의 일자리를 얻었다."
           transliteration: "Geuneun reondeone saero muneul yeoneun han hoesa-eseo gwanggo bumun jung-yeogeuroseoui iljarireul eodeotda."
           translation: "He got a new position as advertising executive for a new firm opening in London."
@@ -57449,7 +57449,7 @@ Used to illustrate the time that a certain action or situation began or will beg
   pos: adv
   defs:
     - def: "quickly, at once, without delay"
-      examples: 
+      examples:
         - example: "얼른 가 봐! — Come have a look!"
 
 - word: 얼마
@@ -57457,7 +57457,7 @@ Used to illustrate the time that a certain action or situation began or will beg
   pos: n
   defs:
     - def: "how much, how many"
-      examples: 
+      examples:
         - example: "이거 얼마에요?"
           transliteration: "Igeo eolmaeyo?"
           translation: "How much does it cost?"
@@ -57469,7 +57469,7 @@ Used to illustrate the time that a certain action or situation began or will beg
   pos: adv
   defs:
     - def: "how long, how much, how many"
-      examples: 
+      examples:
         - example: "여기에 계신 지 얼마나 되셨어요? —두달이요."
           transliteration: "Yeogie gyesin ji eolmana doesyeosseoyo? Dudariyo."
           translation: "How long have you been here? ━ two months."
@@ -57653,7 +57653,7 @@ Used to illustrate the time that a certain action or situation began or will beg
   pos: n
   defs:
     - def: "business, work, task, duty, business operations, service"
-      examples: 
+      examples:
         - example: "그를 담당한 의사들은 업무 일정을 좀 줄이라고 그에게 말했다."
           transliteration: "Geureul damdanghan uisadeureun eommu iljeong-eul jom jurirago geuege malhaetda."
           translation: "His doctors told him to cut down on his work schedule."
@@ -57750,7 +57750,7 @@ Used to illustrate the time that a certain action or situation began or will beg
   pos: suf
   defs:
     - def: "-ed (past tense marker for sentence-final verbs and adjectives)"
-      examples: 
+      examples:
         - example: "그것들은 정말 간단한 것들이었다."
           transliteration: "Geugeotdeureun jeongmal gandanhan geotdeurieotda."
           translation: "They were really simple things."
@@ -57766,7 +57766,7 @@ Used to illustrate the time that a certain action or situation began or will beg
   pos: n
   defs:
     - def: "a fall on one's backside; a pratfall"
-      examples: 
+      examples:
         - example: "엉덩방아를 찧다"
           transliteration: "eongdeongbang-areul jjita"
           translation: "(fall backwards and) land on one's rear end; literally, \"pound with the backside pestle\""
@@ -57828,12 +57828,12 @@ Used to illustrate the time that a certain action or situation began or will beg
   pos: part
   defs:
     - def: "at"
-      examples: 
+      examples:
         - example: "안녕, 앤, 바빠? — 안녕, 아나, 맞아, 오전 10(열)시에는, 난 글을 써."
           transliteration: "Annyeong, aen, bappa?  annyeong, ana, maja, ojeon 10(yeol)sieneun, nan geureul sseo."
           translation: "Hi, Anne. Are you busy? — Hi, Anna. Yes. At 10 a.m. I am writing."
     - def: "to"
-      examples: 
+      examples:
         - example: "어디에 가요?"
           transliteration: "Eodie gayo?"
           translation: "Where are you going to?"
@@ -57846,7 +57846,7 @@ Used to illustrate the time that a certain action or situation began or will beg
   pos: part
   defs:
     - def: "the dative particle; to"
-      examples: 
+      examples:
         - example: "엄마에게 전화를 했습니다."
           transliteration: "Eommaege jeonhwareul haetseumnida."
           translation: "I called my mother."
@@ -57856,7 +57856,7 @@ Used to illustrate the time that a certain action or situation began or will beg
   pos: n
   defs:
     - def: "energy"
-      examples: 
+      examples:
         - example: "애슐리 존슨은 미국에 기반을 두고 있는 국립 아시아 연구소의 에너지, 무역 및 경제학 전문가이다."
           transliteration: "Aesyulli jonseuneun miguge gibaneul dugo inneun gungnip asia yeon-gusoui eneoji, muyeok mit gyeongjehak jeonmun-gaida."
           translation: "Ashley Johnson is an energy, trade and economics expert at the National Bureau of Asian Research, based in the United States."
@@ -57992,7 +57992,7 @@ Used to illustrate the time that a certain action or situation began or will beg
   pos: n
   defs:
     - def: "AIDS"
-      examples: 
+      examples:
         - example: "에이즈 백신을 개발하고 있다."
           transliteration: "Eijeu baeksineul gaebalhago itda."
           translation: "We are developing a vaccine against AIDS."
@@ -58002,7 +58002,7 @@ Used to illustrate the time that a certain action or situation began or will beg
   pos: intj
   defs:
     - def: "damn, geez, o, eh"
-      examples: 
+      examples:
         - example: "에잇, 속상해."
           transliteration: "Eit, soksanghae."
           translation: "Damn, this is annoying."
@@ -58178,7 +58178,7 @@ Used to illustrate the time that a certain action or situation began or will beg
   pos: pron
   defs:
     - def: "here"
-      examples: 
+      examples:
         - example: "그래, 나 여기 있어. — 좋아, 너 거기 있구나."
           transliteration: "Geurae, na yeogi isseo. — joa, neo geogi itguna."
           translation: "Oh, yes. I am here! — Good. You are there."
@@ -58306,7 +58306,7 @@ Used to illustrate the time that a certain action or situation began or will beg
   pos: n
   defs:
     - def: "(my) darling, honey, sweetheart"
-      examples: 
+      examples:
         - example: "여보, 손님 오셨어요."
           transliteration: "Yeobo, sonnim osyeosseoyo."
           translation: "Honey, you have a visitor."
@@ -58368,7 +58368,7 @@ Used to illustrate the time that a certain action or situation began or will beg
   pos: suf
   defs:
     - def: "A connective ending used when the preceding statement is an essential condition for the following statement."
-      examples: 
+      examples:
         - example: "나는 어떻게 그것을 말해야 할지 모르겠다."
           transliteration: "Naneun eotteoke geugeoseul malhaeya halji moreugetda."
           translation: "I don’t know how to say it."
@@ -58545,7 +58545,7 @@ Used to illustrate the time that a certain action or situation began or will beg
   pos: v
   defs:
     - def: "to travel"
-      examples: 
+      examples:
         - example: "여행하는 동안"
           transliteration: "yeohaenghaneun dong-an"
           translation: "during the  traveling (at present)"
@@ -58556,7 +58556,7 @@ Used to illustrate the time that a certain action or situation began or will beg
   pos: propn
   defs:
     - def: "Jehovah"
-      examples: 
+      examples:
         - example: "여호와의 말씀이 또 내게 임하여 가라사대."
           transliteration: "Yeohowaui malsseumi tto naege imhayeo garasadae."
           translation: "The word of the Lord came again unto me, saying,"
@@ -58575,7 +58575,7 @@ Used to illustrate the time that a certain action or situation began or will beg
   pos: a
   defs:
     - def: "sickening; revolting; nauseating"
-      examples: 
+      examples:
         - example: "그 사람 보기만 해도 역겨워."
           transliteration: "Geu saram bogiman haedo yeokgyeowo."
           translation: "It makes me sick just looking at him."
@@ -58618,7 +58618,7 @@ Used to illustrate the time that a certain action or situation began or will beg
   pos: n
   defs:
     - def: "history"
-      examples: 
+      examples:
         - example: "역사가 시작된 후로"
           transliteration: "yeoksaga sijakdoen huro"
           translation: "since the beginning of history"
@@ -58667,7 +58667,7 @@ Used to illustrate the time that a certain action or situation began or will beg
   pos: n
   defs:
     - def: "a role or part"
-      examples: 
+      examples:
         - example: "네가 떠나기 전에 네 역할에 관하여 브리핑을 하겠다."
           transliteration: "Nega tteonagi jeone ne yeokhare gwanhayeo beuriping-eul hagetda."
           translation: "I will give you a briefing about your role before you leave."
@@ -58738,7 +58738,7 @@ Used to illustrate the time that a certain action or situation began or will beg
   pos: v
   defs:
     - def: "To be researched; be studied"
-      examples: 
+      examples:
         - example: "2015년, 과학자들은, 중국에서 연구된 빙하의 82퍼센트의 크기가 감소하였다는 것을 발견하였다."
           transliteration: "2015nyeon, gwahakjadeureun, junggugeseo yeon-gudoen binghaui 82peosenteuui keugiga gamsohayeotdaneun geoseul balgyeonhayeotda."
           translation: "In 2015, scientists found that 82 percent of glaciers studied in China had decreased in size."
@@ -58749,7 +58749,7 @@ Used to illustrate the time that a certain action or situation began or will beg
   pos: n
   defs:
     - def: "A research institute."
-      examples: 
+      examples:
         - example: "왕 씨와 그의 팀이 머무르는 연구소는 인구 백이십(120)만명이 사는 도시 리장의 외곽에 있다."
           transliteration: "Wang ssiwa geuui timi meomureuneun yeon-gusoneun in-gu baegisip(120)manmyeong-i saneun dosi rijang-ui oegwage itda."
           translation: "The research station that houses Wang and his team is outside Lijiang, a city of about 1.2 million people."
@@ -58826,7 +58826,7 @@ Used to illustrate the time that a certain action or situation began or will beg
   pos: n
   defs:
     - def: "time period"
-      examples: 
+      examples:
         - example: "전시한 고대 문물은 모두 연대를 표시하였다."
           transliteration: "Jeonsihan godae munmureun modu yeondaereul pyosihayeotda."
           translation: "All of the ancient artifacts displayed had their time period marked."
@@ -58849,7 +58849,7 @@ Used to illustrate the time that a certain action or situation began or will beg
   defs:
     - def: "to notify; communicate; speak to"
     - def: "to contact; make contact; get in touch"
-      examples: 
+      examples:
         - example: "연락드릴께요."
           transliteration: "Yeollakdeurilkkeyo."
           translation: "I'll be in touch."
@@ -58921,7 +58921,7 @@ Used to illustrate the time that a certain action or situation began or will beg
   pos: n
   defs:
     - def: "speech; address; oration"
-      examples: 
+      examples:
         - example: "의장의 연설은 어땠어요? ―저는 아주 감동했어요."
           transliteration: "Uijang-ui yeonseoreun eottaesseoyo? ―jeoneun aju gamdonghaesseoyo."
           translation: "What do you think of the chairman's speech? ― I was quite impressed."
@@ -59134,7 +59134,7 @@ Used to illustrate the time that a certain action or situation began or will beg
   defs:
     - def: "fever"
     - def: "heat"
-      examples: 
+      examples:
         - example: "저리고쓰린 슬픔은 힘이 되고 열이 되어서 어린 양과 같은 작은 목숨을 살아 움직이게 합니다."
           transliteration: "Jeorigosseurin seulpeumeun himi doego yeori doeeoseo eorin yanggwa gateun jageun moksumeul sara umjigige hamnida."
           translation: "The bitter sadness has become a force and a heat that makes a little life like a lamb move alive."
@@ -59249,12 +59249,12 @@ Used to illustrate the time that a certain action or situation began or will beg
   pos: n
   defs:
     - def: "key"
-      examples: 
+      examples:
         - example: "열쇠로 자물쇠를 열다"
           transliteration: "yeolsoero jamulsoereul yeolda"
           translation: "open a lock with a key"
     - def: "means"
-      examples: 
+      examples:
         - example: "행복의 열쇠"
           transliteration: "haengbogui yeolsoe"
           translation: "the key to happiness"
@@ -59481,7 +59481,7 @@ Used to illustrate the time that a certain action or situation began or will beg
   pos: n
   defs:
     - def: "yeot: a kind of Korean traditional confectionery"
-      examples: 
+      examples:
         - example: "엿 먹어라/먹어"
           transliteration: "yeot meogeora/meogeo"
           translation: "(vulgar) fuck you; literally “eat yeot”"
@@ -59556,7 +59556,7 @@ Used to illustrate the time that a certain action or situation began or will beg
   pos: n
   defs:
     - def: "English, British (person)"
-      examples: 
+      examples:
         - example: "나는 영국인이다."
           transliteration: "Naneun yeongguginida."
           translation: "I am English."
@@ -59645,7 +59645,7 @@ Used to illustrate the time that a certain action or situation began or will beg
   pos: n
   defs:
     - def: "the English language"
-      examples: 
+      examples:
         - example: "영어를 못합니다."
           transliteration: "Yeong-eoreul mothamnida."
           translation: "I don't speak English."
@@ -59773,7 +59773,7 @@ Used to illustrate the time that a certain action or situation began or will beg
   pos: n
   defs:
     - def: "side, flank, vicinity"
-      examples: 
+      examples:
         - example: "옆에 앉아도 될까요?"
           transliteration: "Yeope anjado doelkkayo?"
           translation: "Do you mind if I sit next to you?"
@@ -59789,7 +59789,7 @@ Used to illustrate the time that a certain action or situation began or will beg
   pos: intj
   defs:
     - def: "yes"
-      examples: 
+      examples:
         - example: "그래, 알았다."
           transliteration: "Geurae, aratda."
           translation: "Yes, so be it."
@@ -59811,7 +59811,7 @@ Used to illustrate the time that a certain action or situation began or will beg
   pos: n
   defs:
     - def: "the past, old times"
-      examples: 
+      examples:
         - example: "예로부터 우리나라는 동방예의지국으로 알려져왔다."
           transliteration: "Yerobuteo urinaraneun dongbang-ye-uijigugeuro allyeojyeowatda."
           translation: "Since the ancient times, Korea has been known for having courteous people."
@@ -59821,7 +59821,7 @@ Used to illustrate the time that a certain action or situation began or will beg
   pos: pron
   defs:
     - def: "here"
-      examples: 
+      examples:
         - example: "예가 어디라고 감히 찾아와!"
           transliteration: "Yega eodirago gamhi chajawa!"
           translation: "How dare you show up here! Where do you think here is!"
@@ -59903,7 +59903,7 @@ Used to illustrate the time that a certain action or situation began or will beg
   pos: a
   defs:
     - def: "to be pretty, lovely, beautiful, comely"
-      examples: 
+      examples:
         - example: "리나는 예쁘기 때문에 모두들 그녀를 좋아합니다."
           transliteration: "Rinaneun yeppeugi ttaemune modudeul geunyeoreul joahamnida."
           translation: "Lina is so beautiful that everybody likes her."
@@ -59940,7 +59940,7 @@ Used to illustrate the time that a certain action or situation began or will beg
   pos: v
   defs:
     - def: "to expect, to anticipate, to predict"
-      examples: 
+      examples:
         - example: "수요일에 트위터와 페이스북에서, 사람들은 그들이 선호하는 강아지들을 평하였고, 올해의 퍼피볼에 대해서 예상하였습니다."
           transliteration: "Suyoire teuwiteowa peiseubugeseo, saramdeureun geudeuri seonhohaneun gang-ajideureul pyeonghayeotgo, olhae-ui peopibore daehaeseo  yesanghayeotseumnida."
           translation: "On Twitter and Facebook Wednesday, people commented about their favorite puppies and made predictions for this year’s Puppy Bowl."
@@ -59975,7 +59975,7 @@ Used to illustrate the time that a certain action or situation began or will beg
   pos: n
   defs:
     - def: "art, fine art"
-      examples: 
+      examples:
         - example: "그 화랑에는 많은 예술 작품이 있다."
           transliteration: "Geu hwarang-eneun maneun yesul jakpumi itda."
           translation: "The gallery has many pieces of art."
@@ -60033,7 +60033,7 @@ Used to illustrate the time that a certain action or situation began or will beg
   pos: n
   defs:
     - def: "manners; etiquette"
-      examples: 
+      examples:
         - example: "그는 예의가 없어요."
           transliteration: "Geuneun ye-uiga eopseoyo."
           translation: "He has no manners."
@@ -60119,7 +60119,7 @@ Used to illustrate the time that a certain action or situation began or will beg
   defs:
     - def: "five"
     - def: "fifth"
-      examples: 
+      examples:
         - example: "인간은 한 손, 한 발에 각각 다섯개의 손가락, 발가락을 가지고 있다."
           transliteration: "In-ganeun han son, han bare gakgak daseotgae-ui son-garak, balgarageul gajigo itda."
           translation: "Humans have five fingers and toes on each hand and foot."
@@ -60181,7 +60181,7 @@ Used to illustrate the time that a certain action or situation began or will beg
   pos: n
   defs:
     - def: "today; this day"
-      examples: 
+      examples:
         - example: "오늘은 4(사)월 3(삼)일입니다."
           transliteration: "Oneureun 4(sa)wol 3(sam)irimnida."
           translation: "Today is the April 3rd."
@@ -60201,7 +60201,7 @@ Used to illustrate the time that a certain action or situation began or will beg
   pos: v
   defs:
     - def: "To come"
-      examples: 
+      examples:
         - example: "파티에 와서 고마워."
           transliteration: "Patie waseo gomawo."
           translation: "Thanks for coming to the party."
@@ -60209,7 +60209,7 @@ Used to illustrate the time that a certain action or situation began or will beg
           transliteration: "Toyoire uri baendeu yeonjureul boreo oseyo."
           translation: "Come see my band perform Saturday."
     - def: "(of rain, snow etc) to fall"
-      examples: 
+      examples:
         - example: "비가 온다."
           transliteration: "Biga onda."
           translation: "It's raining. (Literally, \"Rain comes.\")"
@@ -60293,7 +60293,7 @@ Used to illustrate the time that a certain action or situation began or will beg
   pos: n
   defs:
     - def: "barbarian; uncivilised people"
-      examples: 
+      examples:
         - example: "그는 왕명을 받들고 오랑캐를 토벌하러 북으로 갔다."
           transliteration: "Geuneun wangmyeong-eul batdeulgo orangkaereul tobeolhareo bugeuro gatda."
           translation: "He followed the emperor's orders and marched north to subdue the barbarians."
@@ -60319,7 +60319,7 @@ Used to illustrate the time that a certain action or situation began or will beg
   pos: n
   defs:
     - def: "the first occurrence after a long absence"
-      examples: 
+      examples:
         - example: "오래간만 입니다!"
           transliteration: " Oraeganman imnida!"
           translation: "Long time, no see! (literally, \"It has been a long time!\")"
@@ -60329,7 +60329,7 @@ Used to illustrate the time that a certain action or situation began or will beg
   pos: a
   defs:
     - def: "(to be) long continued; having experienced a long duration (since the previous occurrence or some specific event)"
-      examples: 
+      examples:
         - example: "오랜만이지요?"
           transliteration: "Oraenmanijiyo?"
           translation: "It has been a long time. [Since the last time we saw each other, hasn't it?]"
@@ -60469,7 +60469,7 @@ Used to illustrate the time that a certain action or situation began or will beg
   pos: n
   defs:
     - def: "right-hand; the right side"
-      examples: 
+      examples:
         - example: "오른쪽으로 돌다"
           transliteration: "oreunjjogeuro dolda"
           translation: "turn right"
@@ -60520,7 +60520,7 @@ Used to illustrate the time that a certain action or situation began or will beg
   pos: v
   defs:
     - def: "To come"
-      examples: 
+      examples:
         - example: "파티에 와서 고마워."
           transliteration: "Patie waseo gomawo."
           translation: "Thanks for coming to the party."
@@ -60528,7 +60528,7 @@ Used to illustrate the time that a certain action or situation began or will beg
           transliteration: "Toyoire uri baendeu yeonjureul boreo oseyo."
           translation: "Come see my band perform Saturday."
     - def: "(of rain, snow etc) to fall"
-      examples: 
+      examples:
         - example: "비가 온다."
           transliteration: "Biga onda."
           translation: "It's raining. (Literally, \"Rain comes.\")"
@@ -60585,12 +60585,12 @@ Used to illustrate the time that a certain action or situation began or will beg
   pos: n
   defs:
     - def: "elder brother of a female"
-      examples: 
+      examples:
         - example: "니 오빠는 정말 착한 학생이고 절대로 텔레비전은 안 봐."
           transliteration: "Ni oppaneun jeongmal chakhan haksaeng-igo jeoldaero tellebijeoneun an bwa."
           translation: "Your brother is such a good student and he never watches TV."
     - def: "a close elder male, an elder boyfriend"
-      examples: 
+      examples:
         - example: "오빠의 페이스북 친구 중에서 정말 친구는 몇 명이나 돼?"
           transliteration: "Oppaui Peiseubuk chin-gu jung-eseo jeongmal chin-guneun myeot myeong-ina dwae?"
           translation: "How many of your Facebook friends are your real friends?"
@@ -60835,7 +60835,7 @@ Used to illustrate the time that a certain action or situation began or will beg
   pos: n
   defs:
     - def: "p.m."
-      examples: 
+      examples:
         - example: "아나. — 네, 위버님. — 바빠요? —네, 위버님. 바쁩니다. — 내 사무실로 오후 5시에 오세요. — 오후 5시요."
           transliteration: "Ana.  ne, wibeonim.  bappayo? Ne, wibeonim. Bappeumnida.  nae samusillo ohu 5sie oseyo.  ohu 5siyo."
           translation: "Anna. — Yes, Ms. Weaver. — Are you busy? — Yes, Ms. Weaver. I am busy. — My office. 5:00 p.m. —  5:00 p.m."
@@ -60981,7 +60981,7 @@ Used to illustrate the time that a certain action or situation began or will beg
   pos: det
   defs:
     - def: "all; every; all kinds of"
-      examples: 
+      examples:
         - example: "그는 온갖 음해에 시달렸다."
           transliteration: "Geuneun on-gat eumhaee sidallyeotda."
           translation: "He suffered all kinds of slanders."
@@ -61063,7 +61063,7 @@ Used to illustrate the time that a certain action or situation began or will beg
   pos: det
   defs:
     - def: "(in) this year"
-      examples: 
+      examples:
         - example: "올 설날 선물"
           translation: "A present for Seolnal this year."
 
@@ -61072,7 +61072,7 @@ Used to illustrate the time that a certain action or situation began or will beg
   pos: det
   defs:
     - def: "Future determiner of 오다 (oda, “to come”), thus coming (in the future)."
-      examples: 
+      examples:
         - example: "그가 올 시간"
           transliteration: "geu-ga ol sigan"
           translation: "the time when he will come"
@@ -61088,7 +61088,7 @@ Used to illustrate the time that a certain action or situation began or will beg
   pos: v
   defs:
     - def: "to go up, to ascend, to rise or increase"
-      examples: 
+      examples:
         - example: "그들은 계단을 올라가고 있다."
           transliteration: "Geudeureun gyedaneul ollagago itda."
           translation: "They are walking up the steps."
@@ -61212,7 +61212,7 @@ Used to illustrate the time that a certain action or situation began or will beg
   pos: a
   defs:
     - def: "to be right, true, correct"
-      examples: 
+      examples:
         - example: "옳은 일을 하다"
           transliteration: "oreun ireul hada"
           translation: "to do the right thing"
@@ -61223,7 +61223,7 @@ Used to illustrate the time that a certain action or situation began or will beg
   pos: intj
   defs:
     - def: "all right; OK"
-      examples: 
+      examples:
         - example: "옳다, 이제 알았다."
           transliteration: "Olta, ije aratda."
           translation: "OK, now I get it."
@@ -61245,7 +61245,7 @@ Used to illustrate the time that a certain action or situation began or will beg
   pos: n
   defs:
     - def: "scab, scabies, (mammal) mange."
-      examples: 
+      examples:
         - example: "옴 덕에 보지 긁는다. 사타구니 긁다 보지 긁는다."
           transliteration: "Om deoge boji geungneunda. Sataguni geukda boji geungneunda."
           translation: "Scabies justify her to scratch her pubes. She scratches her pubes as well as itchy thigh."
@@ -61290,7 +61290,7 @@ Used to illustrate the time that a certain action or situation began or will beg
   pos: n
   defs:
     - def: "clothing, clothes"
-      examples: 
+      examples:
         - example: "옷이 날개다"
           transliteration: "osi nalgaeda"
           translation: "The better dressed, the brighter looking. Literally, clothing is a wing."
@@ -61325,7 +61325,7 @@ Used to illustrate the time that a certain action or situation began or will beg
   defs:
     - def: "and"
     - def: "with; together with"
-      examples: 
+      examples:
         - example: "우유와 딸기"
           transliteration: "uyuwa ttalgi"
           translation: "milk with strawberries"
@@ -61336,7 +61336,7 @@ Used to illustrate the time that a certain action or situation began or will beg
   pos: intj
   defs:
     - def: "An expression of awe or excitement."
-      examples: 
+      examples:
         - example: "와, 여름이다!"
           transliteration: "Wa, yeoreumida!"
           translation: "Hurray, it's summer!"
@@ -61370,7 +61370,7 @@ Used to illustrate the time that a certain action or situation began or will beg
   pos: v
   defs:
     - def: "To come"
-      examples: 
+      examples:
         - example: "파티에 와서 고마워."
           transliteration: "Patie waseo gomawo."
           translation: "Thanks for coming to the party."
@@ -61378,7 +61378,7 @@ Used to illustrate the time that a certain action or situation began or will beg
           transliteration: "Toyoire uri baendeu yeonjureul boreo oseyo."
           translation: "Come see my band perform Saturday."
     - def: "(of rain, snow etc) to fall"
-      examples: 
+      examples:
         - example: "비가 온다."
           transliteration: "Biga onda."
           translation: "It's raining. (Literally, \"Rain comes.\")"
@@ -61616,7 +61616,7 @@ Used to illustrate the time that a certain action or situation began or will beg
   pos: adv
   defs:
     - def: "why"
-      examples: 
+      examples:
         - example: "너는 이 가수를 왜 좋아하지?"
           transliteration: "Neoneun i gasureul wae joahaji?"
           translation: "Why do you like this singer?"
@@ -61652,7 +61652,7 @@ Used to illustrate the time that a certain action or situation began or will beg
   pos: adv
   defs:
     - def: "because; for the following reason."
-      examples: 
+      examples:
         - example: "오늘 집에 일찍 가야 한다. 왜냐하면 아내가 아프기 때문이다."
           transliteration: "Oneul jibe iljjik gaya handa. Waenyahamyeon anaega apeugi ttaemunida."
           translation: "[I] have to go home early today. It's because [my] wife is sick."
@@ -61662,7 +61662,7 @@ Used to illustrate the time that a certain action or situation began or will beg
   pos: n
   defs:
     - def: "a Japanese female; a Jap girl"
-      examples: 
+      examples:
         - example: "여기는 어째 이렇게 왜놈 왜년이 많나?"
           transliteration: "Yeogineun eojjae ireoke waenom waenyeoni manna?"
           translation: "Why are there so many Japs here?"
@@ -61697,7 +61697,7 @@ Used to illustrate the time that a certain action or situation began or will beg
   pos: adv
   defs:
     - def: "(informal) Why so? Why .... like this?"
-      examples: 
+      examples:
         - example: "왜케 진지해?"
           translation: "Why so serious?"
 
@@ -61718,7 +61718,7 @@ Used to illustrate the time that a certain action or situation began or will beg
   pos: n
   defs:
     - def: "other things"
-      examples: 
+      examples:
         - example: "그외에"
           transliteration: "geuoee"
           translation: "apart from that"
@@ -61944,7 +61944,7 @@ Used to illustrate the time that a certain action or situation began or will beg
   pos: part
   defs:
     - def: "(Sentence-final particle for verbs and adjectives in the 해요체 (haeyoche, “polite”) speech level)"
-      examples: 
+      examples:
         - example: "해요"
           transliteration: "haeyo"
           translation: "does"
@@ -61996,7 +61996,7 @@ Used to illustrate the time that a certain action or situation began or will beg
   pos: v
   defs:
     - def: "to demand, to require, to request"
-      examples: 
+      examples:
         - example: "난 돈을 요구하는 것이 아니다."
           transliteration: "Nan doneul yoguhaneun geosi anida."
           translation: "I'm not asking for money."
@@ -62007,7 +62007,7 @@ Used to illustrate the time that a certain action or situation began or will beg
   pos: n
   defs:
     - def: "fee, charge, fare"
-      examples: 
+      examples:
         - example: "버스 요금이 얼마입니까?"
           transliteration: "Beoseu yogeumi eolmaimnikka?"
           translation: "How much is the bus fare?"
@@ -62029,7 +62029,7 @@ Used to illustrate the time that a certain action or situation began or will beg
   pos: n
   defs:
     - def: "cradle"
-      examples: 
+      examples:
         - example: "요람에서 무덤까지"
           transliteration: "yorameseo mudeomkkaji"
           translation: "from the cradle to the grave"
@@ -62052,7 +62052,7 @@ Used to illustrate the time that a certain action or situation began or will beg
   pos: n
   defs:
     - def: "cooking; cuisine."
-      examples: 
+      examples:
         - example: "그리고, 마샤는 내가 요리를 잘 한다고 말해주네."
           transliteration: "Geurigo, masyaneun naega yorireul jal handago malhaejune."
           translation: "And Marsha says I am good at cooking!"
@@ -62070,7 +62070,7 @@ Used to illustrate the time that a certain action or situation began or will beg
   pos: v
   defs:
     - def: "to cook"
-      examples: 
+      examples:
         - example: "우리는 스테이크를 요리하는 방법을 모른다."
           transliteration: "Urineun seuteikeureul yorihaneun bangbeobeul moreunda."
           translation: "We don't know how to cook steak."
@@ -62207,22 +62207,22 @@ Used to illustrate the time that a certain action or situation began or will beg
   pos: n
   defs:
     - def: "abuse, insulting remark"
-      examples: 
+      examples:
         - example: "그는 영수의 면전에다 욕을 퍼부어 댔다."
           transliteration: "Geuneun yeongsuui myeonjeoneda yogeul peobueo daetda."
           translation: "He started to abuse Yeongsu in his face."
     - def: "scolding, reprimand"
-      examples: 
+      examples:
         - example: "그는 너무 인색하여 동네 사람들에게 욕을 먹는다."
           transliteration: "Geuneun neomu insaekhayeo dongne saramdeurege yogeul meongneunda."
           translation: "He is very stingy and is scolded by other villagers."
     - def: "trouble, effort, labour"
-      examples: 
+      examples:
         - example: "날도 더운데 여기까지 오느라고 욕을 보았구나."
           transliteration: "Naldo deounde yeogikkaji oneurago yogeul boatguna."
           translation: "It's such a trouble for everyone to come here on this hot day."
     - def: "shame, humiliation, disgrace"
-      examples: 
+      examples:
         - example: "그는 주인에게 별별 욕을 다 당하고도 주인에게 충성을 바쳤다."
           transliteration: "Geuneun ju-inege byeolbyeol yogeul da danghagodo ju-inege chungseong-eul bachyeotda."
           translation: "Although he has variously been humiliated by the master, he still remains loyal."
@@ -62232,11 +62232,11 @@ Used to illustrate the time that a certain action or situation began or will beg
   pos: suf
   defs:
     - def: "desire, greed, lust"
-      examples: 
-        - example: "[[권력<span style=\"background-color:#FEF8EA\"><b>욕</b></span>|권력욕]]"
+      examples:
+        - example: "권력욕"
           transliteration: "gwollyeogyok"
           translation: "desire for power"
-        - example: "[[독점<span style=\"background-color:#FEF8EA\"><b>욕</b></span>|독점욕]]"
+        - example: "독점욕"
           transliteration: "dokjeomyok"
           translation: "desire for exclusive possession"
 
@@ -62494,7 +62494,7 @@ Used to illustrate the time that a certain action or situation began or will beg
   pos: n
   defs:
     - def: "thunder"
-      examples: 
+      examples:
         - example: "우레가 울다"
           transliteration: "urega ulda"
           translation: "The thunder rolls."
@@ -62531,7 +62531,7 @@ Used to illustrate the time that a certain action or situation began or will beg
     - def: "we, us"
     - def: "our"
     - def: "(when referring to one's own family members) my"
-      examples: 
+      examples:
         - example: "우리 어머니는 이번 주에 마을에 계십니다."
           transliteration: "Uri eomeonineun ibeon jue ma-eure gyesimnida."
           translation: "My mother is in town this week."
@@ -62567,12 +62567,12 @@ Used to illustrate the time that a certain action or situation began or will beg
   pos: n
   defs:
     - def: "my house; my family's house"
-      examples: 
+      examples:
         - example: "우리집 마당에 대추나무가 한 그루 있다."
           transliteration: "Urijip madang-e daechunamuga han geuru itda."
           translation: "There is a jujube tree in the garden of my house."
     - def: "my family"
-      examples: 
+      examples:
         - example: "우리집의 가훈은 ‘언제나 최선을 다하자’이다."
           transliteration: "Urijibui gahuneun ‘eonjena choeseoneul dahaja’ida."
           translation: "The motto of my family is \"always do your best\"."
@@ -62731,7 +62731,7 @@ Used to illustrate the time that a certain action or situation began or will beg
   pos: n
   defs:
     - def: "cow's milk"
-      examples: 
+      examples:
         - example: "우유 한 잔"
           transliteration: "uyu han jan"
           translation: "a glass of milk"
@@ -62799,7 +62799,7 @@ Used to illustrate the time that a certain action or situation began or will beg
   pos: n
   defs:
     - def: "post office"
-      examples: 
+      examples:
         - example: "우체국이 어디입니까?"
           transliteration: " Uchegugi eodiimnikka?"
           translation: "Where is the post-office?"
@@ -62834,7 +62834,7 @@ Used to illustrate the time that a certain action or situation began or will beg
   pos: n
   defs:
     - def: "post office"
-      examples: 
+      examples:
         - example: "우펀국이 어디입니까?"
           transliteration: " Upeon-gugi eodiimnikka?"
           translation: "Where is the post-office?"
@@ -62873,7 +62873,7 @@ Used to illustrate the time that a certain action or situation began or will beg
   pos: n
   defs:
     - def: "fortune"
-      examples: 
+      examples:
         - example: "운은 인생에서 중요한 역할을 합니다."
           transliteration: "Uneun insaeng-eseo jung-yohan yeokhareul hamnida."
           translation: "Luck plays an important part in your life."
@@ -63043,7 +63043,7 @@ Used to illustrate the time that a certain action or situation began or will beg
   pos: v
   defs:
     - def: "to drive"
-      examples: 
+      examples:
         - example: "연말에는 산타가 운전합니다."
           transliteration: "Yeonmareneun Santaga unjeonhamnida."
           translation: "Santa drives to the end."
@@ -63085,7 +63085,7 @@ Used to illustrate the time that a certain action or situation began or will beg
   pos: v
   defs:
     - def: "to cry; to weep"
-      examples: 
+      examples:
         - example: "울고 싶고 눈물이 나오면, 무언가 재미있는 것을 애써 생각해 보렴."
           transliteration: "Ulgo sipgo nunmuri naomyeon, mueon-ga jaemiinneun geoseul aesseo saenggakhae boryeom."
           translation: "If you feel crying, tears coming, then try to think about something funny."
@@ -63247,12 +63247,12 @@ Used to illustrate the time that a certain action or situation began or will beg
   pos: adv
   defs:
     - def: "so, very"
-      examples: 
+      examples:
         - example: "우리는 워낙 졸아서 잠을 더 자야한다."
           transliteration: "Urineun wonak joraseo jameul deo jayahanda."
           translation: "We are so tired that we need more sleep."
     - def: "by nature, usually, always"
-      examples: 
+      examples:
         - example: "철수는 워낙 감기에 잘 걸려서 문제지."
           transliteration: "Cheolsuneun wonak gamgie jal geollyeoseo munjeji."
           translation: "Cheol-su usually catches a cold so easily, so it is a problem."
@@ -63321,7 +63321,7 @@ Used to illustrate the time that a certain action or situation began or will beg
   pos: adv
   defs:
     - def: "originally"
-      examples: 
+      examples:
         - example: "원래대로"
           transliteration: "wollaedaero"
           translation: "back (to the previous state)"
@@ -63580,7 +63580,7 @@ Used to illustrate the time that a certain action or situation began or will beg
   defs:
     - def: "A determiner which is used to express doubt or wonder: why~ what~"
     - def: ""
-      examples: 
+      examples:
         - example: "웬일이세요?"
           transliteration: "Weniriseyo?"
           translation: "What's up?"
@@ -63590,7 +63590,7 @@ Used to illustrate the time that a certain action or situation began or will beg
   pos: n
   defs:
     - def: "what matter, what cause"
-      examples: 
+      examples:
         - example: "웬일이냐?"
           transliteration: "Wenirinya?"
           translation: "What's up?"
@@ -63612,7 +63612,7 @@ Used to illustrate the time that a certain action or situation began or will beg
   pos: n
   defs:
     - def: "website"
-      examples: 
+      examples:
         - example: "저희 웹사이트를 방문하셔서 더 많은 정보와 특가 상품에 대해 알아보십시오."
           transliteration: "Jeohui wepsaiteureul bangmunhasyeoseo deo maneun jeongbowa teukga sangpume daehae arabosipsio."
           translation: "Visit our website for more information and special offers."
@@ -63628,7 +63628,7 @@ Used to illustrate the time that a certain action or situation began or will beg
   pos: n
   defs:
     - def: "above, upper, upside, top"
-      examples: 
+      examples:
         - example: "위까지"
           transliteration: "wikkaji"
           translation: "to the top"
@@ -63719,7 +63719,7 @@ Used to illustrate the time that a certain action or situation began or will beg
   pos: n
   defs:
     - def: "above, upper, upside, top"
-      examples: 
+      examples:
         - example: "위까지"
           transliteration: "wikkaji"
           translation: "to the top"
@@ -63738,7 +63738,7 @@ Used to illustrate the time that a certain action or situation began or will beg
   pos: n
   defs:
     - def: "member of a committee"
-      examples: 
+      examples:
         - example: "국제연합 기후변화에 관한 정부간 위원단은 최근에 그러한 증가가 전세계적으로 빙하의 28(이십팔) 내지 44(사십사) 퍼센트를 녹이기에 충분하다고 보고하였다."
           transliteration: "Gukjeyeonhap gihubyeonhwa-e gwanhan jeongbugan wiwondaneun choegeune geureohan jeunggaga jeonsegyejeogeuro binghaui 28(isippal) naeji 44(sasipsa) peosenteureul nogigie chungbunhadago bogohayeotda."
           translation: "The United Nations Intergovernmental Panel on Climate Change recently reported that that rise is enough to melt 28 to 44 percent of glaciers worldwide."
@@ -63760,7 +63760,7 @@ Used to illustrate the time that a certain action or situation began or will beg
   pos: n
   defs:
     - def: "(expressing the instrumental function of a noun, often used as 위주로, 위주의)"
-      examples: 
+      examples:
         - example: "나는 이 더운 날에 선풍기 위주로 시원하게 방콕한다."
           transliteration: "Naneun i deoun nare seonpunggi wijuro siwonhage bangkokhanda."
           translation: "I'm staying at home full of cool winds and air mainly with (the help of) a fan on this hot day."
@@ -63816,7 +63816,7 @@ Used to illustrate the time that a certain action or situation began or will beg
   defs:
     - def: "to help or benefit"
     - def: "to do for the sake of, for the purpose of"
-      examples: 
+      examples:
         - example: "세계평화를 위하여"
           transliteration: "segyepyeonghwareul wihayeo"
           translation: "for the sake of world peace"
@@ -63833,7 +63833,7 @@ Used to illustrate the time that a certain action or situation began or will beg
   pos: a
   defs:
     - def: "(to be) dangerous"
-      examples: 
+      examples:
         - example: "플라스틱을 태우면, 위험한 화학물질을 대기 중으로 내보내는 것이다."
           transliteration: "Peullaseutigeul tae-umyeon, wiheomhan hwahangmuljireul daegi jung-euro naebonaeneun geosida."
           translation: "When you burn plastics, you put dangerous chemicals into the air."
@@ -63875,7 +63875,7 @@ Used to illustrate the time that a certain action or situation began or will beg
   pos: propn
   defs:
     - def: "Windows"
-      examples: 
+      examples:
         - example: "윈도우용"
           transliteration: "windouyong"
           translation: "for Windows"
@@ -63905,7 +63905,7 @@ Used to illustrate the time that a certain action or situation began or will beg
   defs:
     - def: "(有) existence, possession"
     - def: "(類) type, kind"
-      examples: 
+      examples:
         - example: "이런 유의 사고"
           transliteration: "ireon yuui sago"
           translation: "Accidents of this type."
@@ -64020,7 +64020,7 @@ Used to illustrate the time that a certain action or situation began or will beg
   pos: n
   defs:
     - def: "judo"
-      examples: 
+      examples:
         - example: "유도에서는 상대방의 힘을 역이용할 줄 알아야 한다."
           transliteration: "Yudoeseoneun sangdaebang-ui himeul yeogiyonghal jul araya handa."
           translation: "In judo, one must know how to use the opponent's strength against him [literally \"in reverse\"]."
@@ -64036,7 +64036,7 @@ Used to illustrate the time that a certain action or situation began or will beg
   pos: n
   defs:
     - def: "guided missile"
-      examples: 
+      examples:
         - example: "대륙 간 탄도 유도탄"
           transliteration: "daeryuk gan tando yudotan"
           translation: "intercontinental ballistic missile (ICBM)"
@@ -64079,7 +64079,7 @@ Used to illustrate the time that a certain action or situation began or will beg
   pos: n
   defs:
     - def: "flow"
-      examples: 
+      examples:
         - example: "다른 장비들은 녹은 얼음이 공급하는 시냇물의 유량을 측정한다."
           transliteration: "Dareun jangbideureun nogeun eoreumi gonggeuphaneun sinaenmurui yuryang-eul cheukjeonghanda."
           translation: "Other devices measure water flow in streams fed by melted ice."
@@ -64207,7 +64207,7 @@ Used to illustrate the time that a certain action or situation began or will beg
   pos: n
   defs:
     - def: "nanny, wet nurse"
-      examples: 
+      examples:
         - example: "유모와 현명한 이웃 여인들은 직접 내 얼굴을 보기도 여러 달 전부터 나에게 지대한 관심을 가지고 있었는데, 그들은 내가 태어난 날과 시간을 헤아려보더니, 첫째, 내 일생이 불행한 운명을 타고 났으며, 둘째, 내가 유령과 망령을 보는 하나의 특별한 능력을 타고나리라 예언했다. 그들은 금요일 밤 자정 앞뒤에 태어난 불운한 아기들은 남녀를 막론하고 이러한 두 가지 선물을 면할 수 없다고 믿었다."
           transliteration: "Yumowa hyeonmyeonghan iut yeoindeureun jikjeop nae eolgureul bogido yeoreo dal jeonbuteo na-ege jidaehan gwansimeul gajigo isseonneunde, geudeureun naega taeeonan nalgwa siganeul hearyeobodeoni, cheotjjae, nae ilsaeng-i bulhaenghan unmyeong-eul tago nasseumyeo, duljjae, naega yuryeonggwa mangnyeong-eul boneun hanaui teukbyeolhan neungnyeogeul tagonarira yeeonhaetda. Geudeureun geumyoil bam jajeong apdwie taeeonan burunhan agideureun namnyeoreul mangnonhago ireohan du gaji seonmureul myeonhal su eopdago mideotda."
           translation: "In consideration of the day and hour of my birth, it was declared by the nurse, and by some sage women in the neighbourhood who had taken a lively interest in me several months before there was any possibility of our becoming personally acquainted, first, that I was destined to be unlucky in life; and secondly, that I was privileged to see ghosts and spirits; both these gifts inevitably attaching, as they believed, to all unlucky infants of either gender, born towards the small hours on a Friday night."
@@ -64229,7 +64229,7 @@ Used to illustrate the time that a certain action or situation began or will beg
   pos: n
   defs:
     - def: "udder, breast"
-      examples: 
+      examples:
         - example: "그들이 애굽에서 행음하되 어렸을 때에 행음하여 그들의 유방이 눌리며 그 처녀의 가슴이 어루만진 바 되었었나니."
           transliteration: "Geudeuri aegubeseo haeng-eumhadoe eoryeosseul ttaee haeng-eumhayeo geudeurui yubang-i nullimyeo geu cheonyeoui gaseumi eorumanjin ba doeeosseonnani."
           translation: "And they committed whoredoms in Egypt; they committed whoredoms in their youth: there were their breasts pressed, and there they bruised the teats of their virginity."
@@ -64349,7 +64349,7 @@ Used to illustrate the time that a certain action or situation began or will beg
   pos: a
   defs:
     - def: "profitable; advantageous ; beneficial"
-      examples: 
+      examples:
         - example: "그 법안은 보건부와 사회복지부 간에 발전되고 있는 유익한 합의를 해치는 것 같다."
           transliteration: "Geu beobaneun bogeonbuwa sahoebokjibu gane baljeondoego inneun yu-ikhan habuireul haechineun geot gatda."
           translation: "The Bill is likely to damage existing beneficial arrangements developing between health departments and social care departments."
@@ -64472,7 +64472,7 @@ Used to illustrate the time that a certain action or situation began or will beg
   pos: n
   defs:
     - def: "fashion, vogue"
-      examples: 
+      examples:
         - example: "퍼피볼은 심지어 페이스북에서 유행하는 스포츠 주제였습니다."
           transliteration: "Peopiboreun simjieo peiseubugeseo yuhaenghaneun seupocheu jujeyeotseumnida."
           translation: "“Puppy Bowl” was even a trending sports topic on Facebook."
@@ -64706,7 +64706,7 @@ Used to illustrate the time that a certain action or situation began or will beg
   pos: part
   defs:
     - def: "은 (eun) marks the topic of the sentence. The topic of a sentence is not to be confused with the subject of the sentence."
-      examples: 
+      examples:
         - example: "그것은 큰 책이야. — 맞아, 맞아, 피트."
           transliteration: "Geugeoseun keun chaegiya.  maja, maja, piteu."
           translation: "It is a big book. — Yes. Yes it is, Pete."
@@ -64820,7 +64820,7 @@ Used to illustrate the time that a certain action or situation began or will beg
   defs:
     - def: "Alternative form of —ㄹ (-l), used after consonants."
     - def: "An ending of a word that makes the preceding statement function as an adnominal phrase."
-      examples: 
+      examples:
         - example: "이 버섯들은 먹을 수 있다."
           transliteration: "I beoseotdeureun meogeul su itda."
           translation: "These mushrooms are edible."
@@ -64831,7 +64831,7 @@ Used to illustrate the time that a certain action or situation began or will beg
   pos: suf
   defs:
     - def: "An informal verbal suffix expressing future tense, a promise."
-      examples: 
+      examples:
         - example: "며칠 내로 꼭 갚을게요."
           transliteration: "Myeochil naero kkok gapeulgeyo."
           translation: "I promise to pay back in a few days."
@@ -64841,7 +64841,7 @@ Used to illustrate the time that a certain action or situation began or will beg
   pos: suf
   defs:
     - def: "Inquisitive or tentative ending."
-      examples: 
+      examples:
         - example: "음악이나 들을까요?"
           transliteration: "Eumagina deureulkkayo?"
           translation: "Shall we listen to music or something?"
@@ -64857,7 +64857,7 @@ Used to illustrate the time that a certain action or situation began or will beg
   pos: suf
   defs:
     - def: "An ending of a word that makes the preceding statement function as an adnominal phrase."
-      examples: 
+      examples:
         - example: "이 버섯들은 먹을 수 있다."
           transliteration: "I beoseotdeureun meogeul su itda."
           translation: "These mushrooms are edible."
@@ -65097,7 +65097,7 @@ Used to illustrate the time that a certain action or situation began or will beg
   pos: a
   defs:
     - def: "be gloomy, dismal, somber"
-      examples: 
+      examples:
         - example: "그는 음침한 성격의 사람이었다."
           transliteration: "Geuneun eumchimhan seonggyeogui saramieotda."
           translation: "He was a man of somber character."
@@ -65143,7 +65143,7 @@ Used to illustrate the time that a certain action or situation began or will beg
   pos: n
   defs:
     - def: "a town with at least 20000 residents."
-      examples: 
+      examples:
         - example: "(Administrative divisions of South Korea) 리 (ri), 동 (dong), 면 (myeon), 읍 (eup), 구 (gu), 군 (gun), 시 (si), 도 (do) "
 
 - word: 응
@@ -65151,7 +65151,7 @@ Used to illustrate the time that a certain action or situation began or will beg
   pos: intj
   defs:
     - def: "yes"
-      examples: 
+      examples:
         - example: "안녕 조나단, 바빠? — 응, 난 바빠."
           transliteration: "Annyeong jonadan, bappa?  eung, nan bappa."
           translation: "Hi, Jonathan. Are you busy? - Yes, I’m busy."
@@ -65215,7 +65215,7 @@ Used to illustrate the time that a certain action or situation began or will beg
   pos: part
   defs:
     - def: "’s. Indicates that the previous word has possession of the next one. It functions like the English suffix “’s”, or like the word “of” with the position of possessor and possessee switched."
-      examples: 
+      examples:
         - example: "한국의 수도는 서울이다."
           transliteration: "Han-gugui sudoneun Seourida."
           translation: "Korea's capital is Seoul."
@@ -65407,7 +65407,7 @@ Used to illustrate the time that a certain action or situation began or will beg
   pos: n
   defs:
     - def: "meaning, significance, importance"
-      examples: 
+      examples:
         - example: "그 사건은 중요한 역사적 의의가 있다."
           transliteration: "Geu sageoneun jung-yohan yeoksajeok uiuiga itda."
           translation: "That incident has great historical significance."
@@ -65417,7 +65417,7 @@ Used to illustrate the time that a certain action or situation began or will beg
   pos: n
   defs:
     - def: "chair, sofa"
-      examples: 
+      examples:
         - example: "의자에 앉으십시오."
           transliteration: "Uijae anjeusipsio."
           translation: "Please seat yourself in a chair."
@@ -65477,12 +65477,12 @@ Used to illustrate the time that a certain action or situation began or will beg
   pos: v
   defs:
     - def: "(-에 의해) to be due to"
-      examples: 
+      examples:
         - example: "교통사고에 의해 운전자 2(두)명은 심한 부상을 받았다."
           transliteration: "Gyotongsago-e uihae unjeonja 2(du)myeong-eun simhan busang-eul badatda."
           translation: "Due to the car accident, the two drivers sustained major injuries."
     - def: "(-에 의하면) to accord with, to be pursuant to"
-      examples: 
+      examples:
         - example: "신문에 의하면, 운전자들은 병원에 치료를 받는다."
           transliteration: "Sinmune uihamyeon, unjeonjadeureun byeong-wone chiryoreul banneunda."
           translation: "According to the newspaper, the drivers are receiving treatment at a hospital."
@@ -65691,7 +65691,7 @@ Used to illustrate the time that a certain action or situation began or will beg
   pos: v
   defs:
     - def: "to win, beat, defeat, gain (war, battle, fight, game, contest, competition)"
-      examples: 
+      examples:
         - example: "왔다, 보았다, 이겼다."
           transliteration: "Watda, boatda, igyeotda."
           translation: "I came, I saw, I won. (veni, vidi, vici.)"
@@ -65713,7 +65713,7 @@ Used to illustrate the time that a certain action or situation began or will beg
   pos: n
   defs:
     - def: "selfish; egoistic"
-      examples: 
+      examples:
         - example: "인간은 모두 이기적이다."
           transliteration: "In-ganeun modu igijeogida."
           translation: "All humans are selfish."
@@ -65748,22 +65748,22 @@ Used to illustrate the time that a certain action or situation began or will beg
   pos: part
   defs:
     - def: "just; at least"
-      examples: 
+      examples:
         - example: "헛소리 말고 잠이나 자라."
           transliteration: "Heotsori malgo jamina jara."
           translation: "Don't be silly and just go to sleep."
     - def: "or"
-      examples: 
+      examples:
         - example: "일반 배송은 이틀이나 사흘 정도 걸립니다."
           transliteration: "Ilban baesong-eun iteurina saheul jeongdo geollimnida."
           translation: "Regular delivery takes two or three days."
     - def: "no less than"
-      examples: 
+      examples:
         - example: "나 살 2kg이나 쪘어."
           transliteration: "Na sal 2kgina jjyeosseo."
           translation: "I gained no less than 4 pounds!"
     - def: "no matter which/who"
-      examples: 
+      examples:
         - example: "마음에 드는 것이면 어느 것이나 좋다."
           transliteration: "Ma-eume deuneun geosimyeon eoneu geosina jota."
           translation: "Anything you'd like is suitable."
@@ -65851,7 +65851,7 @@ Used to illustrate the time that a certain action or situation began or will beg
   pos: adv
   defs:
     - def: "a little later; after a while; a short time later"
-      examples: 
+      examples:
         - example: "이따가 만나자."
           transliteration: " Ittaga mannaja."
           translation: "See you later."
@@ -65947,7 +65947,7 @@ Used to illustrate the time that a certain action or situation began or will beg
   pos: adv
   defs:
     - def: "this and that, one thing or another"
-      examples: 
+      examples:
         - example: "그는 언제나 이러쿵저러쿵 고시랑거리기만 한다."
           transliteration: "Geuneun eonjena ireokungjeoreokung gosiranggeorigiman handa."
           translation: "He is always grumbling about one thing or another."
@@ -65970,7 +65970,7 @@ Used to illustrate the time that a certain action or situation began or will beg
   pos: intj
   defs:
     - def: "weak expression of frustration/disgust; compare darn, oh no, shucks"
-      examples: 
+      examples:
         - example: "이런! 내가 더이상 실수하지 않았으면 좋겠는데."
           transliteration: "Ireon! Naega deoisang silsuhaji anasseumyeon jokenneunde."
           translation: "Darn it! I hope I wouldn't make any mistakes anymore. (colloquial)"
@@ -66049,7 +66049,7 @@ Used to illustrate the time that a certain action or situation began or will beg
   pos: a
   defs:
     - def: "to be early"
-      examples: 
+      examples:
         - example: "이른 아침"
           transliteration: "ireun achim"
           translation: "early morning"
@@ -66085,7 +66085,7 @@ Used to illustrate the time that a certain action or situation began or will beg
     - def: "name (A word used to refer to or address an animal, object, phenomenon, etc., to distinguish it from others.)"
     - def: "name; given name"
     - def: "name; full name"
-      examples: 
+      examples:
         - example: "저는 그의 이름을 알아요."
           transliteration: "Jeoneun geuui ireumeul arayo."
           translation: "I know his name."
@@ -66253,7 +66253,7 @@ Used to illustrate the time that a certain action or situation began or will beg
   pos: n
   defs:
     - def: "tooth"
-      examples: 
+      examples:
         - example: "호랑이의 이빨에 물리면 살 가능성이 거의 없다."
           transliteration: "Horang-iui ippare mullimyeon sal ganeungseong-i geoui eopda."
           translation: "If you get bitten by a tiger's teeth, there is a little chance of living."
@@ -66330,7 +66330,7 @@ Used to illustrate the time that a certain action or situation began or will beg
   pos: n
   defs:
     - def: "strange, abnormal, odd, weird, bizarre"
-      examples: 
+      examples:
         - example: "다른건 다 맞는데 이거 하나만 맞지 않아서 뭔가 이상하다."
           transliteration: "Dareun-geon da manneunde igeo hanaman matji anaseo mwon-ga isanghada."
           translation: "This is strange because everything else is right except for this one."
@@ -66343,7 +66343,7 @@ Used to illustrate the time that a certain action or situation began or will beg
   pos: n
   defs:
     - def: "ideal"
-      examples: 
+      examples:
         - example: "이상과 현실은 다르다."
           transliteration: "Isanggwa hyeonsireun dareuda."
           translation: "Reality is different from ideals."
@@ -66360,7 +66360,7 @@ Used to illustrate the time that a certain action or situation began or will beg
   pos: a
   defs:
     - def: "to be strange, unusual"
-      examples: 
+      examples:
         - example: "이상한 소리를 내다"
           transliteration: "isanghan sorireul naeda"
           translation: "to make weird sounds"
@@ -66512,7 +66512,7 @@ Used to illustrate the time that a certain action or situation began or will beg
   pos: intj
   defs:
     - def: "wow, whoa"
-      examples: 
+      examples:
         - example: "이야, 굉장한데?"
           transliteration: "Iya, goengjanghande?"
           translation: "Wow, awesome!"
@@ -66525,7 +66525,7 @@ Used to illustrate the time that a certain action or situation began or will beg
   pos: part
   defs:
     - def: "semantic marker of emphasis"
-      examples: 
+      examples:
         - example: "이 정도쯤이야 식은 죽 먹기지!"
           transliteration: "I jeongdojjeumiya sigeun juk meokgiji!"
           translation: "It'll be a pushover!"
@@ -66689,7 +66689,7 @@ Used to illustrate the time that a certain action or situation began or will beg
   pos: n
   defs:
     - def: "the time before now; heretofore"
-      examples: 
+      examples:
         - example: "그들은 이전에 눈 속에 놓아둔 측정 장비 몇 점을 찾고 있었다."
           transliteration: "Geudeureun ijeone nun soge noadun cheukjeong jangbi myeot jeomeul chatgo isseotda."
           translation: "They were looking for some measuring equipment they had placed in the ice earlier."
@@ -66705,7 +66705,7 @@ Used to illustrate the time that a certain action or situation began or will beg
   pos: n
   defs:
     - def: "now"
-      examples: 
+      examples:
         - example: "이제 점심 시간이야."
           transliteration: "Ije jeomsim siganiya."
           translation: "Now it's lunchtime."
@@ -66726,7 +66726,7 @@ Used to illustrate the time that a certain action or situation began or will beg
   pos: propn
   defs:
     - def: "Egypt"
-      examples: 
+      examples:
         - example: "이집트는 북동 아프리카에 위치한 나라이다."
           transliteration: "Ijipteuneun bukdong apeurika-e wichihan naraida."
           translation: "Egypt is a country located in northeast Africa."
@@ -66737,7 +66737,7 @@ Used to illustrate the time that a certain action or situation began or will beg
   defs:
     - def: "This side"
     - def: "Our side; us or me"
-      examples: 
+      examples:
         - example: "이쪽으로 오세요."
           transliteration: "Ijjogeuro oseyo."
           translation: "Right this way."
@@ -66882,7 +66882,7 @@ Used to illustrate the time that a certain action or situation began or will beg
   pos: n
   defs:
     - def: "humour, joke, comicality, jocularity"
-      examples: 
+      examples:
         - example: "익살을 떨다"
           transliteration: "iksareul tteolda"
           translation: "to play the buffoon"
@@ -66956,7 +66956,7 @@ Used to illustrate the time that a certain action or situation began or will beg
   pos: det
   defs:
     - def: "that which is or has been something"
-      examples: 
+      examples:
         - example: "임대인인 갑"
           transliteration: "imdaeinin gap"
           translation: "A, who is the lessor"
@@ -66984,7 +66984,7 @@ Used to illustrate the time that a certain action or situation began or will beg
   pos: n
   defs:
     - def: "artificiality"
-      examples: 
+      examples:
         - example: "인공의"
           transliteration: "in-gong-ui"
           translation: "artificial"
@@ -67300,7 +67300,7 @@ Used to illustrate the time that a certain action or situation began or will beg
   pos: adv
   defs:
     - def: "now, but late (overdue); finally"
-      examples: 
+      examples:
         - example: "나는 인제 Rod 집에 도착했다."
           translation: "“I have arrived at Rod’s house now (but I am late).”"
 
@@ -67382,7 +67382,7 @@ Used to illustrate the time that a certain action or situation began or will beg
   pos: n
   defs:
     - def: "interview"
-      examples: 
+      examples:
         - example: "구직자들은 회사 사장과 인터뷰를 하여야 했다."
           transliteration: "Gujikjadeureun hoesa sajanggwa inteobyureul hayeoya haetda."
           translation: "The job applicants had to have an interview with the head of the company."
@@ -67453,7 +67453,7 @@ Used to illustrate the time that a certain action or situation began or will beg
   pos: n
   defs:
     - def: "work, job"
-      examples: 
+      examples:
         - example: "앉아라. 우리는 할 일이 있어."
           transliteration: "Anjara. Urineun hal iri isseo."
           translation: "Sit down! We have work to do."
@@ -67566,7 +67566,7 @@ Used to illustrate the time that a certain action or situation began or will beg
   pos: n
   defs:
     - def: "worker"
-      examples: 
+      examples:
         - example: "지난 주에 일꾼들을 새로 고용했어요."
           transliteration: "Jinan jue ilkkundeureul saero goyonghaesseoyo."
           translation: "I employed new servants last week."
@@ -67589,7 +67589,7 @@ Used to illustrate the time that a certain action or situation began or will beg
   pos: n
   defs:
     - def: "work, job"
-      examples: 
+      examples:
         - example: "앉아라. 우리는 할 일이 있어."
           transliteration: "Anjara. Urineun hal iri isseo."
           translation: "Sit down! We have work to do."
@@ -67665,7 +67665,7 @@ Used to illustrate the time that a certain action or situation began or will beg
   pos: propn
   defs:
     - def: "Japan"
-      examples: 
+      examples:
         - example: "일본 사람"
           transliteration: "ilbon saram"
           translation: "Japanese people; a Japanese person"
@@ -67755,7 +67755,7 @@ Used to illustrate the time that a certain action or situation began or will beg
   pos: n
   defs:
     - def: "common/habitual thing, habit"
-      examples: 
+      examples:
         - example: "그는 거짓말하기가 일쑤이다."
           transliteration: "Geuneun geojinmalhagiga ilssuida."
           translation: "He is prone to lying."
@@ -67785,7 +67785,7 @@ Used to illustrate the time that a certain action or situation began or will beg
   pos: v
   defs:
     - def: "To stand up."
-      examples: 
+      examples:
         - example: "그 여자는 군중 너머를 보려고 일어섰다."
           transliteration: "Geu yeojaneun gunjung neomeoreul boryeogo ireoseotda."
           translation: "She stood in order to see over the crowd."
@@ -67848,7 +67848,7 @@ Used to illustrate the time that a certain action or situation began or will beg
   pos: n
   defs:
     - def: "job, work, occupation, employment"
-      examples: 
+      examples:
         - example: "파트타임 일자리를 구하다"
           transliteration: "pateutaim iljarireul guhada"
           translation: "to look for a part-time job"
@@ -67861,7 +67861,7 @@ Used to illustrate the time that a certain action or situation began or will beg
   pos: n
   defs:
     - def: "(daily) schedule"
-      examples: 
+      examples:
         - example: "만약 일정이 변경되면 제게 연락 주십시오."
           transliteration: "Manyak iljeong-i byeon-gyeongdoemyeon jege yeollak jusipsio."
           translation: "If there are any changes to the schedule, please contact me."
@@ -67920,7 +67920,7 @@ Used to illustrate the time that a certain action or situation began or will beg
   pos: v
   defs:
     - def: "to call (person or thing) (as); to give a name to; to name (as); to refer to (as); to designate (as)"
-      examples: 
+      examples:
         - example: "남에게 자기 딸을 일컫는 말."
           transliteration: "Namege jagi ttareul ilkeonneun mal."
           translation: "Word referring to one's own daughter when speaking to others."
@@ -68071,7 +68071,7 @@ Used to illustrate the time that a certain action or situation began or will beg
   pos: v
   defs:
     - def: "come"
-      examples: 
+      examples:
         - example: "여호와의 말씀이 또 내게 임하여 가라사대."
           transliteration: "Yeohowaui malsseumi tto naege imhayeo garasadae."
           translation: "The word of the Lord came again unto me, saying,"
@@ -68102,7 +68102,7 @@ Used to illustrate the time that a certain action or situation began or will beg
   pos: v
   defs:
     - def: "to wear, put on (clothes)"
-      examples: 
+      examples:
         - example: "그녀는 핑크색 블라우스를 입고 있었다."
           transliteration: "Geunyeoneun pingkeusaek beullauseureul ipgo isseotda."
           translation: "She was wearing a pink blouse."
@@ -68139,7 +68139,7 @@ Used to illustrate the time that a certain action or situation began or will beg
   pos: n
   defs:
     - def: "morning sickness"
-      examples: 
+      examples:
         - example: "아내는 유난히 입덧이 심해서 음식을 거의 먹지 못했다."
           transliteration: "Anaeneun yunanhi ipdeosi simhaeseo eumsigeul geoui meokji mothaetda."
           translation: "My wife has strong morning sickness and can hardly eat."
@@ -68187,7 +68187,7 @@ Used to illustrate the time that a certain action or situation began or will beg
   pos: adv
   defs:
     - def: "fully, filled with (for alcoholic beverages and fuel)"
-      examples: 
+      examples:
         - example: "맥주 입빠이 채워 줄래?"
           transliteration: "Maekju ipppai chaewo jullae?"
           translation: "Would you mind fully fill beer (into my glass)?"
@@ -68221,7 +68221,7 @@ Used to illustrate the time that a certain action or situation began or will beg
   pos: n
   defs:
     - def: "adoption (of baby or child)"
-      examples: 
+      examples:
         - example: "이 강아지들은 동물 보호센터에서 온 것인데, 입양이 가능합니다."
           transliteration: "I gang-ajideureun dongmul bohosenteo-eseo on geodinde, ibyang-i ganeunghamnida."
           translation: "They[puppies] are from animal shelters, and are available for adoption."
@@ -68243,12 +68243,12 @@ Used to illustrate the time that a certain action or situation began or will beg
   pos: n
   defs:
     - def: "standpoint, perspective"
-      examples: 
+      examples:
         - example: "관점이란 어떤 사물을 바라보는 입장을 말한다."
           transliteration: "Gwanjeomiran eotteon samureul baraboneun ipjang-eul malhanda."
           translation: "Point of view means a position from which something is seen."
     - def: "admittance"
-      examples: 
+      examples:
         - example: "초대된 사람만 입장이 가능합니다."
           transliteration: "Chodaedoen saramman ipjang-i ganeunghamnida."
           translation: "Admittance with invitation only."
@@ -68293,7 +68293,7 @@ Used to illustrate the time that a certain action or situation began or will beg
   pos: n
   defs:
     - def: "gum (flesh around the necks of teeth)"
-      examples: 
+      examples:
         - example: "이가 없으면 잇몸으로 산다."
           transliteration: "Iga eopseumyeon inmomeuro sanda."
           translation: "Make do with what you have. [lit. When people do not have teeth, they can still live with their gums.]"
@@ -68303,7 +68303,7 @@ Used to illustrate the time that a certain action or situation began or will beg
   pos: v
   defs:
     - def: "to be (in a place); to exist"
-      examples: 
+      examples:
         - example: "뉴욕은 미국에 있다."
           transliteration: "Nyuyogeun miguge itda."
           translation: "New York is in the United States."
@@ -68311,7 +68311,7 @@ Used to illustrate the time that a certain action or situation began or will beg
           transliteration: "Mulsoge mulgogiga itda."
           translation: "There are fish in the water."
     - def: "To be (in a state)"
-      examples: 
+      examples:
         - example: "서 있다"
           transliteration: "seo itda"
           translation: "to be standing"
@@ -68322,7 +68322,7 @@ Used to illustrate the time that a certain action or situation began or will beg
           transliteration: "moyeo itda"
           translation: "to be gathered"
     - def: "To have"
-      examples: 
+      examples:
         - example: "그녀는 남자 친구가 있다."
           transliteration: "Geunyeoneun namja chin-guga itda."
           translation: "She has a boyfriend."
@@ -68336,7 +68336,7 @@ Used to illustrate the time that a certain action or situation began or will beg
   pos: v
   defs:
     - def: "to be (in a place); to exist"
-      examples: 
+      examples:
         - example: "뉴욕은 미국에 있다."
           transliteration: "Nyuyogeun miguge itda."
           translation: "New York is in the United States."
@@ -68344,7 +68344,7 @@ Used to illustrate the time that a certain action or situation began or will beg
           transliteration: "Mulsoge mulgogiga itda."
           translation: "There are fish in the water."
     - def: "to be (in a state)"
-      examples: 
+      examples:
         - example: "서 있다"
           transliteration: "seo itda"
           translation: "to be standing"
@@ -68355,7 +68355,7 @@ Used to illustrate the time that a certain action or situation began or will beg
           transliteration: "moyeo itda"
           translation: "to be gathered"
     - def: "to have"
-      examples: 
+      examples:
         - example: "그녀는 남자 친구가 있다."
           transliteration: "Geunyeoneun namja chin-guga itda."
           translation: "She has a boyfriend."
@@ -68590,7 +68590,7 @@ rat (Chinese zodiac sign)"
   pos: v
   defs:
     - def: "to sleep"
-      examples: 
+      examples:
         - example: "개는 잠을 잡니다."
           transliteration: "Gaeneun jameul jamnida."
           translation: "The dog is sleeping."
@@ -68616,7 +68616,7 @@ rat (Chinese zodiac sign)"
   pos: n
   defs:
     - def: "automobile, car"
-      examples: 
+      examples:
         - example: "자동차 전용 판매 창구 앞에서요."
           transliteration: "Jadongcha jeonyong panmae changgu apeseoyo."
           translation: "At the drive-thru."
@@ -68663,7 +68663,7 @@ rat (Chinese zodiac sign)"
   pos: a
   defs:
     - def: "to be proud"
-      examples: 
+      examples:
         - example: "그는 그의 업적을 자랑스러워했다."
           transliteration: "Geuneun geuui eopjeogeul jarangseureowohaetda."
           translation: "He took pride in his work."
@@ -69124,7 +69124,7 @@ rat (Chinese zodiac sign)"
   pos: n
   defs:
     - def: "作: a work by (someone)"
-      examples: 
+      examples:
         - example: "이 조각상은 로댕의 작이다"
           translation: "This statue is by Rodin."
 
@@ -69270,7 +69270,7 @@ rat (Chinese zodiac sign)"
   pos: n
   defs:
     - def: "a creative work or product"
-      examples: 
+      examples:
         - example: "문학 작품"
           transliteration: "munhak jakpum"
           translation: "literary work"
@@ -69311,7 +69311,7 @@ rat (Chinese zodiac sign)"
   pos: n
   defs:
     - def: "lawn, grassplot"
-      examples: 
+      examples:
         - example: "잔디밭에 들어가지 말 것."
           transliteration: "Jandibate deureogaji mal geot."
           translation: "Keep off the lawn."
@@ -69321,7 +69321,7 @@ rat (Chinese zodiac sign)"
   pos: adv
   defs:
     - def: "very, quite, heavily"
-      examples: 
+      examples:
         - example: "잔뜩 먹다"
           transliteration: "jantteuk meokda"
           translation: "to eat one's fill"
@@ -69350,7 +69350,7 @@ rat (Chinese zodiac sign)"
   pos: n
   defs:
     - def: "feast; party"
-      examples: 
+      examples:
         - example: "돌잔치"
           transliteration: "doljanchi"
           translation: "first-birthday party"
@@ -69405,7 +69405,7 @@ rat (Chinese zodiac sign)"
   pos: adv
   defs:
     - def: "erroneously"
-      examples: 
+      examples:
         - example: "죄송합니다만, 전화 잘못 거셨네요. — 아… 5558986(오오오에 팔구팔육) 맞나요? — 아니요. 여기는 5558689(오오오에 팔육팔구)입니다. — 아 죄송합니다. — 괜찮아요."
           transliteration: "Joesonghamnidaman, jeonhwa jalmot geosyeonneyo. — a… 5558986(ooo-e palguparyuk) mannayo? — aniyo. Yeogineun 5558689(ooo-e paryukpalgu)imnida. — a joesonghamnida. — gwaenchanayo."
           translation: "I am sorry. You have the wrong number. —  Oh. Is this 555-8986? — No. This is 555-8689. —  Oh. Excuse me! — Okay. Bye."
@@ -69488,7 +69488,7 @@ rat (Chinese zodiac sign)"
   pos: adv
   defs:
     - def: "(for a) short time, for a moment, awhile, briefly"
-      examples: 
+      examples:
         - example: "잠깐 기다리세요."
           transliteration: " Jamkkan gidariseyo."
           translation: "Please wait a minute."
@@ -69524,7 +69524,7 @@ rat (Chinese zodiac sign)"
   pos: n
   defs:
     - def: "a moment, a short time"
-      examples: 
+      examples:
         - example: "잠시만요."
           transliteration: "Jamsimanyo."
           translation: "Wait a minute.;Excuse me."
@@ -69705,7 +69705,7 @@ rat (Chinese zodiac sign)"
   pos: n
   defs:
     - def: "wife's family; marriage (said of a man)"
-      examples: 
+      examples:
         - example: "장가들었니?"
           transliteration: "Janggadeureonni?"
           translation: "Are you married? / Do you have a wife?"
@@ -69863,7 +69863,7 @@ rat (Chinese zodiac sign)"
   pos: n
   defs:
     - def: "equipment"
-      examples: 
+      examples:
         - example: "그 장비는 여름 동안에 빙하가 얼마나 움직였는지 그리고 그것의 높이가 얼마나 떨어졌는지를 보여준다."
           transliteration: "Geu jangbineun yeoreum dong-ane binghaga eolmana umjigyeonneunji geurigo geugeosui nopiga eolmana tteoreojyeonneunjireul boyeojunda."
           translation: "The equipment shows how much the glacier has moved and the amount it dropped in height over the summer."
@@ -70168,7 +70168,7 @@ rat (Chinese zodiac sign)"
   pos: adv
   defs:
     - def: "quickly, rapidly, nimbly"
-      examples: 
+      examples:
         - example: "가능한 한 재빨리!"
           transliteration: "Ganeunghan han jaeppalli!"
           translation: "As quick as you can."
@@ -70186,7 +70186,7 @@ rat (Chinese zodiac sign)"
   pos: n
   defs:
     - def: "luck, fortune"
-      examples: 
+      examples:
         - example: "오늘 아침부터 재수 없네요!"
           transliteration: "Oneul achimbuteo jaesu eomneyo!"
           translation: "I'm having no luck since morning today!"
@@ -70221,7 +70221,7 @@ rat (Chinese zodiac sign)"
   pos: n
   defs:
     - def: "talent"
-      examples: 
+      examples:
         - example: "청년들에게 신속성과 재주를 가르치다"
           transliteration: "cheongnyeondeurege sinsokseonggwa jaejureul gareuchida"
           translation: "to teach young men the speed and skill"
@@ -70421,7 +70421,7 @@ rat (Chinese zodiac sign)"
   defs:
     - def: "um; uh; erm (An exclamation used when one cannot think of something.)"
     - def: "um; uh; erm (An exclamation used when one finds it awkward and uncomfortable to bring up something.)"
-      examples: 
+      examples:
         - example: "저기. 내가 미안해. — 괜찮아. 아나."
           transliteration: "Jeogi. Naega mianhae.  gwaenchana. Ana."
           translation: "Well, I am sorry. — It’s okay, Anna."
@@ -70437,7 +70437,7 @@ rat (Chinese zodiac sign)"
   pos: n
   defs:
     - def: "evening"
-      examples: 
+      examples:
         - example: "저녁 일곱 시에"
           transliteration: "jeonyeok ilgop sie"
           translation: "at seven p.m. (lit. \"in the evening\")"
@@ -70457,7 +70457,7 @@ rat (Chinese zodiac sign)"
   pos: det
   defs:
     - def: "Such, that kind of; like that"
-      examples: 
+      examples:
         - example: "저런 사람."
           transliteration: "Jeoreon saram."
           translation: "That kind of person / Someone like that."
@@ -70539,7 +70539,7 @@ rat (Chinese zodiac sign)"
   pos: v
   defs:
     - def: "to preserve; to store"
-      examples: 
+      examples:
         - example: "설정을 저장했습니다."
           transliteration: "Seoljeong-eul jeojanghaetseumnida."
           translation: "The setup has been stored."
@@ -70596,7 +70596,7 @@ rat (Chinese zodiac sign)"
   pos: n
   defs:
     - def: "a place that is far away but visible, yonder"
-      examples: 
+      examples:
         - example: "저편에 강이 보인다."
           transliteration: "Jeopyeone gang-i boinda."
           translation: "I see a river over there."
@@ -70630,7 +70630,7 @@ rat (Chinese zodiac sign)"
   pos: n
   defs:
     - def: "(-ㄴ 적 있다/없다) time, occurrence, experience"
-      examples: 
+      examples:
         - example: "나는 절대 그런 말을 한 적이 없다."
           transliteration: "Naneun jeoldae geureon mareul han jeogi eopda."
           translation: "I've never said such a thing."
@@ -70649,7 +70649,7 @@ rat (Chinese zodiac sign)"
   pos: n
   defs:
     - def: "activity, positive engagement"
-      examples: 
+      examples:
         - example: "적극 참여하다"
           transliteration: "jeokgeuk chamyeohada"
           translation: "actively participate"
@@ -70705,7 +70705,7 @@ rat (Chinese zodiac sign)"
   pos: n
   defs:
     - def: "equator (circle around the earth)"
-      examples: 
+      examples:
         - example: "바이수에이는 대략, 플로리다의 탬파만큼이나 적도에 가깝다."
           transliteration: "Baisueineun daeryak, peulloridaui taempamankeumina jeokdoe gakkapda."
           translation: "Baishui is about as close to the equator as Tampa, Florida."
@@ -70964,7 +70964,7 @@ rat (Chinese zodiac sign)"
   pos: n
   defs:
     - def: "being nationwide"
-      examples: 
+      examples:
         - example: "2년전 이 연단에서 저는 다섯 기업에게 사회 복지 대상에서 제외된 사람들을 고용하는 전국적인 노력을 이끌어 달라고 요청했습니다."
           transliteration: "2nyeonjeon i yeondaneseo jeoneun daseot gieobege sahoe bokji daesang-eseo je-oedoen saramdeureul goyonghaneun jeon-gukjeogin noryeogeul ikkeureo dallago yocheonghaetseumnida."
           translation: "Two years ago, from this podium, I asked five companies to lead a national effort to hire people off welfare."
@@ -71242,7 +71242,7 @@ rat (Chinese zodiac sign)"
   pos: n
   defs:
     - def: "an infectious disease"
-      examples: 
+      examples:
         - example: "유럽인들이 아메리카 대륙에 정착하기 시작하자, 수백만명의 아메리카 원주민들이 천연두 같은 유입된 전염병으로 숨졌다."
           transliteration: "Yureobindeuri amerika daeryuge jeongchakhagi sijakhaja, subaengmanmyeong-ui amerika wonjumindeuri cheonyeondu gateun yu-ipdoen jeonyeombyeong-euro sumjyeotda."
           translation: "After Europeans began settling in the Americas, many millions of indigenous Americans died from epidemics of imported diseases such as smallpox."
@@ -71392,7 +71392,7 @@ rat (Chinese zodiac sign)"
   pos: n
   defs:
     - def: "(電話) a telephone"
-      examples: 
+      examples:
         - example: "마샤 직장의 전화 번호는 5558986(오오오에 팔구팔육)이야."
           transliteration: "Masya jikjang-ui jeonhwa beonhoneun 5558986(ooo-e palguparyuk)iya."
           translation: "Marsha's work number is 555-8986."
@@ -71413,7 +71413,7 @@ rat (Chinese zodiac sign)"
   pos: n
   defs:
     - def: "telephone number"
-      examples: 
+      examples:
         - example: "전화번호가 몇 번이에요?"
           transliteration: " Jeonhwabeonhoga myeot beonieyo?"
           translation: "what's your phone number?"
@@ -71443,7 +71443,7 @@ rat (Chinese zodiac sign)"
   pos: n
   defs:
     - def: "bow; greeting"
-      examples: 
+      examples:
         - example: "선생님께 절을 한다."
           translation: "You bow to the teacher."
 
@@ -71452,7 +71452,7 @@ rat (Chinese zodiac sign)"
   pos: n
   defs:
     - def: "Buddhist temple"
-      examples: 
+      examples:
         - example: "절을 찾아 마음을 수양해야겠다."
           translation: "I've got to find a temple and cultivate my soul."
 
@@ -71474,7 +71474,7 @@ rat (Chinese zodiac sign)"
   defs:
     - def: "to be salted; to be pickled"
     - def: "to be doused/drenched"
-      examples: 
+      examples:
         - example: "땀에 절다"
           transliteration: "ttame jeolda"
           translation: "to be drenched in sweat"
@@ -71495,7 +71495,7 @@ rat (Chinese zodiac sign)"
   pos: adv
   defs:
     - def: "absolutely, totally, never"
-      examples: 
+      examples:
         - example: "나는 절대 그런 말을 한 적이 없다."
           transliteration: "Naneun jeoldae geureon mareul han jeogi eopda."
           translation: "I've never said such a thing."
@@ -71597,7 +71597,7 @@ rat (Chinese zodiac sign)"
   pos: n
   defs:
     - def: "lunch, luncheon"
-      examples: 
+      examples:
         - example: "점심을 먹다"
           transliteration: "jeomsimeul meokda"
           translation: "to have/to eat lunch"
@@ -71739,7 +71739,7 @@ rat (Chinese zodiac sign)"
   defs:
     - def: "connection"
     - def: "access"
-      examples: 
+      examples:
         - example: "인터넷 접속"
           transliteration: "inteonet jeopsok"
           translation: "internet access"
@@ -71755,7 +71755,7 @@ rat (Chinese zodiac sign)"
   pos: v
   defs:
     - def: "To receive, take (To get applications, reports, etc., through verbal or written means.)"
-      examples: 
+      examples:
         - example: "존슨 씨가 당신의 상세한 얘기를 접수할 겁니다."
           transliteration: "Jonseun ssiga dangsinui sangsehan yaegireul jeopsuhal geomnida."
           translation: "Mr. Johnson will take your detail."
@@ -71809,7 +71809,7 @@ rat (Chinese zodiac sign)"
   pos: n
   defs:
     - def: "chopsticks"
-      examples: 
+      examples:
         - example: "젓가락으로 먹다"
           transliteration: "jeotgarageuro meokda"
           translation: "to eat with chopsticks"
@@ -71825,7 +71825,7 @@ rat (Chinese zodiac sign)"
   pos: n
   defs:
     - def: "using chopsticks; handling chopsticks"
-      examples: 
+      examples:
         - example: "외국인들의 서투른 젓가락질을 보면 정말 재미있다."
           transliteration: "Oegugindeurui seotureun jeotgarakjireul bomyeon jeongmal jaemiitda."
           translation: "It's really interesting to watch foreigners use chopsticks awkwardly."
@@ -71838,7 +71838,7 @@ rat (Chinese zodiac sign)"
   pos: v
   defs:
     - def: "to use chopsticks; to handle chopsticks"
-      examples: 
+      examples:
         - example: "남편은 저녁을 먹으면서 딸아이에게 젓가락질하는 방법을 알려주었다."
           transliteration: "Nampyeoneun jeonyeogeul meogeumyeonseo ttaraiege jeotgarakjilhaneun bangbeobeul allyeojueotda."
           translation: "My husband taught my daughter how to use chopsticks over dinner."
@@ -71975,7 +71975,7 @@ rat (Chinese zodiac sign)"
   pos: n
   defs:
     - def: "quantity"
-      examples: 
+      examples:
         - example: "정량의"
           transliteration: "jeongnyang-ui"
           translation: "quantitative"
@@ -72018,7 +72018,7 @@ rat (Chinese zodiac sign)"
   pos: adv
   defs:
     - def: "really; truly"
-      examples: 
+      examples:
         - example: "그 새로운 하인들은 일을 정말 잘 해."
           transliteration: "Geu saeroun haindeureun ireul jeongmal jal hae."
           translation: "Those new servants really do a splendid job."
@@ -72034,7 +72034,7 @@ rat (Chinese zodiac sign)"
   pos: adv
   defs:
     - def: "really; truly"
-      examples: 
+      examples:
         - example: "하지만 정말로 미안해."
           transliteration: "Hajiman jeongmallo mianhae."
           translation: "But I'm sorry. Truly."
@@ -72050,7 +72050,7 @@ rat (Chinese zodiac sign)"
   pos: n
   defs:
     - def: "front, façade"
-      examples: 
+      examples:
         - example: "바로 정면에"
           transliteration: "baro jeongmyeone"
           translation: "directly/right in front (of), straight ahead"
@@ -72190,7 +72190,7 @@ rat (Chinese zodiac sign)"
   pos: n
   defs:
     - def: "noon, midday"
-      examples: 
+      examples:
         - example: "정오 전에 호텔에서 체크아웃해야 해요."
           transliteration: "Jeong-o jeone hotereseo chekeuauthaeya haeyo."
           translation: "Be sure to check out of the hotel before noon."
@@ -72229,7 +72229,7 @@ rat (Chinese zodiac sign)"
   pos: propn
   defs:
     - def: "Jong-un (name)"
-      examples: 
+      examples:
         - example: "김 정은"
           transliteration: "Gim Jeong-eun"
           translation: "Kim Jong-un (金正恩)"
@@ -72334,7 +72334,7 @@ rat (Chinese zodiac sign)"
   pos: n
   defs:
     - def: "politics; governmental affairs"
-      examples: 
+      examples:
         - example: "정치란 나라를 다스리는 것을 말한다."
           transliteration: "Jeongchiran narareul daseurineun geoseul malhanda."
           translation: "Politics refers to governing a country."
@@ -72356,7 +72356,7 @@ rat (Chinese zodiac sign)"
   pos: n
   defs:
     - def: "politician"
-      examples: 
+      examples:
         - example: "그는 정치인이었으므로, 누구도 다치게 하지 않으려고 모든 주제를 신중히 토의하였다."
           transliteration: "Geuneun jeongchiinieosseumeuro, nugudo dachige haji aneuryeogo modeun jujereul sinjunghi touihayeotda."
           translation: "As he was a politician, he discussed all subjects carefully, not offending anyone."
@@ -72395,12 +72395,12 @@ rat (Chinese zodiac sign)"
   pos: v
   defs:
     - def: "to designate, to specify, to decide, to determine"
-      examples: 
+      examples:
         - example: "초대할 손님을 정하다."
           transliteration: "Chodaehal sonnimeul jeonghada."
           translation: "determine the guests to be invited"
     - def: "to define"
-      examples: 
+      examples:
         - example: "낭만기를 정한 것은 워즈워스였다."
           transliteration: "Nangman-gireul jeonghan geoseun wojeuwoseuyeotda."
           translation: "It was Wordsworth who defined the Romantic Age."
@@ -72411,7 +72411,7 @@ rat (Chinese zodiac sign)"
   pos: v
   defs:
     - def: "to be decided; to be fixed"
-      examples: 
+      examples:
         - example: "참나! 우리가 할 일이 벌써 정해졌단 말이야?"
           transliteration: "Chamna! Uriga hal iri beolsseo jeonghaejyeotdan mariya?"
           translation: "Seriously! So our jobs were already decided? (casual)"
@@ -72422,7 +72422,7 @@ rat (Chinese zodiac sign)"
   pos: a
   defs:
     - def: "to be accurate or exact"
-      examples: 
+      examples:
         - example: "그는 답을 정확하게 맞췄다."
           transliteration: "Geuneun dabeul jeonghwakhage matchwotda."
           translation: "He got the answer exactly right."
@@ -72643,7 +72643,7 @@ rat (Chinese zodiac sign)"
   pos: adv
   defs:
     - def: "please"
-      examples: 
+      examples:
         - example: "제발 좀 그만해요."
           transliteration: "Jebal jom geumanhaeyo."
           translation: "Please stop."
@@ -72769,7 +72769,7 @@ rat (Chinese zodiac sign)"
     - def: "number one; the first or primary"
     - def: "most; -est"
     - def: "(forms superlatives of adjectives)"
-      examples: 
+      examples:
         - example: "그 사전은 제일 좋아요."
           transliteration: "Geu sajeoneun jeil joayo."
           translation: "This dictionary is the best."
@@ -72816,7 +72816,7 @@ rat (Chinese zodiac sign)"
   pos: propn
   defs:
     - def: "Jeju (island, province and its capital in South Korea)"
-      examples: 
+      examples:
         - example: "제주도"
           transliteration: " Jejudo"
           translation: "Jeju island, Jejudo"
@@ -72853,7 +72853,7 @@ rat (Chinese zodiac sign)"
   pos: n
   defs:
     - def: "the Jeju language"
-      examples: 
+      examples:
         - example: "그녀는 제주말을 정말 잘 하세요."
           transliteration: "Geunyeoneun jejumareul jeongmal jal haseyo."
           translation: "She speaks Jeju really well."
@@ -72869,7 +72869,7 @@ rat (Chinese zodiac sign)"
   pos: n
   defs:
     - def: "the Jeju language"
-      examples: 
+      examples:
         - example: "그녀는 제주어를 정말 잘 하세요."
           transliteration: "Geunyeoneun jejueoreul jeongmal jal haseyo."
           translation: "She speaks Jeju really well."
@@ -73039,7 +73039,7 @@ rat (Chinese zodiac sign)"
   pos: adv
   defs:
     - def: "a little; a bit"
-      examples: 
+      examples:
         - example: "안녕, 아멜리아. 바빠? — 조금 바빠."
           transliteration: "Annyeong, amellia. Bappa?  jogeum bappa."
           translation: "Hi, Amelia! Are you busy? — I’m a little busy."
@@ -73049,7 +73049,7 @@ rat (Chinese zodiac sign)"
   pos: n
   defs:
     - def: "a little; a bit"
-      examples: 
+      examples:
         - example: "조금만 기다리십시오."
           transliteration: " Jogeumman gidarisipsio."
           translation: "Please wait a little."
@@ -73132,7 +73132,7 @@ rat (Chinese zodiac sign)"
   pos: n
   defs:
     - def: "aperture, iris (of camera)"
-      examples: 
+      examples:
         - example: "피사계의 심도는 렌즈의 조리개가 좁을수록 깊어진다."
           transliteration: "Pisagye-ui simdoneun renjeuui jorigaega jobeulsurok gipeojinda."
           translation: "The narrower the lens aperture, the deeper the depth of field."
@@ -73367,7 +73367,7 @@ rat (Chinese zodiac sign)"
   pos: adv
   defs:
     - def: "silently or quietly"
-      examples: 
+      examples:
         - example: "조용히 해주세요."
           transliteration: "Joyonghi haejuseyo."
           translation: "Please be quiet."
@@ -73434,7 +73434,7 @@ rat (Chinese zodiac sign)"
   pos: adv
   defs:
     - def: "even"
-      examples: 
+      examples:
         - example: "그 사람하고는 말하기조차 싫어요."
           transliteration: "Geu saramhagoneun malhagijocha sireoyo."
           translation: "I don't even want to talk to that person."
@@ -73520,7 +73520,7 @@ rat (Chinese zodiac sign)"
   pos: n
   defs:
     - def: "admiration, respect"
-      examples: 
+      examples:
         - example: "그에게 존경을 표하세요."
           transliteration: "Geuege jon-gyeong-eul pyohaseyo."
           translation: "Show him respects."
@@ -73632,7 +73632,7 @@ rat (Chinese zodiac sign)"
   defs:
     - def: "Contraction of 조금 (jogeum).: a little; somewhat; quite"
     - def: "a little while, a short time"
-      examples: 
+      examples:
         - example: "좀 있다가 전화할께요."
           transliteration: "Jom itdaga jeonhwahalkkeyo."
           translation: "I'll call you in a little while."
@@ -73644,7 +73644,7 @@ rat (Chinese zodiac sign)"
   defs:
     - def: "silverfish"
     - def: "moth, bookworm; general term for any insect which eats fabrics, paper etc."
-      examples: 
+      examples:
         - example: "양복이 좀이 쏠다."
           transliteration: "Yangbogi jomi ssolda."
           translation: "The clothes become moth-eaten.” (Literally \"moths eat the clothes\")."
@@ -73698,7 +73698,7 @@ rat (Chinese zodiac sign)"
   pos: n
   defs:
     - def: "religion"
-      examples: 
+      examples:
         - example: "제1 추가 헌법은 종교·연설·언론·집회 및 청원의 자유를 보장한다."
           transliteration: "Je1 chuga heonbeobeun jonggyo·yeonseol·eollon·jiphoe mit cheong-wonui jayureul bojanghanda."
           translation: "The First Amendment guarantees freedom of religion, speech, press, assembly, and petition."
@@ -73731,7 +73731,7 @@ rat (Chinese zodiac sign)"
   pos: n
   defs:
     - def: "type, kind"
-      examples: 
+      examples:
         - example: "어떤 종류의 이태리 음식을 좋아하세요?"
           transliteration: "Eotteon jongnyuui itaeri eumsigeul joahaseyo?"
           translation: "What kind of Italian food do you like?"
@@ -73746,7 +73746,7 @@ rat (Chinese zodiac sign)"
   pos: n
   defs:
     - def: "calf"
-      examples: 
+      examples:
         - example: "종아리를 맞다"
           transliteration: "jong-arireul matda"
           translation: "to get whipped on the calf"
@@ -73829,7 +73829,7 @@ rat (Chinese zodiac sign)"
   pos: a
   defs:
     - def: "to be good; great; excellent (Excellent and satisfactory in features and content.)"
-      examples: 
+      examples:
         - example: "그거 좋은 생각입니다."
           transliteration: "Geugeo joeun saenggagimnida."
           translation: "Oh! That sounds good."
@@ -73848,7 +73848,7 @@ rat (Chinese zodiac sign)"
     - def: "good (Having a lot of hair in good condition.)"
     - def: "good; right ((for a day or opportunity to be) Appropriate.)"
     - def: "fond of; in love with (Happy about and satisfied with a thing or object.)"
-      examples: 
+      examples:
         - example: "좋으시면 그걸로 예약해 드릴 수 있습니다."
           transliteration: "Joeusimyeon geugeollo yeyakhae deuril su itseumnida."
           translation: "I can book you for them if you like."
@@ -73856,7 +73856,7 @@ rat (Chinese zodiac sign)"
           transliteration: "Sae apateuro watguna! Joa!"
           translation: "I am in my new apartment! Great!"
     - def: "to be preferable, likeable"
-      examples: 
+      examples:
         - example: "난 축구보다 농구가 더 좋구나."
           transliteration: "Nan chukguboda nongguga deo jokuna."
           translation: "I like basketball more than football. (literally, \"To me basketball is preferable to football.\")"
@@ -73864,7 +73864,7 @@ rat (Chinese zodiac sign)"
     - def: "happy; okay (Having no problems with behavior, work, etc.)"
     - def: "good; easy; convenient (Easy or convenient to do something.)"
     - def: "good (Having qualities that are good for the body or health.)"
-      examples: 
+      examples:
         - example: "아침에 일찍 일어나는 것은 건강에 좋다."
           transliteration: "Achime iljjik ireonaneun geoseun geon-gang-e jota."
           translation: "Getting up early in the morning is good for one's health."
@@ -73889,7 +73889,7 @@ rat (Chinese zodiac sign)"
   pos: v
   defs:
     - def: "to like something or someone; to prefer"
-      examples: 
+      examples:
         - example: "워싱턴 사람들은 운동하는 것을 좋아해요."
           transliteration: "Wosingteon saramdeureun undonghaneun geoseul joahaeyo."
           translation: "People in Washington like to work out!"
@@ -73900,7 +73900,7 @@ rat (Chinese zodiac sign)"
   pos: v
   defs:
     - def: "to like something or someone; to prefer"
-      examples: 
+      examples:
         - example: "워싱턴 사람들은 운동하는 것을 좋아해요."
           transliteration: "Wosingteon saramdeureun undonghaneun geoseul joahaeyo."
           translation: "People in Washington like to work out!"
@@ -73918,12 +73918,12 @@ rat (Chinese zodiac sign)"
   pos: a
   defs:
     - def: "to be good"
-      examples: 
+      examples:
         - example: "아침에 일찍 일어나는 것은 건강에 좋다."
           transliteration: "Achime iljjik ireonaneun geoseun geon-gang-e jota."
           translation: "Getting up early in the morning is good for one's health."
     - def: "to be preferable, likeable"
-      examples: 
+      examples:
         - example: "난 축구보다 농구가 더 좋구나."
           transliteration: "Nan chukguboda nongguga deo jokuna."
           translation: "I like basketball more than football. (literally, \"To me basketball is preferable to football.\")"
@@ -73976,7 +73976,7 @@ rat (Chinese zodiac sign)"
   pos: v
   defs:
     - def: "to be sorry, to feel apologetic"
-      examples: 
+      examples:
         - example: "죄송합니다"
           transliteration: "joesonghamnida"
           translation: "I'm sorry"
@@ -74065,7 +74065,7 @@ rat (Chinese zodiac sign)"
   pos: v
   defs:
     - def: "to give"
-      examples: 
+      examples:
         - example: "선물을 주다"
           transliteration: "seonmureul juda"
           translation: "to give a present"
@@ -74099,7 +74099,7 @@ rat (Chinese zodiac sign)"
   pos: n
   defs:
     - def: "alcoholic drinks; liquor"
-      examples: 
+      examples:
         - example: "주류 판매점"
           transliteration: "juryu panmaejeom"
           translation: "liquor store"
@@ -74115,7 +74115,7 @@ rat (Chinese zodiac sign)"
   pos: n
   defs:
     - def: "weekend"
-      examples: 
+      examples:
         - example: "주말에 짐 정리를 할 수 있어요."
           transliteration: "Jumare jim jeongnireul hal su isseoyo."
           translation: "I can get settled over the weekend."
@@ -74125,7 +74125,7 @@ rat (Chinese zodiac sign)"
   pos: n
   defs:
     - def: "bag, sack, pouch"
-      examples: 
+      examples:
         - example: "주머니에 넣다"
           transliteration: "jumeonie neota"
           translation: "to put into a bag"
@@ -74133,12 +74133,12 @@ rat (Chinese zodiac sign)"
           transliteration: "Geuneun achim sijang-e nagal ttaemyeon hangsang jumeonireul chago naganda."
           translation: "He always carries a bag when going to morning markets."
     - def: "Synonym of 호주머니 (hojumeoni, “pocket”)"
-      examples: 
+      examples:
         - example: "외투 주머니"
           transliteration: "oetu jumeoni"
           translation: "coat pocket"
     - def: "someone with an abundance of something"
-      examples: 
+      examples:
         - example: "할머니는 이야기를 끊임없이 늘어놓는 이야기 주머니이시다."
           transliteration: "Halmeonineun iyagireul kkeunimeopsi neureononneun iyagi jumeoniisida."
           translation: "Grandma is a raconteur [lit. story sack] and her stories never end."
@@ -74182,7 +74182,7 @@ rat (Chinese zodiac sign)"
   pos: n
   defs:
     - def: "order (a request for some product or service)"
-      examples: 
+      examples:
         - example: "주문을 받다"
           transliteration: "jumuneul batda"
           translation: "take/receive/get an order"
@@ -74280,7 +74280,7 @@ rat (Chinese zodiac sign)"
   pos: v
   defs:
     - def: "to give"
-      examples: 
+      examples:
         - example: "선물을 주다"
           transliteration: "seonmureul juda"
           translation: "to give a present"
@@ -74389,7 +74389,7 @@ rat (Chinese zodiac sign)"
   pos: v
   defs:
     - def: "to watch out"
-      examples: 
+      examples:
         - example: "도로 위의 동물을 주의하다."
           transliteration: "Doro wiui dongmureul juuihada."
           translation: "to watch out animals on the road"
@@ -74400,7 +74400,7 @@ rat (Chinese zodiac sign)"
   pos: n
   defs:
     - def: "master or owner"
-      examples: 
+      examples:
         - example: "우리는 그 수상한 짐의 주인을 찾을 수 없다."
           transliteration: "Urineun geu susanghan jimui ju-ineul chajeul su eopda."
           translation: "We can't find the owner of that suspicious luggage."
@@ -74419,7 +74419,7 @@ rat (Chinese zodiac sign)"
   pos: n
   defs:
     - def: "week"
-      examples: 
+      examples:
         - example: "다음 주일"
           transliteration: "da-eum ju-il"
           translation: "next week"
@@ -74438,7 +74438,7 @@ rat (Chinese zodiac sign)"
   pos: n
   defs:
     - def: "Lord's Day; Sunday"
-      examples: 
+      examples:
         - example: "주일이 지나다"
           transliteration: "ju-iri jinada"
           translation: "Sunday passes"
@@ -74466,7 +74466,7 @@ rat (Chinese zodiac sign)"
   pos: n
   defs:
     - def: "being based in Japan"
-      examples: 
+      examples:
         - example: "주일 공사"
           transliteration: "ju-il gongsa"
           translation: "minister based in Japan"
@@ -74500,7 +74500,7 @@ rat (Chinese zodiac sign)"
   pos: n
   defs:
     - def: "a claim or assertion"
-      examples: 
+      examples:
         - example: "사실에 관한 주장"
           transliteration: "sasire gwanhan jujang"
           translation: "factual allegation"
@@ -74527,7 +74527,7 @@ rat (Chinese zodiac sign)"
   pos: adv
   defs:
     - def: "mostly, mainly, principally, primarily"
-      examples: 
+      examples:
         - example: "(The addition of quotations indicative of this usage is being sought):"
 
 - word: 주장하다
@@ -74564,7 +74564,7 @@ rat (Chinese zodiac sign)"
   pos: n
   defs:
     - def: "topic; main idea"
-      examples: 
+      examples:
         - example: "수백년 동안 그 주제는 논의의 중심에 있다."
           transliteration: "Subaengnyeon dong-an geu jujeneun nonuiui jungsime itda."
           translation: "The topic has been at the center of conversation for hundreds of years."
@@ -74659,7 +74659,7 @@ rat (Chinese zodiac sign)"
   pos: n
   defs:
     - def: "death, dying"
-      examples: 
+      examples:
         - example: "죽음보다 사는 것을 더 두려워하는 사람들도 존재한다."
           transliteration: "Jugeumboda saneun geoseul deo duryeowohaneun saramdeuldo jonjaehanda."
           translation: "There are people who are more afraid of living than death."
@@ -74687,7 +74687,7 @@ rat (Chinese zodiac sign)"
   pos: v
   defs:
     - def: "given: Past determiner form of 주다 (juda, “to give”)."
-      examples: 
+      examples:
         - example: "그녀가 준 책"
           transliteration: "geunyeo-ga jun chaek"
           translation: "The book she gave me"
@@ -74730,7 +74730,7 @@ rat (Chinese zodiac sign)"
   pos: adv
   defs:
     - def: "continuously, constantly, all the time"
-      examples: 
+      examples:
         - example: "지금까지 줄곧 어디 계셨습니까?"
           transliteration: "Jigeumkkaji julgot eodi gyesyeotseumnikka?"
           translation: "Where have you been all this while?"
@@ -74760,7 +74760,7 @@ rat (Chinese zodiac sign)"
   pos: v
   defs:
     - def: "to decrease, shrink"
-      examples: 
+      examples:
         - example: "1982(천구백팔십이)년 이래로, 그것은 250(이백오십)미터 만큼 줄었다."
           transliteration: "1982(cheon-gubaekpalsibi)nyeon iraero, geugeoseun 250(ibaegosip)miteo mankeum jureotda."
           translation: "Since 1982, it has shrunk by 250 meters."
@@ -74818,7 +74818,7 @@ rat (Chinese zodiac sign)"
     - def: "middle, center"
     - def: "(dependent noun) amongst (often in the form 중에서 (jung-eseo, “from amongst”))"
     - def: "(dependent noun) in the course of, during"
-      examples: 
+      examples:
         - example: "식사중 (siksajung, “gone to lunch”)"
         - example: "그 철도는 아직 공사중인가요, 아니면 이미 끝났나요?"
           transliteration: "Geu cheoldoneun ajik gongsajung-in-gayo, animyeon imi kkeunnannayo?"
@@ -74873,7 +74873,7 @@ rat (Chinese zodiac sign)"
   pos: propn
   defs:
     - def: "China"
-      examples: 
+      examples:
         - example: "중국 사람"
           transliteration: "jungguk saram"
           translation: "Chinese people; Chinese person"
@@ -74925,7 +74925,7 @@ rat (Chinese zodiac sign)"
   pos: a
   defs:
     - def: "significant"
-      examples: 
+      examples:
         - example: "이것은 중대한 소식이야."
           transliteration: "Igeoseun jungdaehan sosigiya."
           translation: "It is capital news."
@@ -75080,7 +75080,7 @@ rat (Chinese zodiac sign)"
   pos: n
   defs:
     - def: "the state of being important; importance"
-      examples: 
+      examples:
         - example: "이 보따리는 매우 중요하니 잘 들고 가십시오. 동쪽 방향으로 가야 합니다."
           transliteration: "I bottarineun mae-u jung-yohani jal deulgo gasipsio. Dongjjok banghyang-euro gaya hamnida."
           translation: "This bundle is very important, so please carry it well. You must go to the east."
@@ -75096,7 +75096,7 @@ rat (Chinese zodiac sign)"
   pos: a
   defs:
     - def: "to be important"
-      examples: 
+      examples:
         - example: "천구백십삼년(1913년), 중요한 뉴스가 있었다."
           transliteration: "Cheon-gubaeksipsamnyeon(1913nyeon), jung-yohan nyuseuga isseotda."
           translation: "In 1913, there was important news."
@@ -75172,7 +75172,7 @@ rat (Chinese zodiac sign)"
   pos: n
   defs:
     - def: "mouse, rat"
-      examples: 
+      examples:
         - example: "조용한 고양이가 쥐를 잡는다."
           transliteration: "Joyonghan goyang-iga jwireul jamneunda."
           translation: "The quiet cat catches the mouse. (proverb)"
@@ -75183,7 +75183,7 @@ rat (Chinese zodiac sign)"
   defs:
     - def: "To clench"
     - def: "To grasp, to grab, to hold, to squeeze"
-      examples: 
+      examples:
         - example: "손으로 쥐고 놓지 않다."
           transliteration: "Soneuro jwigo nochi anta."
           translation: "To hold something in one's hand and not let it go."
@@ -75212,7 +75212,7 @@ rat (Chinese zodiac sign)"
   pos: adv
   defs:
     - def: "immediately, promptly"
-      examples: 
+      examples:
         - example: "즉시 이용가능한 자금의 형태로"
           transliteration: "jeuksi iyongganeunghan jageumui hyeongtaero"
           translation: "in immediately available funds"
@@ -75254,7 +75254,7 @@ rat (Chinese zodiac sign)"
   pos: n
   defs:
     - def: "growth, increase"
-      examples: 
+      examples:
         - example: "그녀는, 기후 변화로 인한 융해의 증가가 그것을 위험에 처하게 할 수 있다고 말한다."
           transliteration: "Geunyeoneun, gihu byeonhwaro inhan yunghae-ui jeunggaga geugeoseul wiheome cheohage hal su itdago malhanda."
           translation: "She says an increase in melting from climate change may put that at risk."
@@ -75271,7 +75271,7 @@ rat (Chinese zodiac sign)"
   pos: v
   defs:
     - def: "To increase or add."
-      examples: 
+      examples:
         - example: "인구가 130(백삼십)만 명에서 140(백사십)만 명으로 증가했다."
           transliteration: "In-guga 130(baeksamsip)man myeong-eseo 140(baeksasip)man myeong-euro jeunggahaetda."
           translation: "The population has increased from 1.3 million to 1.4 million."
@@ -75368,7 +75368,7 @@ rat (Chinese zodiac sign)"
   pos: suf
   defs:
     - def: "verb suffix used to seek affirmation, or to give the listener(s) an opportunity to express whether they can follow or not, to agree, or to confirm what is said"
-      examples: 
+      examples:
         - example: "“어렵지?”"
           transliteration: "“eoryeopji?”"
           translation: "It's difficult, isn't it?"
@@ -75376,7 +75376,7 @@ rat (Chinese zodiac sign)"
           transliteration: "“geu buneun han-gungmareul ihaehasiji?”"
           translation: "He understands Korean, right?"
     - def: "verb suffix a speaker uses to recommend a change in the listener's behaviour, or to soften imperatives"
-      examples: 
+      examples:
         - example: "“천천히 먹지”"
           transliteration: "“cheoncheonhi meokji”"
           translation: "Eat slowly."
@@ -75386,7 +75386,7 @@ rat (Chinese zodiac sign)"
   pos: suf
   defs:
     - def: "suffix either marking the verb that is negated by following 못하다 (mothada)/않다 (anta), or marking what a following 말다 (malda) says not to do"
-      examples: 
+      examples:
         - example: "“담배를 피우지 맙시다.”"
           transliteration: "“dambaereul piuji mapsida.”"
           translation: "Let's not smoke cigarettes."
@@ -75396,7 +75396,7 @@ rat (Chinese zodiac sign)"
   pos: pron
   defs:
     - def: "oneself; the aforementioned one"
-      examples: 
+      examples:
         - example: "지는 할 거 다 하고 살면서 맨날 나보고 뭐라 그래."
           transliteration: "Jineun hal geo da hago salmyeonseo maennal nabogo mwora geurae."
           translation: "He does all what he wants and he tells me off everyday!"
@@ -75425,7 +75425,7 @@ rat (Chinese zodiac sign)"
   pos: n
   defs:
     - def: "wallet, purse"
-      examples: 
+      examples:
         - example: "오늘 아침에는 지갑이 분명히 재킷 속에 있었는데..."
           transliteration: "Oneul achimeneun jigabi bunmyeonghi jaekit soge isseonneunde..."
           translation: "I could've sworn my wallet was in my jacket this morning."
@@ -75443,7 +75443,7 @@ rat (Chinese zodiac sign)"
   pos: n
   defs:
     - def: "circumstances, situation"
-      examples: 
+      examples:
         - example: "배고파 죽을 지경이다."
           transliteration: "Baegopa jugeul jigyeong-ida."
           translation: "I'm starving to death."
@@ -75484,7 +75484,7 @@ rat (Chinese zodiac sign)"
   pos: adv
   defs:
     - def: "now"
-      examples: 
+      examples:
         - example: "너 지금 기분이 어떠니?"
           transliteration: "Neo jigeum gibuni eotteoni?"
           translation: "How do you feel now?"
@@ -75497,7 +75497,7 @@ rat (Chinese zodiac sign)"
   pos: n
   defs:
     - def: "now, the current time"
-      examples: 
+      examples:
         - example: "지금까지"
           transliteration: "jigeumkkaji"
           translation: "until now"
@@ -75516,7 +75516,7 @@ rat (Chinese zodiac sign)"
   pos: adv
   defs:
     - def: "now"
-      examples: 
+      examples:
         - example: "너 지금 기분이 어떠니?"
           transliteration: "Neo jigeum gibuni eotteoni?"
           translation: "How do you feel now?"
@@ -75526,7 +75526,7 @@ rat (Chinese zodiac sign)"
   pos: n
   defs:
     - def: "now, the current time"
-      examples: 
+      examples:
         - example: "지금까지"
           transliteration: "jigeumkkaji"
           translation: "until now"
@@ -75585,7 +75585,7 @@ rat (Chinese zodiac sign)"
   pos: n
   defs:
     - def: "last night"
-      examples: 
+      examples:
         - example: "지난밤에 근처 아파트 건물에 불이 났다."
           transliteration: "Jinanbame geuncheo apateu geonmure buri natda."
           translation: "There was a fire at a nearby apartment building last night."
@@ -75608,7 +75608,7 @@ rat (Chinese zodiac sign)"
   defs:
     - def: "to spend (one's time)"
     - def: "to live, to get along"
-      examples: 
+      examples:
         - example: "어떻게 지냈어요?"
           transliteration: "Eotteoke jinaesseoyo?"
           translation: "How are you? (polite, literally, \"How are you getting along?\")"
@@ -75670,7 +75670,7 @@ rat (Chinese zodiac sign)"
   defs:
     - def: "to sink; to set; to go down"
     - def: "to wither and fall; to scatter; to be scattered"
-      examples: 
+      examples:
         - example: "바람에 지는 아련한 사랑."
           transliteration: "Barame jineun aryeonhan sarang."
           translation: "A vague love which disappears with the wind."
@@ -75704,7 +75704,7 @@ rat (Chinese zodiac sign)"
   pos: n
   defs:
     - def: "map"
-      examples: 
+      examples:
         - example: "아나, 그것은 지도야."
           transliteration: "Ana, geugeoseun jidoya."
           translation: "Anna, it is a map."
@@ -75756,7 +75756,7 @@ rat (Chinese zodiac sign)"
   pos: v
   defs:
     - def: "to act in a libertine way, to go crazy"
-      examples: 
+      examples:
         - example: "지랄하네."
           transliteration: "Jiralhane."
           translation: "(an offensive expression to show displeasure of someone's action or opinion)"
@@ -75966,7 +75966,7 @@ rat (Chinese zodiac sign)"
   pos: v
   defs:
     - def: "to make up, to fabricate"
-      examples: 
+      examples:
         - example: "지어낸 이야기"
           transliteration: "jieonaen iyagi"
           translation: "made-up story"
@@ -75977,7 +75977,7 @@ rat (Chinese zodiac sign)"
   pos: n
   defs:
     - def: "area, district, particular geographic region"
-      examples: 
+      examples:
         - example: "지역사회 개발 은행을 더 도와줌으로써"
           transliteration: "jiyeoksahoe gaebal eunhaeng-eul deo dowajumeurosseo"
           translation: "with more support for community development banks"
@@ -76041,7 +76041,7 @@ rat (Chinese zodiac sign)"
   pos: n
   defs:
     - def: "supporter"
-      examples: 
+      examples:
         - example: "이번 불우 이웃 돕기 행사는 많은 지원자의 도움으로 기대 이상의 성과를 거둘 수 있었다."
           transliteration: "Ibeon buru iut dopgi haengsaneun maneun jiwonjaui doumeuro gidae isang-ui seonggwareul geodul su isseotda."
           translation: "This charity event was able to achieve more than expected by the help of many supporters."
@@ -76051,7 +76051,7 @@ rat (Chinese zodiac sign)"
   pos: n
   defs:
     - def: "applicant"
-      examples: 
+      examples:
         - example: "지원자가 쇄도하다"
           transliteration: "jiwonjaga swaedohada"
           translation: "be thronged with applicants"
@@ -76156,7 +76156,7 @@ rat (Chinese zodiac sign)"
   pos: v
   defs:
     - def: "to support; to advocate"
-      examples: 
+      examples:
         - example: "저는 여러분이 이것을 지지하시기를 바랍니다."
           transliteration: "Jeoneun yeoreobuni igeoseul jijihasigireul baramnida."
           translation: "I hope you will support it."
@@ -76191,7 +76191,7 @@ rat (Chinese zodiac sign)"
   pos: a
   defs:
     - def: "(to be) exhausted, tired"
-      examples: 
+      examples:
         - example: "벌써 지쳤어요?"
           transliteration: "Beolsseo jichyeosseoyo?"
           translation: "Are you tired already?"
@@ -76203,7 +76203,7 @@ rat (Chinese zodiac sign)"
   pos: v
   defs:
     - def: "to watch; to keep an eye on; to observe; to look after"
-      examples: 
+      examples:
         - example: "누가 선택되는지를 지켜보면서 우리는 모두 신경이 곤두서 있었다."
           transliteration: "Nuga seontaekdoeneunjireul jikyeobomyeonseo urineun modu sin-gyeong-i gonduseo isseotda."
           translation: "Waiting to see who had been chosen, we were all on edge."
@@ -76216,7 +76216,7 @@ rat (Chinese zodiac sign)"
     - def: "to protect or defend"
     - def: "to watch over"
     - def: "to keep to or abide by"
-      examples: 
+      examples:
         - example: "침묵을 지키다"
           transliteration: "chimmugeul jikida"
           translation: "to preserve silence"
@@ -76396,7 +76396,7 @@ rat (Chinese zodiac sign)"
   pos: n
   defs:
     - def: "workplace, job"
-      examples: 
+      examples:
         - example: "아이들을 키우며 직장을 다니기란 어려운 일이다."
           transliteration: "Aideureul kiumyeo jikjang-eul danigiran eoryeoun irida."
           translation: "It´s difficult taking care of children and holding down a job"
@@ -76419,7 +76419,7 @@ rat (Chinese zodiac sign)"
   pos: n
   defs:
     - def: "immediateness; directness"
-      examples: 
+      examples:
         - example: "직접의"
           transliteration: "jikjeobui"
           translation: "direct, immediate, personal"
@@ -76583,7 +76583,7 @@ such a municipality in North Korea, the Republic of China, the People's Republic
   pos: n
   defs:
     - def: "sincerity, earnestness"
-      examples: 
+      examples:
         - example: "진심이에요?"
           transliteration: "Jinsimieyo?"
           translation: "Are you serious?"
@@ -76612,7 +76612,7 @@ such a municipality in North Korea, the Republic of China, the People's Republic
   defs:
     - def: "settle"
     - def: "relax; soothe"
-      examples: 
+      examples:
         - example: "(혼잣말로)진정하자."
           transliteration: "(honjanmallo)jinjeonghaja."
           translation: "Come on."
@@ -76655,7 +76655,7 @@ such a municipality in North Korea, the Republic of China, the People's Republic
   defs:
     - def: "That which is real or actual."
     - def: ""
-      examples: 
+      examples:
         - example: "퍼피볼은 진짜 슈퍼볼에 대한 대체물입니다."
           transliteration: "Peopiboreun jinjja syupeobore daehan daechemurimnida."
           translation: "The Puppy Bowl is an alternative to the real Super Bowl."
@@ -76683,12 +76683,12 @@ such a municipality in North Korea, the Republic of China, the People's Republic
   pos: a
   defs:
     - def: "(to be) thick, strong"
-      examples: 
+      examples:
         - example: "진한 커피"
           transliteration: "jinhan keopi"
           translation: "strong coffee"
     - def: "(to be) dark, deep, heavy"
-      examples: 
+      examples:
         - example: "진한 갈색"
           transliteration: "jinhan galsaek"
           translation: "dark[deep] brown (color)"
@@ -76696,7 +76696,7 @@ such a municipality in North Korea, the Republic of China, the People's Republic
           transliteration: "hwajang-eul jinhage hada"
           translation: "to wear heavy makeup"
     - def: "(to be) strong"
-      examples: 
+      examples:
         - example: "꽃향기가 진하다."
           transliteration: "Kkothyanggiga jinhada."
           translation: "The flowers smell strong."
@@ -76728,7 +76728,7 @@ such a municipality in North Korea, the Republic of China, the People's Republic
   defs:
     - def: "to progress, to make progress (To move forward)"
     - def: "to progress, to make progress (To keep doing something)"
-      examples: 
+      examples:
         - example: "제가 세미나를 진행하겠습니다."
           transliteration: "Jega seminareul jinhaenghagetseumnida."
           translation: "I'll lead the seminar."
@@ -76751,7 +76751,7 @@ such a municipality in North Korea, the Republic of China, the People's Republic
   pos: n
   defs:
     - def: "quality"
-      examples: 
+      examples:
         - example: "품질 (品質, pumjil, “quality”)"
         - example: "질이 나쁜 종이"
           transliteration: "jiri nappeun jong-i"
@@ -76760,7 +76760,7 @@ such a municipality in North Korea, the Republic of China, the People's Republic
           transliteration: "Urineun jil joeun podojureul masyeotda."
           translation: "We had some good-quality wine."
     - def: "nature, disposition"
-      examples: 
+      examples:
         - example: "뛰어나게 질이 좋은 학생"
           transliteration: "ttwieonage jiri joeun haksaeng"
           translation: "an exceptionally brilliant student"
@@ -76771,7 +76771,7 @@ such a municipality in North Korea, the Republic of China, the People's Republic
           transliteration: "Eomeonineun naega jiri an joeun chin-gudeulgwa eoullineun geoseul sireohasyeotda."
           translation: "My mother didn't like me hanging around with a bad crowd."
     - def: "matter"
-      examples: 
+      examples:
         - example: "식물 질"
           transliteration: "singmul jil"
           translation: "vegetable matter"
@@ -76787,10 +76787,10 @@ such a municipality in North Korea, the Republic of China, the People's Republic
   pos: suf
   defs:
     - def: "A depreciative noun-forming suffix attached to nouns."
-      examples: 
+      examples:
         - example: "선생질 (先生—, seonsaengjil, “(depreciative) being a teacher”), 첩질 (妾—, cheopjil, “concubinage”), 손가락질 (son-garakjil, “pointing fingers”), 서방질 (書房—, seobangjil, “cuckolding”)"
     - def: "A nominalisation suffix attached to nouns, verbs or adjectives. The act of doing ..."
-      examples: 
+      examples:
         - example: "톱질 (topjil, “sawing”), 망치질 (mangchijil, “hammering”), 대패질 (daepaejil, “planing”), 부채질 (buchaejil, “fanning”), 바느질 (baneujil, “sewing”)"
 
 - word: 질
@@ -76853,7 +76853,7 @@ such a municipality in North Korea, the Republic of China, the People's Republic
   pos: n
   defs:
     - def: "mass"
-      examples: 
+      examples:
         - example: "공간의 일부를 차지하고 질량을 갖는 요소."
           transliteration: "Gongganui ilbureul chajihago jillyang-eul ganneun yoso."
           translation: "An element that occupies part of space and has mass."
@@ -76880,7 +76880,7 @@ such a municipality in North Korea, the Republic of China, the People's Republic
   pos: n
   defs:
     - def: "A question."
-      examples: 
+      examples:
         - example: "질문이 있으시면, 저에게 말씀해 주십시오."
           transliteration: "Jilmuni isseusimyeon, jeo-ege malsseumhae jusipsio."
           translation: "If you have any questions, please let me know."
@@ -76966,7 +76966,7 @@ such a municipality in North Korea, the Republic of China, the People's Republic
   pos: n
   defs:
     - def: "beast, animal"
-      examples: 
+      examples:
         - example: "짐승을 죽이다."
           transliteration: "Jimseung-eul jugida."
           translation: "To kill an animal."
@@ -77025,7 +77025,7 @@ such a municipality in North Korea, the Republic of China, the People's Republic
   pos: n
   defs:
     - def: "plural of 집 (jip): houses; homes"
-      examples: 
+      examples:
         - example: "내 형의 집들"
           translation: "my brother's houses"
 
@@ -77200,7 +77200,7 @@ such a municipality in North Korea, the Republic of China, the People's Republic
   pos: v
   defs:
     - def: "To rely, rest (on a cane, stick, etc.)"
-      examples: 
+      examples:
         - example: "땅 짚고 헤엄치기"
           transliteration: "ttang jipgo heeomchigi"
           translation: "as easy or safe as swimming (with the arms) resting on the ground"
@@ -77267,12 +77267,12 @@ such a municipality in North Korea, the Republic of China, the People's Republic
   pos: n
   defs:
     - def: "pair"
-      examples: 
+      examples:
         - example: "신발 한 짝"
           transliteration: "sinbal han jjak"
           translation: "a pair of shoes / one pair of shoes"
     - def: "partner; mate"
-      examples: 
+      examples:
         - example: "옆에 있는 너의 짝과 같이 공부해라."
           transliteration: "Yeope inneun neoui jjakgwa gachi gongbuhaera."
           translation: "Study with your partner next to you."
@@ -77472,7 +77472,7 @@ such a municipality in North Korea, the Republic of China, the People's Republic
   pos: suf
   defs:
     - def: "about"
-      examples: 
+      examples:
         - example: "언제쯤 왔어요?"
           transliteration: "Eonjejjeum wasseoyo?"
           translation: "About when did [he] come?"
@@ -77534,7 +77534,7 @@ such a municipality in North Korea, the Republic of China, the People's Republic
     - def: "to make from a model"
     - def: "to print (a document)"
     - def: "to record or take (picture, video, or other media)"
-      examples: 
+      examples:
         - example: "사진을 찍다"
           transliteration: "sajineul jjikda"
           translation: "to photograph, to take pictures"
@@ -77557,12 +77557,12 @@ such a municipality in North Korea, the Republic of China, the People's Republic
   pos: v
   defs:
     - def: "to get (something) pierced; to be stabbed"
-      examples: 
+      examples:
         - example: "해파리에 찔리다"
           transliteration: "haeparie jjillida"
           translation: "to be stung by a jellyfish"
     - def: "to go home to one's heart"
-      examples: 
+      examples:
         - example: "그는 약점을 찔려서는 찍소리도 못했다."
           transliteration: "Geuneun yakjeomeul jjillyeoseoneun jjiksorido mothaetda."
           translation: "He was at a loss to reply because he had been touched on a weak point."
@@ -77591,7 +77591,7 @@ such a municipality in North Korea, the Republic of China, the People's Republic
   pos: v
   defs:
     - def: "to tear, to rip"
-      examples: 
+      examples:
         - example: "책을 찢다."
           transliteration: "Chaegeul jjitda."
           translation: "to rip a book"
@@ -77651,7 +77651,7 @@ such a municipality in North Korea, the Republic of China, the People's Republic
   pos: v
   defs:
     - def: "to fill"
-      examples: 
+      examples:
         - example: "그 상점은 휴일 판매를 위한 장난감들로 가득 찼다."
           transliteration: "Geu sangjeomeun hyu-il panmaereul wihan jangnan-gamdeullo gadeuk chatda."
           translation: "The store was filled with toys for holiday sale."
@@ -77729,7 +77729,7 @@ such a municipality in North Korea, the Republic of China, the People's Republic
   pos: n
   defs:
     - def: "getup, clothes"
-      examples: 
+      examples:
         - example: "평상복 차림으로 오세요."
           transliteration: "Pyeongsangbok charimeuro oseyo."
           translation: "Come dressed in your usual clothes."
@@ -77902,7 +77902,7 @@ such a municipality in North Korea, the Republic of China, the People's Republic
   pos: n
   defs:
     - def: "moment, instant"
-      examples: 
+      examples:
         - example: "찰나적 쾌락"
           transliteration: "challajeok kwaerak"
           translation: "fleeting pleasures"
@@ -78078,7 +78078,7 @@ such a municipality in North Korea, the Republic of China, the People's Republic
   pos: v
   defs:
     - def: "to participate"
-      examples: 
+      examples:
         - example: "적극 참여하다"
           transliteration: "jeokgeuk chamyeohada"
           translation: "actively participate"
@@ -78173,7 +78173,7 @@ such a municipality in North Korea, the Republic of China, the People's Republic
   pos: n
   defs:
     - def: "window"
-      examples: 
+      examples:
         - example: "1층 유리창 전부를 청소하다."
           transliteration: "1cheung yurichang jeonbureul cheongsohada."
           translation: "to clean all ground floor windows"
@@ -78207,7 +78207,7 @@ such a municipality in North Korea, the Republic of China, the People's Republic
   pos: n
   defs:
     - def: "window"
-      examples: 
+      examples:
         - example: "창문의 유리가 반짝거린다."
           transliteration: " Changmunui yuriga banjjakgeorinda."
           translation: "The glass of the window is gleaming."
@@ -78220,7 +78220,7 @@ such a municipality in North Korea, the Republic of China, the People's Republic
   pos: adv
   defs:
     - def: "outside the window"
-      examples: 
+      examples:
         - example: "창밖을 내다보다"
           transliteration: "changbakkeul naedaboda"
           translation: "look outside the window"
@@ -78271,7 +78271,7 @@ such a municipality in North Korea, the Republic of China, the People's Republic
   pos: v
   defs:
     - def: "to create"
-      examples: 
+      examples:
         - example: "한처음에 하느님께서 하늘과 땅을 창조하셨다."
           transliteration: "Hancheo-eume haneunimkkeseo haneulgwa ttang-eul changjohasyeotda."
           translation: "In the beginning, when God created the heavens and the earth."
@@ -78295,7 +78295,7 @@ such a municipality in North Korea, the Republic of China, the People's Republic
   defs:
     - def: "to search, look for"
     - def: "to find"
-      examples: 
+      examples:
         - example: "슈퍼마켓 찾으려 하는데요.— 아, 좋아. 슈퍼마켓은 어빙 1500번지에 있어. 아파트에서 가까워. —좋아요."
           transliteration: "Syupeomaket chajeuryeo haneundeyo.— a, joa. Syupeomakeseun eobing 1500beonjie isseo. Apateueseo gakkawo. —joayo."
           translation: "I want to find a supermarket. —Oh, okay. The supermarket is at 1500 Irving Street. It is near the apartment. — Great!"
@@ -78336,16 +78336,16 @@ such a municipality in North Korea, the Republic of China, the People's Republic
   pos: n
   defs:
     - def: "A whip"
-      examples: 
+      examples:
         - example: "팽이를 채로 치다. (He) hits the spinning top with a whip."
     - def: "Counter for houses:"
-      examples: 
+      examples:
         - example: "집 한 채 One house."
     - def: "A thin strip"
-      examples: 
+      examples:
         - example: "무우를 채를 치다. Cut white radish into thin strips."
     - def: "A continuing state"
-      examples: 
+      examples:
         - example: "옷을 입은 채. while wearing clothes / without undressing"
     - def: "A Korean family name (hanja:菜)"
 
@@ -78353,7 +78353,7 @@ such a municipality in North Korea, the Republic of China, the People's Republic
   pos: adv
   defs:
     - def: "Not yet, still... not"
-      examples: 
+      examples:
         - example: "숙제를 채 마치기도 전에 잠이 들었다. He fell asleep before he finished the homework."
 
 - word: 채널
@@ -78391,7 +78391,7 @@ such a municipality in North Korea, the Republic of China, the People's Republic
   pos: v
   defs:
     - def: "recruit; hire"
-      examples: 
+      examples:
         - example: "회사는 다른 코치를 채용하는 것은 고려하지 않을 것이라고 발표했다."
           transliteration: "Hoesaneun dareun kochireul chaeyonghaneun geoseun goryeohaji aneul geosirago balpyohaetda."
           translation: "The company announced it will not consider recruiting another coach."
@@ -78424,7 +78424,7 @@ such a municipality in North Korea, the Republic of China, the People's Republic
   pos: n
   defs:
     - def: "book"
-      examples: 
+      examples:
         - example: "그 여자는 그 책 삼십칠(37)쪽을 펴서 큰 소리로 읽기 시작했다."
           transliteration: "Geu yeojaneun geu chaek samsipchil(37)jjogeul pyeoseo keun soriro ilgi sijakhaetda."
           translation: "She opened the book to page 37 and began to read aloud."
@@ -78520,7 +78520,7 @@ such a municipality in North Korea, the Republic of China, the People's Republic
   pos: v
   defs:
     - def: "To collect or pack."
-      examples: 
+      examples:
         - example: "비행기에서 내리시기 전에 모든 소지품을 챙기셨는지 확인해 주시기 바랍니다."
           transliteration: "Bihaenggieseo naerisigi jeone modeun sojipumeul chaenggisyeonneunji hwaginhae jusigi baramnida."
           translation: "Before getting off the airplane, please ensure that all your belongings are with you."
@@ -78551,7 +78551,7 @@ such a municipality in North Korea, the Republic of China, the People's Republic
   pos: part
   defs:
     - def: "like, as, as if"
-      examples: 
+      examples:
         - example: "이전처럼"
           transliteration: "ijeoncheoreom"
           translation: "like before"
@@ -78612,7 +78612,7 @@ such a municipality in North Korea, the Republic of China, the People's Republic
   pos: n
   defs:
     - def: "pretense; as if"
-      examples: 
+      examples:
         - example: "난 그냥 모른 척 했다."
           transliteration: "Nan geunyang moreun cheok haetda."
           translation: "I just pretended like I didn't understand."
@@ -78668,7 +78668,7 @@ such a municipality in North Korea, the Republic of China, the People's Republic
   pos: n
   defs:
     - def: "heaven, paradise"
-      examples: 
+      examples:
         - example: "천국에 계신 우리 하느님이 세우신 주님의 왕국과 교회"
           transliteration: "cheon-guge gyesin uri haneunimi se-usin junimui wanggukgwa gyohoe"
           translation: "the Kingdom of God and the Church which our Father in heaven has established"
@@ -78814,7 +78814,7 @@ such a municipality in North Korea, the Republic of China, the People's Republic
   pos: n
   defs:
     - def: "heaven and earth"
-      examples: 
+      examples:
         - example: "太初에 하나님이 天地를 創造하시니라태초에 하나님이 천지를 창조하시니라."
           transliteration: "Taecho-e hananimi cheonjireul changjohasinira."
           translation: "In the beginning God created the heaven and the earth."
@@ -78994,7 +78994,7 @@ such a municipality in North Korea, the Republic of China, the People's Republic
   pos: n
   defs:
     - def: "pack (of herb medicine)"
-      examples: 
+      examples:
         - example: "(The addition of quotations indicative of this usage is being sought):"
 
 - word: 첩
@@ -79123,7 +79123,7 @@ such a municipality in North Korea, the Republic of China, the People's Republic
   pos: n
   defs:
     - def: "cleaning, sweeping"
-      examples: 
+      examples:
         - example: "그 도시의 거리 청소 업무는 비용이 아니라 수입의 원천이 된다."
           transliteration: "Geu dosiui geori cheongso eommuneun biyong-i anira su-ibui woncheoni doenda."
           translation: "[T]he street cleaning service of that city is a source of revenue instead of expense."
@@ -79266,7 +79266,7 @@ such a municipality in North Korea, the Republic of China, the People's Republic
   pos: n
   defs:
     - def: "uninflected/indeclinable word, indeclinable nominal (in Korean or Japanese)"
-      examples: 
+      examples:
         - example: "명사, 대명사, 수사는 체언에 속한다."
           transliteration: "Myeongsa, daemyeongsa, susaneun cheeone sokhanda."
           translation: "Nouns, pronouns, and numerals are classified as chaeeon."
@@ -79289,7 +79289,7 @@ such a municipality in North Korea, the Republic of China, the People's Republic
   pos: n
   defs:
     - def: "physical education"
-      examples: 
+      examples:
         - example: "내일 체육 시간에 1000미 달리기가 있다."
           transliteration: "Naeil cheyuk sigane 1000mi dalligiga itda."
           translation: "In PE class [we] have to run 1000 meters every day."
@@ -79417,7 +79417,7 @@ such a municipality in North Korea, the Republic of China, the People's Republic
   pos: n
   defs:
     - def: "the early part of a time period"
-      examples: 
+      examples:
         - example: "60년대 초"
           transliteration: "60nyeondae cho"
           translation: "The early 60's"
@@ -79427,7 +79427,7 @@ such a municipality in North Korea, the Republic of China, the People's Republic
   pos: n
   defs:
     - def: "high speed"
-      examples: 
+      examples:
         - example: "초고속 인터넷"
           transliteration: "chogosok inteonet"
           translation: "high-speed internet"
@@ -79455,7 +79455,7 @@ such a municipality in North Korea, the Republic of China, the People's Republic
   pos: v
   defs:
     - def: "to invite"
-      examples: 
+      examples:
         - example: "우리의 멋진 파티에 당신을 초대하고자 합니다."
           transliteration: "Uriui meotjin patie dangsineul chodaehagoja hamnida."
           translation: "We would like to invite you to come in on our great party."
@@ -79466,7 +79466,7 @@ such a municipality in North Korea, the Republic of China, the People's Republic
   pos: n
   defs:
     - def: "super"
-      examples: 
+      examples:
         - example: "관중과 수익 면에서 볼 때, 피파(FIFA) 월드컵이 그러한 종류 중에서는 가장 큰 초대형 체육 행사이다."
           transliteration: "Gwanjunggwa su-ik myeoneseo bol ttae, pipa(FIFA) woldeukeobi geureohan jongnyu jung-eseoneun gajang keun chodaehyeong cheyuk haengsaida."
           translation: "In terms of viewing audience and revenue, the FIFA World Cup is the largest sport megaevent of its kind [...]"
@@ -79703,7 +79703,7 @@ such a municipality in North Korea, the Republic of China, the People's Republic
   pos: n
   defs:
     - def: "bullet; shot"
-      examples: 
+      examples:
         - example: "총알이 발명된 이후 총알에 의해 죽은 사람의 숫자가 얼마나 될지 궁금하다."
           transliteration: "Chong-ari balmyeongdoen ihu chong-are uihae jugeun saramui sutjaga eolmana doelji gunggeumhada."
           translation: "I wonder how many people have been killed by the bullet since its invention."
@@ -79806,7 +79806,7 @@ such a municipality in North Korea, the Republic of China, the People's Republic
   pos: n
   defs:
     - def: "the last, the final"
-      examples: 
+      examples:
         - example: "공산주의의 최종목적"
           transliteration: "Gongsanjuuiui choejongmokjeok"
           translation: "The Ultimate Goal of Communism"
@@ -79844,7 +79844,7 @@ such a municipality in North Korea, the Republic of China, the People's Republic
   pos: n
   defs:
     - def: "addition"
-      examples: 
+      examples:
         - example: "추가의"
           transliteration: "chugaui"
           translation: "additional, supplementary"
@@ -79879,7 +79879,7 @@ such a municipality in North Korea, the Republic of China, the People's Republic
   pos: v
   defs:
     - def: "to dance"
-      examples: 
+      examples:
         - example: "춤을 추다"
           transliteration: "chumeul chuda"
           translation: "to dance"
@@ -80000,7 +80000,7 @@ such a municipality in North Korea, the Republic of China, the People's Republic
   pos: n
   defs:
     - def: "football, soccer"
-      examples: 
+      examples:
         - example: "축구를 하다"
           transliteration: "chukgureul hada"
           translation: "to play football"
@@ -80092,7 +80092,7 @@ such a municipality in North Korea, the Republic of China, the People's Republic
   pos: n
   defs:
     - def: "going to work"
-      examples: 
+      examples:
         - example: "그의 동료 중 누구도 그가 오전 아홉(9)시 전에 출근 카드를 기록한 것을 기억하지 못합니다."
           transliteration: "Geuui dongnyo jung nugudo geuga ojeon ahop(9)si jeone chulgeun kadeureul girokhan geoseul gieokhaji mothamnida."
           translation: "None of his colleagues remember he clocked in before 9 A.M."
@@ -80315,7 +80315,7 @@ such a municipality in North Korea, the Republic of China, the People's Republic
   pos: n
   defs:
     - def: "(one's innermost) heart"
-      examples: 
+      examples:
         - example: "충심으로 감사합니다"
           transliteration: "chungsimeuro gamsahamnida"
           translation: "I thank you from the bottom of my heart"
@@ -80457,7 +80457,7 @@ such a municipality in North Korea, the Republic of China, the People's Republic
   pos: suf
   defs:
     - def: "value."
-      examples: 
+      examples:
         - example: "계산치. 측정치."
 
 - word: 치
@@ -80465,7 +80465,7 @@ such a municipality in North Korea, the Republic of China, the People's Republic
   pos: suf
   defs:
     - def: "contraction of 하지."
-      examples: 
+      examples:
         - example: "중요치 않다."
 
 - word: 치는
@@ -80473,7 +80473,7 @@ such a municipality in North Korea, the Republic of China, the People's Republic
   pos: v
   defs:
     - def: "adnominal form of 치다 (chida)"
-      examples: 
+      examples:
         - example: "\"That hits,\" \"hitting.\""
         - example: "\"That plays,\" \"playing.\""
 
@@ -80483,7 +80483,7 @@ such a municipality in North Korea, the Republic of China, the People's Republic
   defs:
     - def: "to hit"
     - def: "to play"
-      examples: 
+      examples:
         - example: "테니스를 치다"
           transliteration: "teniseureul chida"
           translation: "to play tennis"
@@ -80576,7 +80576,7 @@ such a municipality in North Korea, the Republic of China, the People's Republic
   pos: n
   defs:
     - def: "cheese"
-      examples: 
+      examples:
         - example: "프랑스는 치즈의 생산지로 유명하다."
           transliteration: "Peurangseuneun chijeuui saengsanjiro yumyeonghada."
           translation: "France is famous as a source of cheese."
@@ -80695,7 +80695,7 @@ such a municipality in North Korea, the Republic of China, the People's Republic
   pos: a
   defs:
     - def: "to be close (intimate), familiar"
-      examples: 
+      examples:
         - example: "친한 친구"
           transliteration: "chinhan chin-gu"
           translation: "a close friend"
@@ -80871,7 +80871,7 @@ such a municipality in North Korea, the Republic of China, the People's Republic
   pos: n
   defs:
     - def: "bedroom"
-      examples: 
+      examples:
         - example: "한 각경 뒤, 캄캄한 신돈의 침실 밖에 계집 하인 하나가 어쩔줄 모르고 망설이고 있었다."
           transliteration: "Han gakgyeong dwi, kamkamhan sindonui chimsil bakke gyejip hain hanaga eojjeoljul moreugo mangseorigo isseotda."
           translation: "After about 15 minutes, a servant girl who in outside the Sin Don's dark bedroom was so hesitate that she didn't know what to do."
@@ -81171,7 +81171,7 @@ such a municipality in North Korea, the Republic of China, the People's Republic
   pos: n
   defs:
     - def: "caffeine"
-      examples: 
+      examples:
         - example: "커피와 차는 카페인을 즐긴다는 점에서 큰 차이가 없다."
           transliteration: "Keopiwa chaneun kapeineul jeulgindaneun jeomeseo keun chaiga eopda."
           translation: "There is not a big difference between coffee and tea as both contain caffeine [allow one to enjoy caffeine]."
@@ -81516,7 +81516,7 @@ such a municipality in North Korea, the Republic of China, the People's Republic
   pos: n
   defs:
     - def: "couple (two partners)"
-      examples: 
+      examples:
         - example: "잘 어울리는 커플이에요."
           transliteration: "Jal eoullineun keopeurieyo."
           translation: "You two are a perfect match."
@@ -81526,7 +81526,7 @@ such a municipality in North Korea, the Republic of China, the People's Republic
   pos: n
   defs:
     - def: "coffee, especially the beverage"
-      examples: 
+      examples:
         - example: "졸리면 커피를 좀 마셔 봐."
           transliteration: "Jollimyeon keopireul jom masyeo bwa."
           translation: "Drink some coffee if you feel sleepy."
@@ -81560,7 +81560,7 @@ such a municipality in North Korea, the Republic of China, the People's Republic
   pos: n
   defs:
     - def: "computer"
-      examples: 
+      examples:
         - example: "나는 내일 할인점에서 컴퓨터 하나를 사려고 해."
           transliteration: "Naneun naeil harinjeomeseo keompyuteo hanareul saryeogo hae."
           translation: "I'm going to get a computer tomorrow from the discount store."
@@ -81601,7 +81601,7 @@ such a municipality in North Korea, the Republic of China, the People's Republic
   pos: n
   defs:
     - def: "cake"
-      examples: 
+      examples:
         - example: "난 단지 케익을 아주 조금 먹었을 뿐이야."
           transliteration: "Nan danji keigeul aju jogeum meogeosseul ppuniya."
           translation: "I just ate a tiny little piece of the cake."
@@ -82004,7 +82004,7 @@ such a municipality in North Korea, the Republic of China, the People's Republic
   defs:
     - def: "call."
     - def: "OK, agreed (on a proposal)."
-      examples: 
+      examples:
         - example: "— 치맥 어때?— 콜!"
           transliteration: " chimaek eottae? kol!"
           translation: "— How about chicken and beer?— OK!"
@@ -82208,7 +82208,7 @@ such a municipality in North Korea, the Republic of China, the People's Republic
   pos: adv
   defs:
     - def: "snoringly"
-      examples: 
+      examples:
         - example: "쿨쿨 코를 골다"
           transliteration: "kulkul koreul golda"
           translation: "to snore loudly"
@@ -82265,7 +82265,7 @@ such a municipality in North Korea, the Republic of China, the People's Republic
   pos: n
   defs:
     - def: "quiz"
-      examples: 
+      examples:
         - example: "오늘은 청취자들을 위한 퀴즈 프로그램이 있습니다."
           transliteration: "Oneureun cheongchwijadeureul wihan kwijeu peurogeuraemi itseumnida."
           translation: "We’ve got a quiz show for you today."
@@ -82758,7 +82758,7 @@ such a municipality in North Korea, the Republic of China, the People's Republic
   pos: n
   defs:
     - def: "kilo (unit of weight), kilogram"
-      examples: 
+      examples:
         - example: "몸무게가 이 킬로나 빠졌다. (Mommuge-ga i killo-na bbajyeottda) [I] lost two kilos."
         - example: "쇠고기 일 킬로에 얼마나하죠? (soegogu il killo-e oelmana hajo?) How much is the beef per kilo?"
     - def: "kilometer."
@@ -83055,7 +83055,7 @@ such a municipality in North Korea, the Republic of China, the People's Republic
   pos: v
   defs:
     - def: "to compromise; to meet halfway"
-      examples: 
+      examples:
         - example: "이것은 당신이 당원이 되기 위해서 타협하는 것 중의 하나입니다."
           transliteration: "Igeoseun dangsini dang-woni doegi wihaeseo tahyeophaneun geot jung-ui hanaimnida."
           translation: "It is one of the things you compromise on to be a party member."
@@ -83075,7 +83075,7 @@ such a municipality in North Korea, the Republic of China, the People's Republic
   pos: n
   defs:
     - def: "table tennis, ping pong (game similar to tennis)"
-      examples: 
+      examples:
         - example: "탁구를 치다"
           transliteration: "takgureul chida"
           translation: "to play table tennis"
@@ -83109,7 +83109,7 @@ such a municipality in North Korea, the Republic of China, the People's Republic
   pos: v
   defs:
     - def: "Past determiner of 타다 (tada), thus often burnt or embarked"
-      examples: 
+      examples:
         - example: "불에 탄 숭례문"
           transliteration: "bure tan Sungnyemun"
           translation: "the burnt Sungnyemun gate"
@@ -83340,17 +83340,17 @@ such a municipality in North Korea, the Republic of China, the People's Republic
   pos: n
   defs:
     - def: "cause, reason"
-      examples: 
+      examples:
         - example: "이번 사고는 전기 누전 탓이다."
           transliteration: "Ibeon sagoneun jeon-gi nujeon tasida."
           translation: "This accident is due to electrical leakage."
     - def: "defect, fault"
-      examples: 
+      examples:
         - example: "남탓"
           transliteration: "namtat"
           translation: "other's fault"
     - def: "blame, fault, scolding"
-      examples: 
+      examples:
         - example: "그의 친구들은 그 실패를 그의 탓으로 돌렸다."
           transliteration: "Geuui chin-gudeureun geu silpaereul geuui taseuro dollyeotda."
           translation: "His friends put the blame for the failure on him."
@@ -83442,7 +83442,7 @@ such a municipality in North Korea, the Republic of China, the People's Republic
   defs:
     - def: "the Sun"
     - def: "Someone of extraordinary importance."
-      examples: 
+      examples:
         - example: "아이들의 태양이 되어주실 선생"
           transliteration: "aideur-ui taeyang-i doe-eojusil seonsaeng"
           translation: "a teacher who will be the center of the children's lives"
@@ -83470,7 +83470,7 @@ such a municipality in North Korea, the Republic of China, the People's Republic
   pos: n
   defs:
     - def: "sun-dried chili pepper"
-      examples: 
+      examples:
         - example: "태양초 고춧가루"
           transliteration: "taeyangcho gochutgaru"
           translation: "sun-dried chili pepper powder"
@@ -83494,7 +83494,7 @@ such a municipality in North Korea, the Republic of China, the People's Republic
   pos: v
   defs:
     - def: "to give a ride/lift"
-      examples: 
+      examples:
         - example: "인천 공항까지 좀 태워 주실래요?"
           transliteration: "Incheon gonghangkkaji jom taewo jusillaeyo?"
           translation: "Can you give me a ride to Incheon airport?"
@@ -83511,7 +83511,7 @@ such a municipality in North Korea, the Republic of China, the People's Republic
   pos: n
   defs:
     - def: "the beginning [of the world]"
-      examples: 
+      examples:
         - example: "太初에 하나님이 天地를 創造하시니라태초에 하나님이 천지를 창조하시니라."
           transliteration: "Taechoe hananimi cheonjireul changjohasinira."
           translation: "In the beginning God created the heaven and the earth."
@@ -83600,7 +83600,7 @@ such a municipality in North Korea, the Republic of China, the People's Republic
   pos: n
   defs:
     - def: "(dependent) inference; intention, plan"
-      examples: 
+      examples:
         - example: "출근 시간이라 사람 많을 텐데 (=터인데)."
           transliteration: "Chulgeun siganira saram maneul tende (=teoinde)."
           translation: "I think it'll be crowded. It's rush hour!"
@@ -83608,7 +83608,7 @@ such a municipality in North Korea, the Republic of China, the People's Republic
           transliteration: "Ibeonen kkok haenaego mal teya!"
           translation: "I will make it out this time!"
     - def: "(dependent) situation, circumstance"
-      examples: 
+      examples:
         - example: "지난 밤에 한숨도 못 잔 터라 지금 몹시 피곤하다."
           transliteration: "Jinan bame hansumdo mot jan teora jigeum mopsi pigonhada."
           translation: "I couldn't sleep a wink last night so I'm very tired now."
@@ -83637,7 +83637,7 @@ such a municipality in North Korea, the Republic of China, the People's Republic
   pos: n
   defs:
     - def: "terminal (various senses)"
-      examples: 
+      examples:
         - example: "고속버스 터미널"
           transliteration: "gosokbeoseu teomineol"
           translation: "express bus terminal"
@@ -83774,7 +83774,7 @@ such a municipality in North Korea, the Republic of China, the People's Republic
   pos: n
   defs:
     - def: "tennis"
-      examples: 
+      examples:
         - example: "테니스를 치다"
           transliteration: "teniseureul chida"
           translation: "to play tennis"
@@ -83828,7 +83828,7 @@ such a municipality in North Korea, the Republic of China, the People's Republic
   pos: n
   defs:
     - def: "test, examination"
-      examples: 
+      examples:
         - example: "아이큐 테스트"
           transliteration: "aikyu teseuteu"
           translation: "IQ test"
@@ -83892,7 +83892,7 @@ such a municipality in North Korea, the Republic of China, the People's Republic
   pos: n
   defs:
     - def: "television"
-      examples: 
+      examples:
         - example: "텔레비전 채널, 애니멀 플래닛은 2005년에 \"퍼피 볼\"을 창작했다."
           transliteration: "Tellebijeon chaeneol, Aenimeol Peullaeniseun 2005nyeone Peopi Bol-eul changjakhaetda."
           translation: "The Animal Planet television channel created the Puppy Bowl in 2005."
@@ -84101,7 +84101,7 @@ such a municipality in North Korea, the Republic of China, the People's Republic
   pos: n
   defs:
     - def: "the native language of a region; a regional language; a regional dialect"
-      examples: 
+      examples:
         - example: "제주도는 지리적 여건으로 말미암아 한국어의 특수한 토착어를 형성하였다."
           transliteration: "Jejudoneun jirijeok yeogeoneuro malmiama han-gugeoui teuksuhan tochageoreul hyeongseonghayeotda."
           translation: "Due to its geographic situation, Cheju Island developed a unique regional dialect of Korean."
@@ -84340,7 +84340,7 @@ such a municipality in North Korea, the Republic of China, the People's Republic
   pos: n
   defs:
     - def: "Compost."
-      examples: 
+      examples:
         - example: "그 시설은 단지 8주만에 음식물 쓰레기를,  가정용 및 농업용으로 적합한 풍부하고 깨끗한 퇴비로 만들 것입니다."
           transliteration: "Geu siseoreun danji 8jumane eumsingmul sseuregireul,  gajeong-yong mit nong-eobyong-euro jeokhaphan pungbuhago kkaekkeuthan toebiro mandeul geosimnida."
           translation: "[The] facility […] in just eight weeks, turns [the food waste] into a rich, clean compost suitable for home and agricultural use."
@@ -84520,7 +84520,7 @@ such a municipality in North Korea, the Republic of China, the People's Republic
   pos: n
   defs:
     - def: "Turkic"
-      examples: 
+      examples:
         - example: "튀르크 어족"
           transliteration: "twireukeu eojok"
           translation: "Turkic languages"
@@ -84591,7 +84591,7 @@ such a municipality in North Korea, the Republic of China, the People's Republic
   pos: n
   defs:
     - def: "(a pack of) playing cards"
-      examples: 
+      examples:
         - example: "트럼프를 하다"
           transliteration: "teureompeureul hada"
           translation: "to play cards"
@@ -84601,7 +84601,7 @@ such a municipality in North Korea, the Republic of China, the People's Republic
   pos: propn
   defs:
     - def: "Trump (surname)"
-      examples: 
+      examples:
         - example: "도널드 트럼프"
           transliteration: "Doneoldeu Teureompeu"
           translation: "Donald Trump"
@@ -84683,7 +84683,7 @@ such a municipality in North Korea, the Republic of China, the People's Republic
   pos: n
   defs:
     - def: "burp, belching"
-      examples: 
+      examples:
         - example: "트림(이) 나오다"
           transliteration: "teurim(i) naoda"
           translation: " to come out"
@@ -84792,7 +84792,7 @@ such a municipality in North Korea, the Republic of China, the People's Republic
   pos: a
   defs:
     - def: "(to be) sturdy, strong"
-      examples: 
+      examples:
         - example: "내가 샀던 나무상자는 진짜로 튼튼하지."
           transliteration: "Naega satdeon namusangjaneun jinjjaro teunteunhaji."
           translation: "The wooden box that I bought is really sturdy. (casual)"
@@ -84816,7 +84816,7 @@ such a municipality in North Korea, the Republic of China, the People's Republic
     - def: "to turn, twist, wrench"
     - def: "to thwart"
     - def: "to turn on a machine that produces sound"
-      examples: 
+      examples:
         - example: "라디오를 틀다"
           transliteration: "radioreul teulda"
           translation: "to turn on the radio"
@@ -84828,7 +84828,7 @@ such a municipality in North Korea, the Republic of China, the People's Republic
   defs:
     - def: "to become turned, twisted"
     - def: "to become wrong"
-      examples: 
+      examples:
         - example: "시험에서 세 개의 틀린 답변을 냈다."
           transliteration: "Siheomeseo se gae-ui teullin dapbyeoneul naetda."
           translation: "I had three wrong answers on the test."
@@ -85013,7 +85013,7 @@ such a municipality in North Korea, the Republic of China, the People's Republic
   pos: n
   defs:
     - def: "A wave of water or emotion."
-      examples: 
+      examples:
         - example: "파도는 대부분 바람에 의해 만들어진다."
           transliteration: "Padoneun daebubun barame uihae mandeureojinda."
           translation: "Waves are mostly made by the wind."
@@ -85214,7 +85214,7 @@ such a municipality in North Korea, the Republic of China, the People's Republic
   pos: intj
   defs:
     - def: "good luck!; go for it!, go!, come on!"
-      examples: 
+      examples:
         - example: "대한민국, 파이팅!"
           transliteration: "Daehanmin-guk, paiting!"
           translation: "Go, Korea!"
@@ -85249,7 +85249,7 @@ such a municipality in North Korea, the Republic of China, the People's Republic
   pos: n
   defs:
     - def: "pajamas (clothes for wearing to bed and sleeping in)"
-      examples: 
+      examples:
         - example: "난 파자마를 입고 있어."
           transliteration: "Nan pajamareul ipgo isseo."
           translation: "I'm wearing pajamas."
@@ -85301,7 +85301,7 @@ such a municipality in North Korea, the Republic of China, the People's Republic
   pos: n
   defs:
     - def: "part-time"
-      examples: 
+      examples:
         - example: "파트타임 일자리를 구하다"
           transliteration: "pateutaim iljarireul guhada"
           translation: "to look for a part-time job"
@@ -85402,28 +85402,28 @@ such a municipality in North Korea, the Republic of China, the People's Republic
   pos: v
   defs:
     - def: "判: to judge"
-      examples: 
+      examples:
         - example: "(eumhun reading: 판단할 판 (pandanhal pan), MC reading: 判 (MC pʰuɑn))"
     - def: "販: to sell"
-      examples: 
+      examples:
         - example: "(eumhun reading: 팔 판 (pal pan), MC reading: 販 (MC pʉɐn))"
     - def: "贩: to sell"
-      examples: 
+      examples:
         - example: "(eumhun reading: 팔 판 (pal pan), MC reading: 贩)"
     - def: "辦: to exert oneself"
-      examples: 
+      examples:
         - example: "(eumhun reading: 힘들일 판 (himdeuril pan), MC reading: 辦 (MC bˠɛn))"
     - def: "办: to exert oneself"
-      examples: 
+      examples:
         - example: "(eumhun reading: 힘들일 판 (himdeuril pan), MC reading: 办)"
     - def: "辧: to have"
-      examples: 
+      examples:
         - example: "(eumhun reading: 갖출 판 (gatchul pan), MC reading: 辧)"
     - def: "瓪: to be defeated"
-      examples: 
+      examples:
         - example: "(eumhun reading: 패할 판 (paehal pan), MC reading: 瓪 (MC puɑn, pˠan))"
     - def: "㤆: to repent"
-      examples: 
+      examples:
         - example: "(eumhun reading: 뉘우칠 판 (nwiuchil pan), MC reading: 㤆 (MC pʰʉɐn))"
 
 - word: 판
@@ -85431,49 +85431,49 @@ such a municipality in North Korea, the Republic of China, the People's Republic
   pos: n
   defs:
     - def: "板: board, plank"
-      examples: 
+      examples:
         - example: "(eumhun reading: 널빤지 판 (neolppanji pan), MC reading: 板 (MC pˠan))"
     - def: "版: wooden block"
-      examples: 
+      examples:
         - example: "(eumhun reading: 판목 판 (panmok pan), MC reading: 版 (MC pˠan))"
     - def: "阪: hill"
-      examples: 
+      examples:
         - example: "(eumhun reading: 언덕 판 (eondeok pan), MC reading: 阪 (MC pʉɐn, bˠan))"
     - def: "坂: hill"
-      examples: 
+      examples:
         - example: "(eumhun reading: 언덕 판 (eondeok pan), MC reading: 坂 (MC pʉɐn))"
     - def: "岅: hill"
-      examples: 
+      examples:
         - example: "(eumhun reading: 언덕 판 (eondeok pan), MC reading: 岅)"
     - def: "瓣: cucumber seeds"
-      examples: 
+      examples:
         - example: "(eumhun reading: 외씨 판 (oessi pan), MC reading: 瓣 (MC bˠɛn))"
     - def: "鈑: gold foil"
-      examples: 
+      examples:
         - example: "(eumhun reading: 금박 판 (geumbak pan), MC reading: 鈑 (MC pˠan))"
     - def: "钣: gold foil"
-      examples: 
+      examples:
         - example: "(eumhun reading: 금박 판 (geumbak pan), MC reading: 钣)"
     - def: "汴: river name"
-      examples: 
+      examples:
         - example: "(eumhun reading: 물 이름 판 (mul ireum pan), MC reading: 汴 (MC bˠiᴇn))"
     - def: "舨: boat"
-      examples: 
+      examples:
         - example: "(eumhun reading: 배 판 (bae pan), MC reading: 舨)"
     - def: "蝂: insect name"
-      examples: 
+      examples:
         - example: "(eumhun reading: 벌레 이름 판 (beolle ireum pan), MC reading: 蝂 (MC pˠan))"
     - def: "畈: field"
-      examples: 
+      examples:
         - example: "(eumhun reading: 밭 판 (bat pan), MC reading: 畈 (MC pʉɐn))"
     - def: "眅: disdainful look"
-      examples: 
+      examples:
         - example: "(eumhun reading: 눈 흰자위 많을 판 (nun huinjawi maneul pan), MC reading: 眅 (MC pʰˠan, pʰˠan))"
     - def: "鵥: eagle"
-      examples: 
+      examples:
         - example: "(eumhun reading: 독수리 판 (doksuri pan), MC reading: 鵥)"
     - def: "粄: 싸라기떡"
-      examples: 
+      examples:
         - example: "(MC reading: 粄 (MC puɑn))"
 
 - word: 판
@@ -85481,7 +85481,7 @@ such a municipality in North Korea, the Republic of China, the People's Republic
   pos: a
   defs:
     - def: "昄: big"
-      examples: 
+      examples:
         - example: "(eumhun reading: 클 판 (keul pan), MC reading: 昄 (MC puɑn, pˠan, bˠan))"
 
 - word: 판결
@@ -85539,7 +85539,7 @@ such a municipality in North Korea, the Republic of China, the People's Republic
   pos: n
   defs:
     - def: "selling; sale"
-      examples: 
+      examples:
         - example: "그녀는 자신이 좋아하는 상점의 할인판매 광고를 보고 쇼핑을 하기로 했다."
           transliteration: "Geunyeoneun jasini joahaneun sangjeomui harinpanmae gwanggoreul bogo syoping-eul hagiro haetda."
           translation: "She decided to go shopping after reading an advertisement of a sale at her favorite store."
@@ -85698,7 +85698,7 @@ such a municipality in North Korea, the Republic of China, the People's Republic
   pos: n
   defs:
     - def: "bracelet, bangle"
-      examples: 
+      examples:
         - example: "팔찌를 끼다 (paljji-reul ggida) Put on/wear a bracelet."
 
 - word: 팝송
@@ -85978,7 +85978,7 @@ such a municipality in North Korea, the Republic of China, the People's Republic
   pos: propn
   defs:
     - def: "Persia"
-      examples: 
+      examples:
         - example: "페르시아어"
           transliteration: "pereusiaeo"
           translation: "Persian (language)"
@@ -86027,7 +86027,7 @@ such a municipality in North Korea, the Republic of China, the People's Republic
   pos: n
   defs:
     - def: "page"
-      examples: 
+      examples:
         - example: "웹페지"
           transliteration: "weppeji"
           translation: "webpage"
@@ -86105,7 +86105,7 @@ such a municipality in North Korea, the Republic of China, the People's Republic
     - def: "to spread, stretch, or expand something"
     - def: "to unfold"
     - def: "to open"
-      examples: 
+      examples:
         - example: "책을 펴세요."
           transliteration: "Chaegeul pyeoseyo."
           translation: "Please open the book."
@@ -86121,7 +86121,7 @@ such a municipality in North Korea, the Republic of China, the People's Republic
     - def: "to spread, stretch, or expand something"
     - def: "to unfold"
     - def: "to open"
-      examples: 
+      examples:
         - example: "책을 펴세요."
           transliteration: "Chaegeul pyeoseyo."
           translation: "Please open the book."
@@ -86241,7 +86241,7 @@ such a municipality in North Korea, the Republic of China, the People's Republic
   pos: n
   defs:
     - def: "editor"
-      examples: 
+      examples:
         - example: "나는 우리 편집자들 여러 명과의 회의에 늦었다."
           transliteration: "Naneun uri pyeonjipjadeul yeoreo myeonggwaui hoe-uie neujeotda."
           translation: "I'm late for the meeting with several of our editors."
@@ -86258,7 +86258,7 @@ such a municipality in North Korea, the Republic of China, the People's Republic
   pos: a
   defs:
     - def: "to be ill, sick"
-      examples: 
+      examples:
         - example: "어디가 편찮으세요?"
           transliteration: "Eodiga pyeonchaneuseyo?"
           translation: "Where [do you feel] ill?"
@@ -86338,7 +86338,7 @@ such a municipality in North Korea, the Republic of China, the People's Republic
   pos: n
   defs:
     - def: "mediocrity, commonness"
-      examples: 
+      examples:
         - example: "평범한게 가장 좋다."
           transliteration: "Pyeongbeomhan-ge gajang jota."
           translation: "Being normal is the best."
@@ -86348,7 +86348,7 @@ such a municipality in North Korea, the Republic of China, the People's Republic
   pos: a
   defs:
     - def: "(to be) average, ordinary, common, mediocre"
-      examples: 
+      examples:
         - example: "평범한 제안을 한 가지 드리겠습니다."
           transliteration: "Pyeongbeomhan jeaneul han gaji deurigetseumnida."
           translation: "I'd like to offer a modest proposal."
@@ -86469,7 +86469,7 @@ such a municipality in North Korea, the Republic of China, the People's Republic
   pos: n
   defs:
     - def: "lung, pulmonary (organ)"
-      examples: 
+      examples:
         - example: "폐와 심장은 생명을 유지시키기 위해 서로 협동한다."
           transliteration: "Pyewa simjang-eun saengmyeong-eul yujisikigi wihae seoro hyeopdonghanda."
           translation: "The lungs and the heart collaborate to make the body function properly."
@@ -86639,7 +86639,7 @@ such a municipality in North Korea, the Republic of China, the People's Republic
   pos: n
   defs:
     - def: "formaldehyde"
-      examples: 
+      examples:
         - example: "그의 어머니는 항상 포름알데히드 냄새를 맡았다."
           transliteration: "Geuui eomeonineun hangsang poreumaldehideu naemsaereul matatda."
           translation: "His mother always smelled of formaldehyde."
@@ -86774,7 +86774,7 @@ such a municipality in North Korea, the Republic of China, the People's Republic
   pos: n
   defs:
     - def: "prepuce, foreskin"
-      examples: 
+      examples:
         - example: "포피재건술"
           transliteration: "popijaegeonsul"
           translation: "foreskin restoration"
@@ -86884,7 +86884,7 @@ such a municipality in North Korea, the Republic of China, the People's Republic
   pos: n
   defs:
     - def: "storm"
-      examples: 
+      examples:
         - example: "폭풍이 오고 있소."
           transliteration: "Pokpung-i ogo itso."
           translation: "Storm's coming."
@@ -87107,7 +87107,7 @@ such a municipality in North Korea, the Republic of China, the People's Republic
   pos: a
   defs:
     - def: "(to be) blue; (to be) green"
-      examples: 
+      examples:
         - example: "푸른 하늘"
           transliteration: "pureun haneul"
           translation: "azure sky"
@@ -87126,7 +87126,7 @@ such a municipality in North Korea, the Republic of China, the People's Republic
   pos: a
   defs:
     - def: "(to be) blue; (to be) green"
-      examples: 
+      examples:
         - example: "푸른 하늘"
           transliteration: "pureun haneul"
           translation: "azure sky"
@@ -87166,7 +87166,7 @@ such a municipality in North Korea, the Republic of China, the People's Republic
   pos: adv
   defs:
     - def: "completely; well; enough"
-      examples: 
+      examples:
         - example: "푹 쉬다"
           transliteration: "puk swida"
           translation: "to get a good rest"
@@ -87198,7 +87198,7 @@ such a municipality in North Korea, the Republic of China, the People's Republic
     - def: "to untie"
     - def: "to loosen up"
     - def: "to solve"
-      examples: 
+      examples:
         - example: "난 실용적이라기보다는 이론적으로 그 문제를 풀었다."
           transliteration: "Nan siryongjeogiragibodaneun ironjeogeuro geu munjereul pureotda."
           translation: "I solved the problem theoretically rather than practically."
@@ -87297,7 +87297,7 @@ such a municipality in North Korea, the Republic of China, the People's Republic
   pos: n
   defs:
     - def: "absence of stock, being out of stock"
-      examples: 
+      examples:
         - example: "품절녀(品切女)"
           transliteration: "pumjeollyeo"
           translation: "woman who is married and, therefore unavailable"
@@ -87504,7 +87504,7 @@ such a municipality in North Korea, the Republic of China, the People's Republic
   pos: n
   defs:
     - def: "French (language)"
-      examples: 
+      examples:
         - example: "저는 프랑스어를 공부할 준비가 되었어요."
           transliteration: "Jeoneun peurangseueoreul gongbuhal junbiga doeeosseoyo."
           translation: "I am ready to learn French."
@@ -87559,7 +87559,7 @@ such a municipality in North Korea, the Republic of China, the People's Republic
   defs:
     - def: "a computer program"
     - def: "a television program, show"
-      examples: 
+      examples:
         - example: "날마다 난 아침 프로그램을 진행해."
           transliteration: "Nalmada nan achim peurogeuraemeul jinhaenghae."
           translation: "Every day I do my morning show."
@@ -87814,7 +87814,7 @@ such a municipality in North Korea, the Republic of China, the People's Republic
   pos: n
   defs:
     - def: "blood"
-      examples: 
+      examples:
         - example: "피는 골수에서 만들어진다."
           transliteration: "Pineun golsueseo mandeureojinda."
           translation: "Blood is produced in the bone marrow."
@@ -87859,7 +87859,7 @@ such a municipality in North Korea, the Republic of China, the People's Republic
   pos: v
   defs:
     - def: "to bloom"
-      examples: 
+      examples:
         - example: "봄에는 꽃이 펴요."
           transliteration: "Bomeneun kkochi pyeoyo."
           translation: "In spring flowers bloom."
@@ -87949,7 +87949,7 @@ such a municipality in North Korea, the Republic of China, the People's Republic
   pos: n
   defs:
     - def: "skin"
-      examples: 
+      examples:
         - example: "매일 세수를 안하면 얼굴 피부에 먼지가 달라붙어 여드름이 생길 수도 있다."
           transliteration: "Maeil sesureul anhamyeon eolgul pibue meonjiga dallabuteo yeodeureumi saenggil sudo itda."
           translation: "If you don't wash your face every day, it will stick to the skin of your face and cause pimples."
@@ -88013,7 +88013,7 @@ such a municipality in North Korea, the Republic of China, the People's Republic
   pos: v
   defs:
     - def: "to smoke"
-      examples: 
+      examples:
         - example: "여기서 담배 피워도 되나요?"
           transliteration: "Yeogiseo dambae piwodo doenayo?"
           translation: "Can I smoke here?"
@@ -88137,12 +88137,12 @@ such a municipality in North Korea, the Republic of China, the People's Republic
   pos: n
   defs:
     - def: "A bolt or roll of cloth"
-      examples: 
+      examples:
         - example: "한 필의 베적삼"
           transliteration: "han pir-ui bejeoksam"
           translation: "one bolt of summer silk"
     - def: "A head of horse or cattle"
-      examples: 
+      examples:
         - example: "네 필의 말"
           transliteration: "ne pir-ui mal"
           translation: "four horses"
@@ -88204,7 +88204,7 @@ such a municipality in North Korea, the Republic of China, the People's Republic
   pos: n
   defs:
     - def: "need, necessity"
-      examples: 
+      examples:
         - example: "그들이 이것을 필요로 할 때면 언제든지"
           transliteration: "geudeuri igeoseul piryoro hal ttaemyeon eonjedeunji"
           translation: "whenever they would need it"
@@ -88214,7 +88214,7 @@ such a municipality in North Korea, the Republic of China, the People's Republic
   pos: n
   defs:
     - def: "necessity, need"
-      examples: 
+      examples:
         - example: "필요성을 느끼다"
           transliteration: "piryoseong-eul neukkida"
           translation: "to feel the need"
@@ -88224,7 +88224,7 @@ such a municipality in North Korea, the Republic of China, the People's Republic
   pos: a
   defs:
     - def: "to have a need"
-      examples: 
+      examples:
         - example: "그 각각은 훌륭한 가정이 필요합니다."
           transliteration: "Geu gakgageun hullyunghan gajeong-i piryohamnida."
           translation: "Each one is in need of a good home."
@@ -88281,7 +88281,7 @@ such a municipality in North Korea, the Republic of China, the People's Republic
   pos: adv
   defs:
     - def: "honestly, in fact, really, indeed (used as a positive feedback for an aforementioned topic in a conversation)"
-      examples: 
+      examples:
         - example: "하긴 결과가 잘 나와서 다행이다."
           transliteration: "Hagin gyeolgwaga jal nawaseo dahaeng-ida."
           translation: "Honestly, (I'm) relieved that the result turned out fine."
@@ -88291,7 +88291,7 @@ such a municipality in North Korea, the Republic of China, the People's Republic
   pos: n
   defs:
     - def: "one"
-      examples: 
+      examples:
         - example: "아나, 너 펜 있어? — 응 가방에 펜 하나가 있어. 하나가…"
           transliteration: "Ana, neo pen isseo?  eung gabang-e pen hanaga isseo. Hanaga…"
           translation: "Anna, do you have a pen?  —  Yes. I have a pen in my bag. I have a …"
@@ -88303,12 +88303,12 @@ such a municipality in North Korea, the Republic of China, the People's Republic
   pos: n
   defs:
     - def: "God, creator"
-      examples: 
+      examples:
         - example: "太初에 하나님이 天地를 創造하시니라태초에 하나님이 천지를 창조하시니라."
           transliteration: "Taecho-e hananimi cheonjireul changjohasinira."
           translation: "In the beginning God created the heaven and the earth."
     - def: "God, creator"
-      examples: 
+      examples:
         - example: "하나님 외에 다른 신은 없습니다. 무함마드는 그분의 사도입니다."
           transliteration: "Hananim oee dareun sineun eopseumnida. Muhammadeuneun geubunui sadoimnida."
           translation: "There is no god but God. Muhammad is the messenger of God."
@@ -88318,7 +88318,7 @@ such a municipality in North Korea, the Republic of China, the People's Republic
   pos: n
   defs:
     - def: "one"
-      examples: 
+      examples:
         - example: "아나, 너 펜 있어? — 응 가방에 펜 하나가 있어. 하나가…"
           transliteration: "Ana, neo pen isseo?  eung gabang-e pen hanaga isseo. Hanaga…"
           translation: "Anna, do you have a pen?  —  Yes. I have a pen in my bag. I have a …"
@@ -88340,12 +88340,12 @@ such a municipality in North Korea, the Republic of China, the People's Republic
   pos: n
   defs:
     - def: "God, heaven"
-      examples: 
+      examples:
         - example: "하느님이 보우하사 우리나라 만세!"
           transliteration: "Haneunimi bouhasa urinara manse!"
           translation: "May God preserve our country for ten thousand years!"
     - def: "God, creator"
-      examples: 
+      examples:
         - example: "한처음에 하느님께서 하늘과 땅을 창조하셨다."
           transliteration: "Hancheo-eume haneunimkkeseo haneulgwa ttang-eul changjohasyeotda."
           translation: "In the beginning God created the heavens and the earth."
@@ -88356,7 +88356,7 @@ such a municipality in North Korea, the Republic of China, the People's Republic
   defs:
     - def: "sky"
     - def: "heaven"
-      examples: 
+      examples:
         - example: "하늘이 무섭지 않는가?"
           transliteration: "Haneuri museopji anneun-ga?"
           translation: "Do you not fear heaven?"
@@ -88380,7 +88380,7 @@ such a municipality in North Korea, the Republic of China, the People's Republic
   pos: v
   defs:
     - def: "(…을 하다) to do"
-      examples: 
+      examples:
         - example: "하루 분의 일을 하다"
           transliteration: "haru bunui ireul hada"
           translation: "to do a full day of work"
@@ -88421,7 +88421,7 @@ such a municipality in North Korea, the Republic of China, the People's Republic
           transliteration: "Eoreun ai hal geot eopsi modu deultteo itda."
           translation: "Everyone is excited regardless of age."
     - def: "to do"
-      examples: 
+      examples:
         - example: "하루 분의 일을 하다"
           transliteration: "haru bunui ireul hada"
           translation: "to do a full day of work"
@@ -88429,72 +88429,72 @@ such a municipality in North Korea, the Republic of China, the People's Republic
           transliteration: "Jega hal su isseoyo."
           translation: "I can do it."
     - def: "to make; to arrange; to cook"
-      examples: 
+      examples:
         - example: "내일 먹을 밥을 미리 하다"
           transliteration: "naeil meogeul babeul miri hada"
           translation: "to cook rice ahead for tomorrow"
     - def: "to express feeling or attitude"
-      examples: 
+      examples:
         - example: "어두운 얼굴을 하다"
           transliteration: "eoduun eolgureul hada"
           translation: "to wear a gloomy face"
     - def: "to take; to eat; to drink"
-      examples: 
+      examples:
         - example: "술을 좀처럼 하지 않다"
           transliteration: "sureul jomcheoreom haji anta"
           translation: "to rarely drink alcohol"
     - def: "to wear"
-      examples: 
+      examples:
         - example: "화려한 귀걸이를 하고 나가다"
           transliteration: "hwaryeohan gwigeorireul hago nagada"
           translation: "to go out wearing a fancy earring"
     - def: "to work in/as; to operate"
-      examples: 
+      examples:
         - example: "조그만 옷가게를 하다"
           transliteration: "jogeuman otgagereul hada"
           translation: "to run a small clothing store"
     - def: "to play a role; to take a responsibility for"
-      examples: 
+      examples:
         - example: "학생 회장을 하다"
           transliteration: "haksaeng hoejang-eul hada"
           translation: "to be the student body president"
     - def: "to get a result"
-      examples: 
+      examples:
         - example: "반에서 일등을 하다"
           transliteration: "baneseo ildeung-eul hada"
           translation: "to be at top of one's class"
     - def: "to buy; to arrange"
-      examples: 
+      examples:
         - example: "휴대폰을 하나 하다"
           transliteration: "hyudaeponeul hana hada"
           translation: "to buy a cell phone"
     - def: "to reach a certain price"
-      examples: 
+      examples:
         - example: "집 한 채에 십 억이나 한다"
           transliteration: "jip han chaee sip eogina handa"
           translation: "That house is as much as a billion won."
     - def: "(in the form of '…값을 하다') to meet an expectation"
-      examples: 
+      examples:
         - example: "밥값은 해야지."
           transliteration: "Bapgapseun haeyaji."
           translation: "I will be worthy of food. (I will work.)"
     - def: "(in the form of 'A B 할 것 없이') to say separately"
-      examples: 
+      examples:
         - example: "어른 아이 할 것 없이 모두 들떠 있다."
           transliteration: "Eoreun ai hal geot eopsi modu deultteo itda."
           translation: "Everyone is excited regardless of age."
     - def: "(…을 —게 하다) to handle; to dispose"
-      examples: 
+      examples:
         - example: "이 사기범을 어떻게 할까요?"
           transliteration: "I sagibeomeul eotteoke halkkayo?"
           translation: "What to do with this swindler?"
     - def: "to handle; to dispose"
-      examples: 
+      examples:
         - example: "이 사기범을 어떻게 할까요?"
           transliteration: "I sagibeomeul eotteoke halkkayo?"
           translation: "What to do with this swindler?"
     - def: "(…을 …으로 하다) to make become; to cause to become"
-      examples: 
+      examples:
         - example: "여자를 아내로 하다"
           transliteration: "yeojareul anaero hada"
           translation: "to make a woman become one's wife"
@@ -88505,34 +88505,34 @@ such a municipality in North Korea, the Republic of China, the People's Republic
           transliteration: "naeil dasi mannagiro hada"
           translation: "to decide to meet again tomorrow"
     - def: "to make become; to cause to become"
-      examples: 
+      examples:
         - example: "여자를 아내로 하다"
           transliteration: "yeojareul anaero hada"
           translation: "to make a woman become one's wife"
     - def: "to head; to face"
-      examples: 
+      examples:
         - example: "머리를 북쪽으로 하고 자다"
           transliteration: "meorireul bukjjogeuro hago jada"
           translation: "to sleep with the head northward."
     - def: "to decide"
-      examples: 
+      examples:
         - example: "내일 다시 만나기로 하다"
           transliteration: "naeil dasi mannagiro hada"
           translation: "to decide to meet again tomorrow"
     - def: "…을 —고 하다
 to call; to name"
-      examples: 
+      examples:
         - example: "다른 말과 뜻이 같은 말을 '동의어'라고 한다."
           transliteration: "Dareun malgwa tteusi gateun mareul  dong-uieo rago handa."
           translation: "We call a word which means the same with another word a 'synonym'."
     - def: "to call; to name"
-      examples: 
+      examples:
         - example: "다른 말과 뜻이 같은 말을 '동의어'라고 한다."
           transliteration: "Dareun malgwa tteusi gateun mareul  dong-uieo rago handa."
           translation: "We call a word which means the same with another word a 'synonym'."
     - def: "…으로 하다
 (in the form of '해서' or '하여') to be caused by"
-      examples: 
+      examples:
         - example: "이 일로 하여 그는 중징계를 받았다."
           transliteration: "I illo hayeo geuneun jungjinggyereul badatda."
           translation: "Due to this incident, he got heavily disciplined."
@@ -88540,18 +88540,18 @@ to call; to name"
           transliteration: "Busaneuro haeseo ilbone gal saenggagida."
           translation: "I'm going to visit Japan via Busan."
     - def: "(in the form of '해서' or '하여') to be caused by"
-      examples: 
+      examples:
         - example: "이 일로 하여 그는 중징계를 받았다."
           transliteration: "I illo hayeo geuneun jungjinggyereul badatda."
           translation: "Due to this incident, he got heavily disciplined."
     - def: "(in the form of '해서' or '하여') to go via"
-      examples: 
+      examples:
         - example: "부산으로 해서 일본에 갈 생각이다."
           transliteration: "Busaneuro haeseo ilbone gal saenggagida."
           translation: "I'm going to visit Japan via Busan."
     - def: "See below:
 (in the form of '…쯤 해서') to reach a certain time"
-      examples: 
+      examples:
         - example: "12시 반쯤 해서 갈게."
           transliteration: "12si banjjeum haeseo galge."
           translation: "I'll be there around 12:30."
@@ -88559,18 +88559,18 @@ to call; to name"
           transliteration: "Maekju hamyeon yeoksi dogirida."
           translation: "To say about beer, Germany is the best."
     - def: "(in the form of '…쯤 해서') to reach a certain time"
-      examples: 
+      examples:
         - example: "12시 반쯤 해서 갈게."
           transliteration: "12si banjjeum haeseo galge."
           translation: "I'll be there around 12:30."
     - def: "(in the form of '… 하면') to make something a topic"
-      examples: 
+      examples:
         - example: "맥주 하면 역시 독일이다."
           transliteration: "Maekju hamyeon yeoksi dogirida."
           translation: "To say about beer, Germany is the best."
     - def: "—고 하다
 to say, to talk"
-      examples: 
+      examples:
         - example: "잠깐 쉬자고 하다"
           transliteration: "jamkkan swijago hada"
           translation: "to say \"Let's take a rest a bit!\""
@@ -88578,18 +88578,18 @@ to say, to talk"
           transliteration: "Jamkkan swijaneun sorie naneun geunyeoreul dorabwatda."
           translation: "Hearing a voice saying \"Let's take a rest a bit!\", I looked back to her."
     - def: "to say, to talk"
-      examples: 
+      examples:
         - example: "잠깐 쉬자고 하다"
           transliteration: "jamkkan swijago hada"
           translation: "to say \"Let's take a rest a bit!\""
     - def: "(in the form of '하는', often '—고 하는' being shorten to '—하는' or '—는') to be that"
-      examples: 
+      examples:
         - example: "잠깐 쉬자는 소리에 나는 그녀를 돌아봤다."
           transliteration: "Jamkkan swijaneun sorie naneun geunyeoreul dorabwatda."
           translation: "Hearing a voice saying \"Let's take a rest a bit!\", I looked back to her."
     - def: "Other uses:
 (after enumerating verbs) to do, actually not doing either of them well"
-      examples: 
+      examples:
         - example: "앉았다가 섰다가 하다"
           transliteration: "anjatdaga seotdaga hada"
           translation: "to alternate between sitting down and standing up"
@@ -88603,30 +88603,30 @@ to say, to talk"
           transliteration: "Geuneun geuman! Hago oechyeotda."
           translation: "\"Stop!\", he yelled."
     - def: "(after enumerating verbs) to do, actually not doing either of them well"
-      examples: 
+      examples:
         - example: "앉았다가 섰다가 하다"
           transliteration: "anjatdaga seotdaga hada"
           translation: "to alternate between sitting down and standing up"
     - def: "(after an indirect question) to think"
-      examples: 
+      examples:
         - example: "그가 무얼 보는가 했더니 만화책이었다."
           transliteration: "Geuga mueol boneun-ga haetdeoni manhwachaegieotda."
           translation: "I wondered what he was reading to find it was a comic."
     - def: "(in the form of '—니 —니 하다') to say"
     - def: "(in the form of '—다 하면') to do, emphasizing inevitability"
-      examples: 
+      examples:
         - example: "쐈다 하면 명중이다."
           transliteration: "Sswatda hamyeon myeongjung-ida."
           translation: "Every time he shoots, it hits the mark."
     - def: "(after a word descripting sound) to sound"
     - def: "(after a quotation not followed by any marker) to say"
-      examples: 
+      examples:
         - example: "그는 \"그만!\" 하고 외쳤다."
           transliteration: "Geuneun geuman! Hago oechyeotda."
           translation: "\"Stop!\", he yelled."
     - def: "(in front of a sentence, in the form of '하나', '하니', '하면', '하여', ' 한데', and '해서') 'but', 'so', 'then', 'thus', 'by the way', and 'therefore' respectively."
     - def: "(after verb or adjective, in the form of '—게 하다') to make sb/sth do"
-      examples: 
+      examples:
         - example: "아이에게 숙제를 하게 하다"
           transliteration: "aiege sukjereul hage hada"
           translation: "to have a child do the homework"
@@ -88661,7 +88661,7 @@ to say, to talk"
           transliteration: "Geuneun sonnyeoreul mopsi gwiyeowohaetda."
           translation: "He loved his granddaughter very much."
     - def: "(after verb or adjective, in the form of '—게 하다') to make sb/sth do"
-      examples: 
+      examples:
         - example: "아이에게 숙제를 하게 하다"
           transliteration: "aiege sukjereul hage hada"
           translation: "to have a child do the homework"
@@ -88669,12 +88669,12 @@ to say, to talk"
           transliteration: "geureuseul kkaekkeuthage hada"
           translation: "to make a dish clean"
     - def: "(after verb or adjective, in the form of '—었으면 하다') to wish that"
-      examples: 
+      examples:
         - example: "나는 여름에 비가 덜 내렸으면 한다."
           transliteration: "Naneun yeoreume biga deol naeryeosseumyeon handa."
           translation: "I wish that it rained less in summer."
     - def: "(after verb or adjective, in the form of '—어야 하다') to have to do"
-      examples: 
+      examples:
         - example: "모든 재료는 언제나 신선해야 한다."
           transliteration: "Modeun jaeryoneun eonjena sinseonhaeya handa."
           translation: "All ingredients should always be fresh."
@@ -88685,27 +88685,27 @@ to say, to talk"
           transliteration: "Jeong-o jeone chekeuaut haeya hamnida."
           translation: "I'll have to check out before noon."
     - def: "(after verb, in the form of '—으려(고) 하다' or '—고자 하다') to intend to"
-      examples: 
+      examples:
         - example: "이번 주말에는 영화를 보려고 한다."
           transliteration: "Ibeon jumareneun yeonghwareul boryeogo handa."
           translation: "I'm going to watch a movie this weekend."
     - def: "(in the form of \"verb stem + '—기' + semantic marker + ' 하다') to do, with an emphasis"
-      examples: 
+      examples:
         - example: "그는 자기만 한다."
           transliteration: "Geuneun jagiman handa."
           translation: "He only sleeps."
     - def: "(after verb, in the form of '—고 하다') to do, as a cause"
-      examples: 
+      examples:
         - example: "눈도 오고 해서 일찍 왔다."
           transliteration: "Nundo ogo haeseo iljjik watda."
           translation: "'Cause it snows, so I came early."
     - def: "(after verb, in the form of '—고는 하다' or '—곤 하다') used to do"
-      examples: 
+      examples:
         - example: "시골에 살 적에, 나는 도랑을 따라 걷곤 했다."
           transliteration: "Sigore sal jeoge, naneun dorang-eul ttara geotgon haetda."
           translation: "When I lived in countryside, I used to walk along a ditch."
     - def: "(after adjective, in the form of '—어하다') to feel that sb/sth is"
-      examples: 
+      examples:
         - example: "그는 손녀를 몹시 귀여워했다."
           transliteration: "Geuneun sonnyeoreul mopsi gwiyeowohaetda."
           translation: "He loved his granddaughter very much."
@@ -88729,7 +88729,7 @@ to say, to talk"
   pos: adv
   defs:
     - def: "too much, so, very"
-      examples: 
+      examples:
         - example: "하도 바빠서 화장실 갈 시간조차 없으셨어요."
           transliteration: "Hado bappaseo hwajangsil gal siganjocha eopseusyeosseoyo."
           translation: "I was too busy even to go to the toilet."
@@ -88936,7 +88936,7 @@ to say, to talk"
   pos: n
   defs:
     - def: "hiking"
-      examples: 
+      examples:
         - example: "빙하를 보호하기 위해, 관계자들은 방문객의 수를 하루 1만명으로 제한하였고, 얼음 위를 하이킹하는 것을 금지하였다."
           transliteration: "Binghareul bohohagi wihae, gwan-gyejadeureun bangmun-gaegui sureul haru 1manmyeong-euro jehanhayeotgo, eoreum wireul haikinghaneun geoseul geumjihayeotda."
           translation: "To protect the glacier, officials have limited the number of visitors to 10,000 a day and have banned hiking on the ice."
@@ -89000,7 +89000,7 @@ to say, to talk"
   pos: n
   defs:
     - def: "hearts"
-      examples: 
+      examples:
         - example: "하트의 퀸"
           transliteration: "hateu-ui kwin"
           translation: "queen of hearts"
@@ -89042,7 +89042,7 @@ to say, to talk"
   pos: intj
   defs:
     - def: "ha-ha"
-      examples: 
+      examples:
         - example: "하하 . 나는 그렇게 생각하지 않아요."
           transliteration: "Haha . Naneun geureoke saenggakhaji anayo."
           translation: "Ha-ha. I don't think so."
@@ -89071,7 +89071,7 @@ to say, to talk"
   pos: n
   defs:
     - def: "school"
-      examples: 
+      examples:
         - example: "우리가 학교에 다녔을 때 이래로"
           transliteration: "uriga hakgyoe danyeosseul ttae iraero"
           translation: "since we went to school; since schooldays"
@@ -89096,7 +89096,7 @@ to say, to talk"
   defs:
     - def: "school year"
     - def: "grade, year"
-      examples: 
+      examples:
         - example: "3학년, 삼학년"
           transliteration: "3hangnyeon, samhangnyeon"
           translation: "third grade, third year, junior"
@@ -89258,7 +89258,7 @@ to say, to talk"
     - def: "A word used to indicate that the extent of what is referred to in the preceding statement is beyond measure."
     - def: "A word used to indicate a situation in which one is expected to sacrifice oneself for a certain task or endure a difficult and painful circumstance."
     - def: "being as long as; being as far as"
-      examples: 
+      examples:
         - example: "내가 알고 있는 한, ..."
           transliteration: "Naega algo inneun han, ..."
           translation: "As far as I've been informed ..."
@@ -89333,7 +89333,7 @@ to say, to talk"
   pos: n
   defs:
     - def: "the Korean language"
-      examples: 
+      examples:
         - example: "그녀는 한국말을 정말 잘 하세요."
           transliteration: "Geunyeoneun han-gungmareul jeongmal jal haseyo."
           translation: "She speaks Korean really well."
@@ -89370,12 +89370,12 @@ to say, to talk"
   pos: n
   defs:
     - def: "hangeul, hangul, Hangul, Korean letters."
-      examples: 
+      examples:
         - example: "한글은 15(십오)세기에 만들어진 글자이다."
           transliteration: "Han-geureun 15(sibo)segie mandeureojin geuljaida."
           translation: "Hangul is the writing system made in the 15th century."
     - def: "(mistakenly) the Korean language."
-      examples: 
+      examples:
         - example: "한글을 바르게 사용합시다."
           transliteration: "Han-geureul bareuge sayonghapsida."
           translation: "(when pointing out the indiscriminate use of neologisms) Let's use the right words."
@@ -89383,7 +89383,7 @@ to say, to talk"
           transliteration: "Han-geul jiwoni doeneun peurogeuraem."
           translation: "a program that supports Korean language."
     - def: "Korean native word."
-      examples: 
+      examples:
         - example: "그는 아이 이름을 한글 이름으로 지을 거라고 했다."
           transliteration: "Geuneun ai ireumeul han-geul ireumeuro jieul georago haetda."
           translation: "He said he would build his child's name by using native word."
@@ -89418,7 +89418,7 @@ to say, to talk"
   pos: n
   defs:
     - def: "limit; cap; ceiling"
-      examples: 
+      examples:
         - example: "그 은행은 최근에 내 여신 한도를 삭감했다."
           transliteration: "Geu eunhaeng-eun choegeune nae yeosin handoreul sakgamhaetda."
           translation: "That bank cut my line of credit recently."
@@ -89539,7 +89539,7 @@ to say, to talk"
   pos: n
   defs:
     - def: "sigh"
-      examples: 
+      examples:
         - example: "한숨 쉬다"
           transliteration: "hansum swida"
           translation: "to sigh, draw a long breath"
@@ -89595,7 +89595,7 @@ to say, to talk"
   pos: n
   defs:
     - def: "Korean-English"
-      examples: 
+      examples:
         - example: "한영 사전"
           transliteration: "hanyeong sajeon"
           translation: "Korean-English dictionary"
@@ -89681,7 +89681,7 @@ to say, to talk"
   pos: part
   defs:
     - def: "to; at; for"
-      examples: 
+      examples:
         - example: "친구한테 생일 선물을 보냈어요."
           transliteration: "Chin-guhante saeng-il seonmureul bonaesseoyo."
           translation: "I sent a birthday present to my friend"
@@ -89982,7 +89982,7 @@ to say, to talk
 (after verb or adjective, in the form of '—었으면 하다') to wish that
 
 (after verb or adjective, in the form of '—어야 하다') to have to do"
-      examples: 
+      examples:
         - example: "모든 재료는 언제나 신선해야 한다."
           transliteration: "Modeun jaeryoneun eonjena sinseonhaeya handa."
           translation: "All ingredients should always be fresh."
@@ -89995,7 +89995,7 @@ to say, to talk
     - def: "(after verb or adjective, in the form of '—게 하다') to make sb/sth do"
     - def: "(after verb or adjective, in the form of '—었으면 하다') to wish that"
     - def: "(after verb or adjective, in the form of '—어야 하다') to have to do"
-      examples: 
+      examples:
         - example: "모든 재료는 언제나 신선해야 한다."
           transliteration: "Modeun jaeryoneun eonjena sinseonhaeya handa."
           translation: "All ingredients should always be fresh."
@@ -90074,7 +90074,7 @@ to say, to talk
   pos: v
   defs:
     - def: "to combine; to merge"
-      examples: 
+      examples:
         - example: "우리 용돈을 합쳐서 저 거 사면 어때?"
           transliteration: "Uri yongdoneul hapchyeoseo jeo geo samyeon eottae?"
           translation: "How about buying that thing after we combine our allowances? (casual)"
@@ -90195,7 +90195,7 @@ to say, to talk
   pos: n
   defs:
     - def: "the Sun"
-      examples: 
+      examples:
         - example: "해가 서쪽에서 뜨다."
           transliteration: "Haega seojjogeseo tteuda."
           translation: "(saying) The Sun rises from the west; i.e. something impossible."
@@ -90203,7 +90203,7 @@ to say, to talk
           transliteration: "Haega jin da-eum, nalssiga chuwojil geosida."
           translation: "The weather will become cold after the sun goes down."
     - def: "sunlight, sunbeam"
-      examples: 
+      examples:
         - example: "이 방은 해가 잘 든다."
           transliteration: "I bang-eun haega jal deunda."
           translation: "This room is well-illuminated by sunlight."
@@ -90264,7 +90264,7 @@ to say, to talk
   pos: v
   defs:
     - def: "To resolve a dispute or confusion."
-      examples: 
+      examples:
         - example: "문제를 해결하는 데에는 여러 가지의 방법이 있다."
           transliteration: "Munjereul haegyeolhaneun deeneun yeoreo gajiui bangbeobi itda."
           translation: "There are various ways to fix the problem."
@@ -90281,7 +90281,7 @@ to say, to talk
   pos: v
   defs:
     - def: "to dismiss; to discharge"
-      examples: 
+      examples:
         - example: "내 전 상사는 나를 해고할 기회를 가지게 되어 매우 기뻐했었다."
           transliteration: "Nae jeon sangsaneun nareul haegohal gihoereul gajige doeeo mae-u gippeohaesseotda."
           translation: "My former boss was very happy for the chance to fire me."
@@ -90517,7 +90517,7 @@ to say, to talk
   pos: a
   defs:
     - def: "to be pale"
-      examples: 
+      examples:
         - example: "푸르스름할 만큼 해쓱하다"
           transliteration: "pureuseureumhal mankeum haesseukhada"
           translation: "to be as pale as bluish"
@@ -90873,7 +90873,7 @@ to say, to talk
 (after verb or adjective, in the form of '—었으면 하다') to wish that
 
 (after verb or adjective, in the form of '—어야 하다') to have to do"
-      examples: 
+      examples:
         - example: "모든 재료는 언제나 신선해야 한다."
           transliteration: "Modeun jaeryoneun eonjena sinseonhaeya handa."
           translation: "All ingredients should always be fresh."
@@ -90886,7 +90886,7 @@ to say, to talk
     - def: "(after verb or adjective, in the form of '—게 하다') to make sb/sth do"
     - def: "(after verb or adjective, in the form of '—었으면 하다') to wish that"
     - def: "(after verb or adjective, in the form of '—어야 하다') to have to do"
-      examples: 
+      examples:
         - example: "모든 재료는 언제나 신선해야 한다."
           transliteration: "Modeun jaeryoneun eonjena sinseonhaeya handa."
           translation: "All ingredients should always be fresh."
@@ -90954,7 +90954,7 @@ to say, to talk
   pos: a
   defs:
     - def: "to be happy"
-      examples: 
+      examples:
         - example: "우리 가족은 항상 행복합니다."
           transliteration: "Uri gajogeun hangsang haengbokhamnida."
           translation: "Our family is always happy."
@@ -90965,7 +90965,7 @@ to say, to talk
   pos: a
   defs:
     - def: "to be happy"
-      examples: 
+      examples:
         - example: "우리 가족은 항상 행복합니다."
           transliteration: "Uri gajok-eun hangsang haengbokhamnida."
           translation: "Our family is always happy."
@@ -91117,7 +91117,7 @@ to say, to talk
   pos: propn
   defs:
     - def: "許: a surname"
-      examples: 
+      examples:
         - example: "(MC reading: 許 (MC hɨʌ))"
 
 - word: 허
@@ -91125,7 +91125,7 @@ to say, to talk
   pos: n
   defs:
     - def: "虛: falseness; worthlessness"
-      examples: 
+      examples:
         - example: "(MC reading: 虛 (MC hɨʌ, kʰɨʌ))"
 
 - word: 허가
@@ -91249,7 +91249,7 @@ to say, to talk
   pos: n
   defs:
     - def: "constitution"
-      examples: 
+      examples:
         - example: "싱가포르의 완전한 사법적 권한은 싱가포르 헌법에 의해 대법원과 그의 부속 법원에 부여되어 있다."
           transliteration: "Singgaporeuui wanjeonhan sabeopjeok gwonhaneun singgaporeu heonbeobe uihae daebeobwon-gwa geuui busok beobwone buyeodoeeo itda."
           translation: "The full Judicial power in Singapore is vested in the Supreme Court as well as subordinate courts by the Constitution of Singapore."
@@ -91308,7 +91308,7 @@ to say, to talk
   pos: n
   defs:
     - def: "gentle fart; farting without sound or smell"
-      examples: 
+      examples:
         - example: "복부 수술을 한 사람이 우유를 먹으면 헛방귀가 나오고 회복에 불리하다."
           transliteration: "Bokbu susureul han sarami uyureul meogeumyeon heotbanggwiga naogo hoeboge bullihada."
           translation: "For people who have had abdominal surgery, drinking milk will lead to mild flatulence, which may delay recovery."
@@ -91386,17 +91386,17 @@ to say, to talk
   pos: v
   defs:
     - def: "to consider, to think over (a matter)"
-      examples: 
+      examples:
         - example: "앞날을 헤아리지 아니하면 머지않아 우환이 따르기 마련이다."
           transliteration: "Amnareul heariji anihamyeon meojiana uhwani ttareugi maryeonida."
           translation: "Lack of consideration for the distant future is sure to be followed by trouble in the near future."
     - def: "to guess, to conjecture, to see through"
-      examples: 
+      examples:
         - example: "그의 안색에서 헤아려 보건대 그가 실패한 모양이다."
           transliteration: "Geuui ansaegeseo hearyeo bogeondae geuga silpaehan moyang-ida."
           translation: "From the way he looks, I would say that he failed."
     - def: "to count, to calculate"
-      examples: 
+      examples:
         - example: "대학 4년 동안의 수확은 헤아릴 수 없이 많다."
           transliteration: "Daehak 4nyeon dong-anui suhwageun hearil su eopsi manta."
           translation: "There's no way I can measure all that I got out of my four years in college."
@@ -91477,7 +91477,7 @@ to say, to talk
   pos: n
   defs:
     - def: "gym"
-      examples: 
+      examples:
         - example: "피트, 나 운동하고 싶은데, 헬스클럽이 어디야?"
           transliteration: "Piteu, na undonghago sipeunde, helseukeulleobi eodiya?"
           translation: "Pete, I want to work out. Where is the gym?"
@@ -91605,7 +91605,7 @@ to say, to talk
   pos: n
   defs:
     - def: "reality; the actual case"
-      examples: 
+      examples:
         - example: "현실에 존재하는 물체."
           transliteration: "Hyeonsire jonjaehaneun mulche."
           translation: "A thing that exists in reality."
@@ -91767,7 +91767,7 @@ to say, to talk
   pos: part
   defs:
     - def: "such a type, such a form"
-      examples: 
+      examples:
         - example: "이상형"
           transliteration: "isanghyeong"
           translation: "ideal type"
@@ -91887,7 +91887,7 @@ to say, to talk
   pos: n
   defs:
     - def: "shape"
-      examples: 
+      examples:
         - example: "우윳빛 수정은 색깔이 하얀, 투명한 수정의 일반적인 형태이다."
           transliteration: "Uyutbit sujeong-eun saekkkari hayan, tumyeonghan sujeong-ui ilbanjeogin hyeongtaeida."
           translation: "Milky quartz is a common form of crystalline quartz that is white in color."
@@ -91898,7 +91898,7 @@ to say, to talk
   pos: n
   defs:
     - def: "circumstances, conditions"
-      examples: 
+      examples:
         - example: "부모님께서는 지금 당장은 형편이 좋지 않으셔."
           transliteration: "Bumonimkkeseoneun jigeum dangjang-eun hyeongpyeoni jochi aneusyeo."
           translation: "My parents are in a tight financial situation at the moment."
@@ -91926,7 +91926,7 @@ to say, to talk
   pos: n
   defs:
     - def: "advantage, boon"
-      examples: 
+      examples:
         - example: "~의 혜택을 받다/입다/보다"
           transliteration: "~ui hyetaegeul batda/ipda/boda"
           translation: "share in the benefits of ~; be blessed[graced] with ~"
@@ -92095,7 +92095,7 @@ to say, to talk
   pos: n
   defs:
     - def: "pocket"
-      examples: 
+      examples:
         - example: "호주머니를 다 뒤졌지만 잔돈 하나 없었다."
           transliteration: "Hojumeonireul da dwijyeotjiman jandon hana eopseotda."
           translation: "There was not a single penny even when all the pockets have been emptied."
@@ -92192,7 +92192,7 @@ to say, to talk
   pos: adv
   defs:
     - def: "by chance"
-      examples: 
+      examples:
         - example: "공항까지 지하철을 타면 될 것 같은데 혹시 지하철이 어디 있는지 아세요?"
           transliteration: "Gonghangkkaji jihacheoreul tamyeon doel geot gateunde hoksi jihacheori eodi inneunji aseyo?"
           translation: "I think I can take the subway to the airport. Do you know where the subway is?"
@@ -92215,7 +92215,7 @@ to say, to talk
   pos: a
   defs:
     - def: "(to be) chaotic"
-      examples: 
+      examples:
         - example: "땅이 混沌하고 空虛하며 黑暗이 깊음 위에 있고 하나님의 神은 水面에 運行하시니라땅이 혼돈하고 공허하며; 흑암이 깊음 위에 있고. 하나님의 신은 수면에 운행하시니라."
           transliteration: "Ttang-i hondonhago gongheohamyeo; heugami gipeum wie itgo. Hananimui sineun sumyeone unhaenghasinira."
           translation: "And the earth was without form, and void; and darkness was upon the face of the deep. And the Spirit of God moved upon the face of the waters."
@@ -92436,7 +92436,7 @@ to say, to talk
   defs:
     - def: "(火) fire"
     - def: "(火) anger"
-      examples: 
+      examples:
         - example: "화가 나다 (hwaga nada) — one becomes angry"
         - example: "그 여자는 왜 화가 났습니까?"
           transliteration: "Geu yeojaneun wae hwaga natseumnikka?"
@@ -92505,7 +92505,7 @@ to say, to talk
   pos: n
   defs:
     - def: "hwabyeong, a Korean culture-specific mental illness caused by pent-up rage"
-      examples: 
+      examples:
         - example: "화병에 걸리다"
           transliteration: "hwabyeong-e geollida"
           translation: "to become ill with hwabyeong"
@@ -92652,7 +92652,7 @@ to say, to talk
   pos: n
   defs:
     - def: "topic of discussion"
-      examples: 
+      examples:
         - example: "자 이제 당신들끼리 화제거리가 생겼네요. 둘 다 한 잔 하러 갈까요?"
           transliteration: "Ja ije dangsindeulkkiri hwajegeoriga saenggyeonneyo. Dul da han jan hareo galkkayo?"
           translation: "Well, now you've got something to talk about, can I get you both a drink?"
@@ -92686,7 +92686,7 @@ to say, to talk
   pos: n
   defs:
     - def: "peace, harmony, placidity"
-      examples: 
+      examples:
         - example: "화평을 제의하다"
           transliteration: "hwapyeong-eul je-uihada"
           translation: "make a proposal for peace"
@@ -92784,7 +92784,7 @@ to say, to talk
   pos: adv
   defs:
     - def: "surely, certainly, definitely, unquestionably, for certain, for sure, without doubt"
-      examples: 
+      examples:
         - example: "확실히 조사하다"
           transliteration: "hwaksilhi josahada"
           translation: "to make sure to check out"
@@ -92820,7 +92820,7 @@ to say, to talk
   pos: v
   defs:
     - def: "to decide; to determine; to finalize"
-      examples: 
+      examples:
         - example: "비행기 표를 구하는 즉시, 우리는 호텔 예약을 확정할 겁니다."
           transliteration: "Bihaenggi pyoreul guhaneun jeuksi, urineun hotel yeyageul hwakjeonghal geomnida."
           translation: "As soon as we get the plane tickets, we'll finalize our reservations with the hotel."
@@ -93175,7 +93175,7 @@ to say, to talk
   pos: n
   defs:
     - def: "hall, meeting hall"
-      examples: 
+      examples:
         - example: "학생회관"
           transliteration: "haksaenghoegwan"
           translation: "student union, student centre"
@@ -93254,7 +93254,7 @@ to say, to talk
   pos: n
   defs:
     - def: "a company"
-      examples: 
+      examples:
         - example: "그는 런던에 새로 문을 여는 한 회사에서 광고 부문 중역으로서의 일자리를 얻었다."
           transliteration: "Geuneun reondeone saero muneul yeoneun han hoesaeseo gwanggo bumun jung-yeogeuroseoui iljarireul eodeotda."
           translation: "He got a new position as advertising executive for a new firm opening in London."
@@ -93362,7 +93362,7 @@ to say, to talk
   pos: n
   defs:
     - def: "crossing, transversal"
-      examples: 
+      examples:
         - example: "남북횡단열차"
           transliteration: "nambukhoengdanyeolcha"
           translation: "a train crossing between North and South (Korea)"
@@ -93431,7 +93431,7 @@ to say, to talk
   pos: n
   defs:
     - def: "after"
-      examples: 
+      examples:
         - example: "먹은 후"
           transliteration: "meogeun hu"
           translation: "after eating"
@@ -93453,7 +93453,7 @@ to say, to talk
   pos: n
   defs:
     - def: "successor"
-      examples: 
+      examples:
         - example: "크리스티안 공이 아직 어린이일 때, 그는 덴마크와 노르웨이에 있어서 부친의 후계자로 선택되었다."
           transliteration: "Keuriseutian gong-i ajik eoriniil ttae, geuneun denmakeuwa noreuweie isseoseo buchinui hugyejaro seontaekdoeeotda."
           translation: "While Duke Christian was still a child, he had been chosen as his father's successor in both Denmark and Norway."
@@ -93543,7 +93543,7 @@ to say, to talk
   pos: n
   defs:
     - def: "matter from now on, matter after that"
-      examples: 
+      examples:
         - example: "후사를 부탁하다"
           transliteration: "husareul butakhada"
           translation: "to leave the matter to someone"
@@ -93684,7 +93684,7 @@ to say, to talk
   pos: n
   defs:
     - def: "whistle"
-      examples: 
+      examples:
         - example: "휘파람을 불다"
           transliteration: "hwiparameul bulda"
           translation: "to whistle"
@@ -93978,7 +93978,7 @@ to say, to talk
   pos: v
   defs:
     - def: "to cause to dangle, shake, wave, or undulate"
-      examples: 
+      examples:
         - example: "그 여자는 그녀의 연인에게 손을 흔들고 있다."
           transliteration: "Geu yeojaneun geunyeoui yeoninege soneul heundeulgo itda."
           translation: "The woman is waving her hand to her lover."
@@ -94175,7 +94175,7 @@ to say, to talk
   pos: v
   defs:
     - def: "to scatter, spread, strew, disperse, disseminate"
-      examples: 
+      examples:
         - example: "엔트로피 법칙에 따르면, 모든 것은 자꾸 흩어진다."
           transliteration: "Enteuropi beopchige ttareumyeon, modeun geoseun jakku heuteojinda."
           translation: "According to the law of entropy, everything is getting more and more scattered."
@@ -94186,7 +94186,7 @@ to say, to talk
   pos: v
   defs:
     - def: "to scatter, to disperse"
-      examples: 
+      examples:
         - example: "중국은 거기에 눈을 만들고 냇물을 막아 흩어진 물의 양을 늘려서 융해를 늦추려는 계획이다."
           transliteration: "Junggugeun geogie nuneul mandeulgo naenmureul maga heuteojin murui yang-eul neullyeoseo yunghaereul neutchuryeoneun gyehoegida."
           translation: "China plans to create snow there and block streams to increase the amount of water in the air, which slows melting."
@@ -94256,7 +94256,7 @@ to say, to talk
   defs:
     - def: "sacrifice"
     - def: "casualty; victim"
-      examples: 
+      examples:
         - example: "자기 가족들을 지키기 위해 자기보다 약한 다른 누군가를 희생시키다."
           transliteration: "Jagi gajokdeureul jikigi wihae jagiboda yakhan dareun nugun-gareul huisaengsikida."
           translation: "to sacrifice someone who is weaker than himself in order to protect his family"
@@ -94278,7 +94278,7 @@ to say, to talk
   pos: n
   defs:
     - def: "good news"
-      examples: 
+      examples:
         - example: "희소식이 있습니다. 지난 6년간, 복지 혜택자수를 거의 반절로 줄였습니다."
           transliteration: "Huisosigi itseumnida. Jinan 6nyeon-gan, bokji hyetaekjasureul geoui banjeollo juryeotseumnida."
           translation: "Here's some good news: In the past six years, we have cut the welfare rolls nearly in half."
@@ -94477,7 +94477,7 @@ to say, to talk
   pos: suf
   defs:
     - def: "An adverbial suffix, often forming the adverbial counterpart to an adjective formed with 하다 (hada)."
-      examples: 
+      examples:
         - example: "완전히"
           transliteration: "wanjeonhi"
           translation: "completely"
@@ -94561,7 +94561,7 @@ to say, to talk
   pos: v
   defs:
     - def: "to pluck up one's heart, to gather heart"
-      examples: 
+      examples:
         - example: "힘내!"
           transliteration: "Himnae!"
           translation: "Hold on!, Keep at it!, Hang in there!, Cheer up!"
@@ -94572,7 +94572,7 @@ to say, to talk
   pos: a
   defs:
     - def: "(to be) difficult"
-      examples: 
+      examples:
         - example: "그것은 힘든 일이다!"
           transliteration: "Geugeoseun himdeun irida!"
           translation: "That is a hard work!"

--- a/kedict.yml
+++ b/kedict.yml
@@ -24,15 +24,15 @@
   romaja: ga
   pos: n
   defs:
-    - def: ": family, house"
-    - def: ": price, value"
-    - def: ": falsehood"
+    - def: "family, house"
+    - def: "price, value"
+    - def: "falsehood"
 
 - word: 가
   romaja: ga
   pos: suf
   defs:
-    - def: ": street"
+    - def: "street"
 
 - word: 가
   romaja: ga
@@ -51,7 +51,7 @@
   romaja: gagauseueo
   pos: n
   defs:
-    - def: "The Gagauz language."
+    - def: "The Gagauz language"
 
 - word: 가감
   romaja: gagam
@@ -89,7 +89,7 @@
   romaja: gagye
   pos: n
   defs:
-    - def: "A family line; bloodline; lineage"
+    - def: "a family line; bloodline; lineage"
 
 - word: 가계
   romaja: gagye
@@ -168,14 +168,14 @@
   romaja: gakkapda
   pos: a
   defs:
-    - def: "To be close, near (in distance, time)"
+    - def: "to be close, near (in distance, time)"
       examples:
         - example: "새로 이사한 집에선 학교가 가깝다."
           transliteration: "Saero isahan jibeseon hakgyoga gakkapda."
           translation: "The school is close to our new house."
-    - def: "To be on friendly terms."
-    - def: "To be of similar quantity."
-    - def: "To be closely related."
+    - def: "to be on friendly terms"
+    - def: "to be of similar quantity"
+    - def: "to be closely related"
       examples:
         - example: "가까운 친척"
           transliteration: "gakkaun chincheok"
@@ -186,8 +186,8 @@
   romaja: gakkuda
   pos: v
   defs:
-    - def: "To cultivate (plants)."
-    - def: "To decorate."
+    - def: "to cultivate (plants)"
+    - def: "to decorate"
   conj: [가꾼다, 가꾸어, 가꾸어요/가꿔요, 가꿉니다]
 
 - word: 가끔
@@ -264,8 +264,8 @@
   romaja: ganeumhada
   pos: v
   defs:
-    - def: "To aim at a goal"
-    - def: "To predict how something will turn out"
+    - def: "to aim at a goal"
+    - def: "to predict how something will turn out"
   conj: [가늠한다, 가늠해, 가늠해요, 가늠합니다]
 
 - word: 가능
@@ -368,7 +368,7 @@
   romaja: gadeukhada
   pos: a
   defs:
-    - def: "To be full"
+    - def: "to be full"
   conj: [가득하다, 가득해, 가득해요, 가득합니다]
 
 - word: 가득히
@@ -456,7 +456,7 @@
   romaja: garyeonhada
   pos: a
   defs:
-    - def: "To be miserable or wretched"
+    - def: "to be miserable or wretched"
   conj: [가련하다, 가련해, 가련해요, 가련합니다]
 
 - word: 가련히
@@ -508,13 +508,13 @@
   romaja: garomak
   pos: n
   defs:
-    - def: "The diaphragm."
+    - def: "the diaphragm"
 
 - word: 가로채다
   romaja: garochaeda
   pos: v
   defs:
-    - def: "To snatch or steal"
+    - def: "to snatch or steal"
   conj: [가로챈다, 가로채, 가로채요/가로채어요, 가로챕니다]
 
 - word: 가루
@@ -587,8 +587,8 @@
   romaja: garikida
   pos: v
   defs:
-    - def: "To point."
-    - def: "To indicate or emphasize something."
+    - def: "to point"
+    - def: "to indicate or emphasize something"
   conj: [가리킨다, 가리켜, 가리켜요/가리키어요, 가리킵니다]
 
 - word: 가마
@@ -690,10 +690,10 @@
   romaja: gamanhi
   pos: adv
   defs:
-    - def: "Still; not moving."
+    - def: "still; not moving"
     - def: "quietly"
-    - def: "Just as it is."
-    - def: "Stealthily; in secret."
+    - def: "just as it is"
+    - def: "stealthily; in secret"
 
 - word: 가면
   romaja: gamyeon
@@ -871,14 +871,14 @@
   romaja: gasoropda
   pos: a
   defs:
-    - def: "To be absurd; laughable."
+    - def: "to be absurd; laughable"
   conj: [가소롭다, 가소로워, 가소로워요, 가소롭습니다]
 
 - word: 가소제
   romaja: gasoje
   pos: n
   defs:
-    - def: "A plasticizer."
+    - def: "a plasticizer"
 
 - word: 가솔린
   romaja: gasollin
@@ -929,7 +929,7 @@
   romaja: gaseumppyeo
   pos: n
   defs:
-    - def: "The sternum or breastbone."
+    - def: "the sternum or breastbone"
 
 - word: 가시
   romaja: gasi
@@ -1397,18 +1397,18 @@
   romaja: gahada
   pos: v
   defs:
-    - def: "To add; to increase"
-    - def: "To do a certain act; to affect"
-    - def: "To affect in order to do a certain act"
-    - def: "To drive quickly"
+    - def: "to add; to increase"
+    - def: "to do a certain act; to affect"
+    - def: "to affect in order to do a certain act"
+    - def: "to drive quickly"
   conj: [가한다, 가해, 가해요, 가합니다]
 
 - word: 가하다
   romaja: gahada
   pos: a
   defs:
-    - def: "To be right; to be good"
-    - def: "To be good in accordance with one's will"
+    - def: "to be right; to be good"
+    - def: "to be good in accordance with one's will"
   conj: [가한다, 가해, 가해요, 가합니다]
 
 - word: 가히
@@ -1569,7 +1569,7 @@
   romaja: gandan
   pos: n
   defs:
-    - def: "A pause; a brief cessation"
+    - def: "a pause; a brief cessation"
 
 - word: 간단
   romaja: gandan
@@ -1581,7 +1581,7 @@
   romaja: gandanhada
   pos: a
   defs:
-    - def: "To be simple or straightforward."
+    - def: "to be simple or straightforward"
       examples:
         - example: "아주 간단합니다."
           transliteration: "Aju gandanhamnida."
@@ -1592,7 +1592,7 @@
   romaja: gandanhada
   pos: v
   defs:
-    - def: "To pause briefly."
+    - def: "to pause briefly"
   conj: [간단하다, 간단해, 간단해요, 간단합니다]
 
 - word: 간단히
@@ -1630,14 +1630,14 @@
   romaja: gansahada
   pos: a
   defs:
-    - def: "To be deceitful or cunning."
+    - def: "to be deceitful or cunning"
   conj: [간사하다, 간사해, 간사해요, 간사합니다]
 
 - word: 간사하다
   romaja: gansahada
   pos: v
   defs:
-    - def: "To manage or administer."
+    - def: "to manage or administer"
   conj: [간사하다, 간사해, 간사해요, 간사합니다]
 
 - word: 간선도로
@@ -1668,7 +1668,7 @@
   romaja: gansin
   pos: n
   defs:
-    - def: "A villainous vassal."
+    - def: "a villainous vassal"
 
 - word: 간쑤
   romaja: Ganssu
@@ -1752,23 +1752,23 @@
   romaja: ganjilgeorida
   pos: v
   defs:
-    - def: "To tickle"
-    - def: "To be delighted"
+    - def: "to tickle"
+    - def: "to be delighted"
   conj: [간질거린다, 간질거려, 간질거려요/간질거리어요, 간질거립니다]
 
 - word: 간질대다
   romaja: ganjildaeda
   pos: v
   defs:
-    - def: "To tickle"
-    - def: "To be tickled or ticklish"
+    - def: "to tickle"
+    - def: "to be tickled or ticklish"
   conj: [간질댄다, 간질대, 간질대요/간질대어요, 간질댑니다]
 
 - word: 간질이다
   romaja: ganjirida
   pos: v
   defs:
-    - def: "To tickle"
+    - def: "to tickle"
   conj: [간질인다, 간질여, 간질여요/간질이어요, 간질입니다]
 
 - word: 간첩
@@ -1793,14 +1793,14 @@
   romaja: gancheja
   pos: n
   defs:
-    - def: "simplified Chinese character"
+    - def: "Simplified Chinese character"
 
 - word: 간추리다
   romaja: ganchurida
   pos: v
   defs:
-    - def: "To summarize"
-    - def: "To abridge"
+    - def: "to summarize"
+    - def: "to abridge"
   conj: [간추린다, 간추려, 간추려요/간추리어요, 간추립니다]
 
 - word: 간통
@@ -2132,14 +2132,14 @@
   romaja: gam
   pos: propn
   defs:
-    - def: "A  surname​."
+    - def: "a surname​"
 
 - word: 감각
   romaja: gamgak
   pos: n
   defs:
     - def: "sensation"
-    - def: "A sense for something."
+    - def: "a sense for something"
 
 - word: 감각적
   romaja: gamgakjeok
@@ -2286,14 +2286,14 @@
   romaja: gamsahada
   pos: a
   defs:
-    - def: "To be thankful"
+    - def: "to be thankful"
   conj: [감사하다, 감사해, 감사해요, 감사합니다]
 
 - word: 감사하다
   romaja: gamsahada
   pos: v
   defs:
-    - def: "To give thanks; to thank"
+    - def: "to give thanks; to thank"
   conj: [감사하다, 감사해, 감사해요, 감사합니다]
 
 - word: 감사합니다
@@ -2495,7 +2495,7 @@
 - word: 갑작부자
   pos: n
   defs:
-    - def: "Someone who has become instantly rich."
+    - def: "someone who has become instantly rich"
 
 - word: 갑작스럽다
   romaja: gapjakseureopda
@@ -2608,8 +2608,8 @@
   romaja: gangnyeokhada
   pos: a
   defs:
-    - def: "To be strong or powerful."
-    - def: "To have great potential."
+    - def: "to be strong or powerful."
+    - def: "to have great potential."
   conj: [강력하다, 강력해, 강력해요, 강력합니다]
 
 - word: 강렬하다
@@ -2756,7 +2756,7 @@
   romaja: gangchu
   pos: n
   defs:
-    - def: "Strong recommendation"
+    - def: "strong recommendation"
 
 - word: 강판
   romaja: gangpan
@@ -2877,8 +2877,8 @@
   romaja: gachihada
   pos: v
   defs:
-    - def: "To do together."
-    - def: "To do or think alike."
+    - def: "to do together"
+    - def: "to do or think alike"
   conj: [같이한다, 같이해, 같이해요, 같이합니다]
 
 - word: 같잖다
@@ -2925,7 +2925,7 @@
   romaja: gaegahada
   pos: v
   defs:
-    - def: "To remarry after separation or divorce."
+    - def: "to remarry after separation or divorce"
   conj: [개가한다, 개가해, 개가해요, 개가합니다]
 
 - word: 개고기
@@ -2992,7 +2992,7 @@
   romaja: gaekkum
   pos: n
   defs:
-    - def: "A meaningless dream."
+    - def: "a meaningless dream"
 
 - word: 개꿩
   romaja: gaekkwong
@@ -3077,7 +3077,7 @@
   romaja: gaebalhada
   pos: v
   defs:
-    - def: "to develop or exploit."
+    - def: "to develop or exploit"
   conj: [개발한다, 개발해, 개발해요, 개발합니다]
 
 - word: 개밥바라기
@@ -3105,14 +3105,14 @@
   romaja: gaebyeok
   pos: n
   defs:
-    - def: "Creation"
-    - def: "The dawn of a new age or order"
+    - def: "creation"
+    - def: "the dawn of a new age or order"
 
 - word: 개별자
   romaja: gaebyeolja
   pos: n
   defs:
-    - def: "individuals or particulars, as opposed to universals."
+    - def: "individuals or particulars, as opposed to universals"
 
 - word: 개살구
   romaja: gaesalgu
@@ -3130,7 +3130,7 @@
   romaja: gaeseon
   pos: n
   defs:
-    - def: "Reform or improvement in general."
+    - def: "reform or improvement in general"
 
 - word: 개선하다
   romaja: gaeseonhada
@@ -3155,7 +3155,7 @@
   romaja: gaeseong
   pos: n
   defs:
-    - def: "Opening the gates of a fortress"
+    - def: "opening the gates of a fortress"
     - def: "surrender"
 
 - word: 개성
@@ -3436,27 +3436,27 @@
   romaja: gyaulda
   pos: v
   defs:
-    - def: "To tilt something."
+    - def: "to tilt something"
   conj: [갸운다, 갸울어, 갸울어요, 갸웁니다]
 
 - word: 갸웃
   romaja: gyaut
   pos: adv
   defs:
-    - def: "Cocking or tilting one's head to one side."
+    - def: "cocking or tilting one's head to one side"
 
 - word: 갸웃거리다
   romaja: gyautgeorida
   pos: v
   defs:
-    - def: "To cock or tilt one's head."
+    - def: "to cock or tilt one's head"
   conj: [갸웃거린다, 갸웃거려, 갸웃거려요/갸웃거리어요, 갸웃거립니다]
 
 - word: 갹출
   romaja: gyakchul
   pos: n
   defs:
-    - def: "To make a contribution; chip in, donation."
+    - def: "to make a contribution; chip in, donation"
 
 - word: 걔
   pos: pron
@@ -3477,8 +3477,8 @@
   romaja: geo
   pos: n
   defs:
-    - def: "thing."
-    - def: "what, that which."
+    - def: "thing"
+    - def: "what, that which"
       examples:
         - example: "그건 내 한 거예요."
           translation: "Geugeon nae han geoyeyo."
@@ -3511,9 +3511,9 @@
   romaja: geoduda
   pos: v
   defs:
-    - def: "To harvest."
-    - def: "To gather or collect."
-    - def: "To earn."
+    - def: "to harvest"
+    - def: "to gather or collect"
+    - def: "to earn"
   conj: [거둔다, 거두어, 거두어요/거둬요, 거둡니다]
 
 - word: 거드름
@@ -3544,7 +3544,7 @@
   romaja: georae
   pos: n
   defs:
-    - def: "transaction; trade."
+    - def: "transaction; trade"
       examples:
         - example: "제2항에 규정한 권리는 영업주가 그 거래를 안 날로부터 2주간을 경과하거나 그 거래가 있은 날로부터 1년을 경과하면 소멸한다."
           transliteration: "Je2hang-e gyujeonghan gwollineun yeong-eopjuga geu georaereul an nallobuteo 2juganeul gyeonggwahageona geu georaega isseun nallobuteo 1nyeoneul gyeonggwahamyeon somyeolhanda."
@@ -3579,7 +3579,7 @@
   defs:
     - def: "to sift out, to filter out"
     - def: "to strain"
-    - def: ": to skip, miss"
+    - def: "to skip, miss"
   conj: [거른다, 걸러, 걸러요, 거릅니다]
 
 - word: 거름
@@ -3604,7 +3604,7 @@
   romaja: geori
   pos: v
   defs:
-    - def: "bare stem of 거리다 (georida), a frequentative verb suffix."
+    - def: "bare stem of 거리다 (georida), a frequentative verb suffix"
 
 - word: 거리다
   romaja: georida
@@ -3622,7 +3622,7 @@
   romaja: geomanhada
   pos: a
   defs:
-    - def: "To be arrogant or haughty."
+    - def: "to be arrogant or haughty"
   conj: [거만하다, 거만해, 거만해요, 거만합니다]
 
 - word: 거머리
@@ -3659,8 +3659,8 @@
   romaja: geobuhada
   pos: v
   defs:
-    - def: "To refuse."
-    - def: "To veto."
+    - def: "to refuse"
+    - def: "to veto"
   conj: [거부한다, 거부해, 거부해요, 거부합니다]
 
 - word: 거북
@@ -3906,8 +3906,8 @@
   romaja: geokjeongdoeda
   pos: v
   defs:
-    - def: "To be worried about"
-    - def: "To give cause for concern"
+    - def: "to be worried about"
+    - def: "to give cause for concern"
   conj: [걱정된다, 걱정돼, 걱정돼요/걱정되어요, 걱정됩니다]
 
 - word: 걱정하다
@@ -4017,8 +4017,8 @@
   romaja: geonneda
   pos: v
   defs:
-    - def: "To hand over or turn over"
-    - def: "To bring over or across"
+    - def: "to hand over or turn over"
+    - def: "to bring over or across"
   conj: [건넨다, 건네, 건네요/건네어요, 건넵니다]
 
 - word: 건달
@@ -4037,13 +4037,13 @@
   romaja: geondeurida
   pos: v
   defs:
-    - def: "To touch"
+    - def: "to touch"
       examples:
         - example: "우리 집고양이를 건들지 마세요."
           transliteration: "Uri jipgoyang-ireul geondeulji maseyo."
           translation: "Don't touch my (our) house cat, please."
-    - def: "To meddle with or interfere in"
-    - def: "To seduce (a woman)"
+    - def: "to meddle with or interfere in"
+    - def: "to seduce (a woman)"
   conj: [건드린다, 건드려, 건드려요/건드리어요, 건드립니다]
 
 - word: 건망증
@@ -4277,15 +4277,15 @@
   romaja: georeogada
   pos: v
   defs:
-    - def: "To walk, to go on foot."
+    - def: "to walk, to go on foot."
   conj: [걸어간다, 걸어가, 걸어가요, 걸어갑니다]
 
 - word: 걸음
   romaja: georeum
   pos: n
   defs:
-    - def: "A step or steps."
-    - def: "Going by or past somewhere."
+    - def: "a step or steps"
+    - def: "going by or past somewhere"
 
 - word: 걸음걸이
   romaja: georeumgeori
@@ -4341,8 +4341,8 @@
   romaja: geolpitgeolpit
   pos: adv
   defs:
-    - def: "The appearance of many things progressing rapidly together. in full swing"
-    - def: "The appearance of something coming to mind suddenly and frequently."
+    - def: "the appearance of many things progressing rapidly together; in full swing"
+    - def: "the appearance of something coming to mind suddenly and frequently"
 
 - word: 검
   romaja: geom
@@ -4482,7 +4482,7 @@
   romaja: geomjeongsaek
   pos: n
   defs:
-    - def: "The color black."
+    - def: "the color black"
 
 - word: 검증
   romaja: geomjeung
@@ -4568,7 +4568,7 @@
   romaja: geot
   pos: n
   defs:
-    - def: "A thing; an object, one (impersonal pronoun)"
+    - def: "a thing; an object, one (impersonal pronoun)"
       examples:
         - example: "비싼 것"
           transliteration: "bissan geot"
@@ -4595,7 +4595,7 @@
   romaja: geot
   pos: n
   defs:
-    - def: "A thing; an object, one (impersonal pronoun)"
+    - def: "a thing; an object, one (impersonal pronoun)"
       examples:
         - example: "비싼 것"
           transliteration: "bissan geot"
@@ -4763,7 +4763,7 @@
   romaja: ge-uda
   pos: v
   defs:
-    - def: "To disgorge, discharge, regurgitate, spew, throw up, vomit"
+    - def: "to disgorge, discharge, regurgitate, spew, throw up, vomit"
   conj: [게운다, 게워, 게워요, 게웁니다]
 
 - word: 게으르다
@@ -5059,8 +5059,8 @@
         - example: "그 연구의 결과들은 그 주제에 관한 선행 조사들을 확증한다."
           transliteration: "Geu yeon-guui gyeolgwadeureun geu jujee gwanhan seonhaeng josadeureul hwakjeunghanda."
           translation: "The results of the study confirm previous research on the topic."
-        - example: "그것이 촬영한 영상들은 극단적인 상실이라는 결과를 말해주는 데 도움이 된다. 즉,  1957년 이래로 얼음의 25퍼센트와 빙하 19개 중 4개가 사라졌다."
-          transliteration: "Geugeosi chwaryeonghan yeongsangdeureun geukdanjeogin sangsiriraneun gyeolgwareul malhaejuneun de doumi doenda. Jeuk,  1957nyeon iraero eoreumui 25peosenteuwa bingha 19gae jung 4gaega sarajyeotda."
+        - example: "그것이 촬영한 영상들은 극단적인 상실이라는 결과를 말해주는 데 도움이 된다. 즉, 1957년 이래로 얼음의 25퍼센트와 빙하 19개 중 4개가 사라졌다."
+          transliteration: "Geugeosi chwaryeonghan yeongsangdeureun geukdanjeogin sangsiriraneun gyeolgwareul malhaejuneun de doumi doenda. Jeuk, 1957nyeon iraero eoreumui 25peosenteuwa bingha 19gae jung 4gaega sarajyeotda."
           translation: "The images it captured help tell a story of extreme loss: 25 percent of its ice and four of its 19 glaciers have disappeared since 1957."
     - def: "bearing fruit"
 
@@ -5124,7 +5124,7 @@
   romaja: gyeoljang
   pos: n
   defs:
-    - def: "The colon"
+    - def: "the colon"
 
 - word: 결점
   romaja: gyeoljeom
@@ -5148,14 +5148,14 @@
   romaja: gyeoljeongdoeda
   pos: v
   defs:
-    - def: "To be decided; to be arrived at as a decision."
+    - def: "to be decided; to be arrived at as a decision"
   conj: [결정된다, 결정돼, 결정돼요/결정되어요, 결정됩니다]
 
 - word: 결정되다
   romaja: gyeoljeongdoeda
   pos: v
   defs:
-    - def: "To crystallize; to be crystallized."
+    - def: "to crystallize; to be crystallized"
   conj: [결정된다, 결정돼, 결정돼요/결정되어요, 결정됩니다]
 
 - word: 결정수
@@ -5381,7 +5381,7 @@
   romaja: gyeongmyeoljeok
   pos: det
   defs:
-    - def: "Scornful."
+    - def: "scornful"
 
 - word: 경보기
   romaja: gyeongbogi
@@ -5618,7 +5618,7 @@
   romaja: gyeot
   pos: n
   defs:
-    - def: "The vicinity or side of something."
+    - def: "the vicinity or side of something"
 
 - word: 곁사슬
   romaja: gyeotsaseul
@@ -5759,7 +5759,7 @@
   romaja: gyesokhada
   pos: v
   defs:
-    - def: "To continue or be continuous, without interruption."
+    - def: "to continue or be continuous, without interruption"
   conj: [계속한다, 계속해, 계속해요, 계속합니다]
 
 - word: 계수
@@ -6013,7 +6013,7 @@
   romaja: gogitteok
   pos: n
   defs:
-    - def: "A side dish prepared from a fish which has been gutted, split, coated with flour and seasonings, and fried or roasted."
+    - def: "a side dish prepared from a fish which has been gutted, split, coated with flour and seasonings, and fried or roasted"
 
 - word: 고난
   romaja: gonan
@@ -6032,7 +6032,7 @@
   pos: n
   defs:
     - def: "The tundra swan, Cygnus columbianus."
-    - def: "Any swan."
+    - def: "any swan"
 
 - word: 고대
   romaja: godae
@@ -6051,13 +6051,13 @@
   pos: n
   defs:
     - def: "loneliness"
-    - def: "A childless old person."
+    - def: "a childless old person"
 
 - word: 고독하다
   romaja: godokhada
   pos: a
   defs:
-    - def: "To be lonely or isolated."
+    - def: "to be lonely or isolated"
   conj: [고독하다, 고독해, 고독해요, 고독합니다]
 
 - word: 고드름
@@ -6123,13 +6123,13 @@
   romaja: goryeomal
   pos: n
   defs:
-    - def: "Koryo-mar, the Korean dialect spoken in Russia and Central Asia."
+    - def: "Koryo-mar, the Korean dialect spoken in Russia and Central Asia"
 
 - word: 고려하다
   romaja: goryeohada
   pos: v
   defs:
-    - def: "To consider or reflect on something."
+    - def: "to consider or reflect on something"
       examples:
         - example: "그는 파리를 떠날 것을 고려하고 있다."
           transliteration: "Geuneun parireul tteonal geoseul goryeohago itda."
@@ -6200,7 +6200,7 @@
 - word: 고리무늬물범
   pos: n
   defs:
-    - def: "The ringed seal."
+    - def: "the ringed seal"
 
 - word: 고리짝
   pos: n
@@ -6301,7 +6301,7 @@
   romaja: gobayasibakjwi
   pos: n
   defs:
-    - def: "The Kobayashi's bat (Eptesicus koyabashii)."
+    - def: "The Kobayashi's bat (Eptesicus koyabashii)"
 
 - word: 고발
   romaja: gobal
@@ -6313,7 +6313,7 @@
   romaja: gobang-ori
   pos: n
   defs:
-    - def: "The Northern pintail, Anas acuta."
+    - def: "The Northern pintail, Anas acuta"
 
 - word: 고백
   romaja: gobaek
@@ -6406,7 +6406,7 @@
   romaja: goseumdochi
   pos: n
   defs:
-    - def: "hedgehog, particularly the Amur hedgehog, Erinaceus amurensis."
+    - def: "hedgehog, particularly the Amur hedgehog, Erinaceus amurensis"
 
 - word: 고시
   romaja: gosi
@@ -6464,7 +6464,7 @@
   romaja: goyohada
   pos: a
   defs:
-    - def: "To be still; tranquil."
+    - def: "to be still; tranquil"
   conj: [고요하다, 고요해, 고요해요, 고요합니다]
 
 - word: 고유
@@ -6511,7 +6511,7 @@
 - word: 고인돌
   pos: n
   defs:
-    - def: "A dolmen, a prehistoric megalith having a capstone supported by two or more upright stones."
+    - def: "a dolmen, a prehistoric megalith having a capstone supported by two or more upright stones"
 
 - word: 고작
   romaja: gojak
@@ -6529,8 +6529,8 @@
   romaja: gojang
   pos: n
   defs:
-    - def: "A populated district; a town."
-    - def: "A center of production for a particular commodity."
+    - def: "a populated district; a town"
+    - def: "a center of production for a particular commodity"
 
 - word: 고전
   romaja: gojeon
@@ -6566,8 +6566,8 @@
   romaja: gojodoeda
   pos: v
   defs:
-    - def: "To tone up; be raised"
-    - def: "To be elated; be enhanced"
+    - def: "to tone up; be raised"
+    - def: "to be elated; be enhanced"
       examples:
         - example: "그것은 기후 변화의 효과로 인해 고조되었다고 그녀는 덧붙였다."
           transliteration: "Geugeoseun gihu byeonhwaui hyogwaro inhae gojodoeeotdago geunyeoneun deotbutyeotda."
@@ -6584,7 +6584,7 @@
   romaja: gojilbyeong
   pos: n
   defs:
-    - def: "A chronic disease, a disease that is not easily healed."
+    - def: "a chronic disease, a disease that is not easily healed"
       examples:
         - example: "우울증이 내 고질병이야."
           transliteration: "Uuljeung-i nae gojilbyeong-iya."
@@ -6600,13 +6600,13 @@
   romaja: gojipbultong
   pos: n
   defs:
-    - def: "Implacable stubbornness; mulishness"
+    - def: "implacable stubbornness; mulishness"
 
 - word: 고집스럽다
   romaja: gojipseureopda
   pos: a
   defs:
-    - def: "To be stubborn"
+    - def: "to be stubborn"
   conj: [고집스럽다, 고집스러워, 고집스러워요, 고집스럽습니다]
 
 - word: 고집하다
@@ -6626,13 +6626,13 @@
   romaja: gochu
   pos: n
   defs:
-    - def: "The chili pepper, often specifically the Korean chili pepper, a variety of Capsicum annuum."
+    - def: "the chili pepper, often specifically the Korean chili pepper, a variety of Capsicum annuum"
     - def: "willy, wee-wee, penis"
 
 - word: 고추돌고래
   pos: n
   defs:
-    - def: "The northern right whale dolphin, Lissodelphis borealis."
+    - def: "the northern right whale dolphin, Lissodelphis borealis"
 
 - word: 고추자지
   romaja: gochujaji
@@ -6682,7 +6682,7 @@
   romaja: gopeuda
   pos: a
   defs:
-    - def: "To be hungry, empty, starved"
+    - def: "to be hungry, empty, starved"
   conj: [고프다, 고파, 고파요, 고픕니다]
 
 - word: 고해
@@ -6722,7 +6722,7 @@
   romaja: gongmul
   pos: n
   defs:
-    - def: "corn, cereals, grain."
+    - def: "corn, cereals, grain"
 
 - word: 곡식
   romaja: goksik
@@ -6734,7 +6734,7 @@
   romaja: gogyesa
   pos: n
   defs:
-    - def: "acrobat."
+    - def: "acrobat"
 
 - word: 곡조
   romaja: gokjo
@@ -6768,7 +6768,7 @@
   romaja: gondeulmaegi
   pos: n
   defs:
-    - def: "The malma trout, Salvelinus malma."
+    - def: "The malma trout, Salvelinus malma"
 
 - word: 곤란
   romaja: gollan
@@ -6835,8 +6835,8 @@
   romaja: gotda
   pos: a
   defs:
-    - def: "To be straight"
-    - def: "To be upright and virtuous"
+    - def: "to be straight"
+    - def: "to be upright and virtuous"
   conj: [곧다, 곧아, 곧아요, 곧습니다]
 
 - word: 곧바로
@@ -6850,7 +6850,7 @@
   romaja: godeunchangja
   pos: n
   defs:
-    - def: "The rectum"
+    - def: "the rectum"
 
 - word: 곧장
   romaja: gotjang
@@ -6959,8 +6959,8 @@
   romaja: gomda
   pos: v
   defs:
-    - def: "To fester"
-    - def: "To come to a head"
+    - def: "to fester"
+    - def: "to come to a head"
   conj: [곪는다, 곪아, 곪아요, 곪습니다]
 
 - word: 곰
@@ -6974,7 +6974,7 @@
   romaja: gomguk
   pos: n
   defs:
-    - def: "A thick meat soup, with beef usually the main ingredient."
+    - def: "a thick meat soup, with beef usually the main ingredient"
 
 - word: 곰쥐
   romaja: gomjwi
@@ -7006,7 +7006,7 @@
   romaja: gopsayeoneo
   pos: n
   defs:
-    - def: "The Sakhalin salmon, Onchorhynchus gorbuscha."
+    - def: "The Sakhalin salmon, Onchorhynchus gorbuscha"
 
 - word: 곱셈
   romaja: gopsem
@@ -7071,22 +7071,22 @@
   romaja: gonggalchida
   pos: v
   defs:
-    - def: "To threaten"
+    - def: "to threaten"
   conj: [공갈친다, 공갈쳐, 공갈쳐요/공갈치어요, 공갈칩니다]
 
 - word: 공갈하다
   romaja: gonggalhada
   pos: v
   defs:
-    - def: "To threaten"
-    - def: "To blackmail or extort"
+    - def: "to threaten"
+    - def: "to blackmail or extort"
   conj: [공갈한다, 공갈해, 공갈해요, 공갈합니다]
 
 - word: 공개
   romaja: gonggae
   pos: n
   defs:
-    - def: "Opening to the public."
+    - def: "opening to the public"
     - def: "announcement; disclosure"
     - def: "laying open"
 
@@ -7111,7 +7111,7 @@
     - def: "offensive war"
       examples:
         - example: "《공격전이다》"
-          transliteration: "《 Gonggyeokjeonida》"
+          transliteration: "《Gonggyeokjeonida》"
           translation: "\"It's War\" "
 
 - word: 공공
@@ -7158,7 +7158,7 @@
   romaja: gonggi
   pos: n
   defs:
-    - def: "Gonggi, a Korean children's game similar to jacks."
+    - def: "Gonggi, a Korean children's game similar to jacks"
 
 - word: 공동
   romaja: gongdong
@@ -7201,7 +7201,7 @@
   romaja: gongmuwon
   pos: n
   defs:
-    - def: "A public official."
+    - def: "a public official"
 
 - word: 공민
   romaja: gongmin
@@ -7229,7 +7229,7 @@
 - word: 공부
   pos: propn
   defs:
-    - def: "The imperial Chinese Ministry of Works from the Tang to Qing dynasties"
+    - def: "the imperial Chinese Ministry of Works from the Tang to Qing dynasties"
     - def: "the Korean ministry of Works of Goryeo Kingdom"
 
 - word: 공부자
@@ -7261,13 +7261,13 @@
   romaja: gongsa
   pos: n
   defs:
-    - def: "A government-run corporation."
+    - def: "a government-run corporation"
 
 - word: 공사
   romaja: gongsa
   pos: n
   defs:
-    - def: "Public and private."
+    - def: "public and private"
 
 - word: 공산주의
   romaja: gongsanjuui
@@ -7351,20 +7351,20 @@
   romaja: gong-eon
   pos: n
   defs:
-    - def: "A public oath or declaration"
+    - def: "a public oath or declaration"
 
 - word: 공언하다
   romaja: gong-eonhada
   pos: v
   defs:
-    - def: "To prattle, to spew meaningless words"
+    - def: "to prattle, to spew meaningless words"
   conj: [공언한다, 공언해, 공언해요, 공언합니다]
 
 - word: 공언하다
   romaja: gong-eonhada
   pos: v
   defs:
-    - def: "To swear or declare in public or in front of witnesses."
+    - def: "to swear or declare in public or in front of witnesses."
   conj: [공언한다, 공언해, 공언해요, 공언합니다]
 
 - word: 공업
@@ -7461,8 +7461,8 @@
   romaja: gongjeong
   pos: n
   defs:
-    - def: "official stipulation."
-    - def: "stipulation by general agreement."
+    - def: "official stipulation"
+    - def: "stipulation by general agreement"
 
 - word: 공정하다
   romaja: gongjeonghada
@@ -7839,12 +7839,12 @@
 - word: 곽
   pos: n
   defs:
-    - def: ": The outer part of a coffin."
+    - def: "the outer part of a coffin"
 
 - word: 곽
   pos: propn
   defs:
-    - def: "A common surname​, Kwak."
+    - def: "a common surname​, Kwak"
 
 - word: 곽밥
   romaja: gwakbap
@@ -7954,7 +7954,7 @@
 - word: 관람차
   pos: n
   defs:
-    - def: "Ferris wheel"
+    - def: "ferris wheel"
 
 - word: 관련
   romaja: gwallyeon
@@ -7966,14 +7966,14 @@
   romaja: gwallyeondoeda
   pos: v
   defs:
-    - def: "To have a connection; to be connected."
+    - def: "to have a connection; to be connected"
   conj: [관련된다, 관련돼, 관련돼요/관련되어요, 관련됩니다]
 
 - word: 관련하다
   romaja: gwallyeonhada
   pos: v
   defs:
-    - def: "To be connected or related; to be in a relationship."
+    - def: "to be connected or related; to be in a relationship"
   conj: [관련한다, 관련해, 관련해요, 관련합니다]
 
 - word: 관료제
@@ -8644,7 +8644,7 @@
   romaja: gyomihada
   pos: v
   defs:
-    - def: "To mate; to copulate"
+    - def: "to mate; to copulate"
   conj: [교미한다, 교미해, 교미해요, 교미합니다]
 
 - word: 교복
@@ -8850,7 +8850,7 @@
   romaja: gyohwalhada
   pos: a
   defs:
-    - def: "To be crafty; sly"
+    - def: "to be crafty; sly"
   conj: [교활하다, 교활해, 교활해요, 교활합니다]
 
 - word: 교황
@@ -9017,7 +9017,7 @@
   romaja: gunihada
   pos: v
   defs:
-    - def: "To be absorbed in or obsessed by something."
+    - def: "to be absorbed in or obsessed by something"
   conj: [구니한다, 구니해, 구니해요, 구니합니다]
 
 - word: 구더기
@@ -9110,7 +9110,7 @@
       examples:
         - example: "구름 개다"
           transliteration: "gureum gaeda"
-          translation: " to be cleared"
+          translation: "to be cleared"
         - example: "구름 끼다"
           transliteration: "gureum kkida"
           translation: "to be clouded"
@@ -9126,8 +9126,8 @@
   romaja: gureumdari
   pos: n
   defs:
-    - def: "A skywalk."
-    - def: "A pedestrian overpass."
+    - def: "a skywalk."
+    - def: "a pedestrian overpass"
 
 - word: 구리
   pos: n
@@ -9152,7 +9152,7 @@
   romaja: gurinnae
   pos: n
   defs:
-    - def: "A disgusting smell."
+    - def: "a disgusting smell"
 
 - word: 구마
   romaja: guma
@@ -9176,7 +9176,7 @@
   romaja: gumaehada
   pos: v
   defs:
-    - def: "To purchase."
+    - def: "to purchase"
   conj: [구매한다, 구매해, 구매해요, 구매합니다]
 
 - word: 구멍
@@ -9211,13 +9211,13 @@
   romaja: gubyeol
   pos: n
   defs:
-    - def: "A distinction; a differentiation"
+    - def: "a distinction; a differentiation"
 
 - word: 구별되다
   romaja: gubyeoldoeda
   pos: v
   defs:
-    - def: "To be differentiated or distinguished."
+    - def: "to be differentiated or distinguished"
   conj: [구별된다, 구별돼, 구별돼요/구별되어요, 구별됩니다]
 
 - word: 구별하다
@@ -9242,7 +9242,7 @@
   romaja: guburida
   pos: v
   defs:
-    - def: "To bend or curve"
+    - def: "to bend or curve"
   conj: [구부린다, 구부려, 구부려요/구부리어요, 구부립니다]
 
 - word: 구분
@@ -9261,7 +9261,7 @@
   romaja: gubunhada
   pos: v
   defs:
-    - def: "To classify."
+    - def: "to classify"
   conj: [구분한다, 구분해, 구분해요, 구분합니다]
 
 - word: 구상
@@ -9306,12 +9306,12 @@
   romaja: guseongdoeda
   pos: v
   defs:
-    - def: "To be configured or shaped."
+    - def: "to be configured or shaped"
       examples:
         - example: "물은 수소와 산소로 구성되어 있다."
           transliteration: "Mureun susowa sansoro guseongdoeeo itda."
           translation: "Water is composed of hydrogen and oxygen."
-    - def: "To be plotted."
+    - def: "to be plotted"
   conj: [구성된다, 구성돼, 구성돼요/구성되어요, 구성됩니다]
 
 - word: 구성원
@@ -9324,9 +9324,9 @@
   romaja: guseonghada
   pos: v
   defs:
-    - def: "To constitute."
-    - def: "To configure."
-    - def: "To construct a plot."
+    - def: "to constitute"
+    - def: "to configure"
+    - def: "to construct a plot"
   conj: [구성한다, 구성해, 구성해요, 구성합니다]
 
 - word: 구속
@@ -9461,7 +9461,7 @@
   romaja: gujeol
   pos: n
   defs:
-    - def: "A paragraph."
+    - def: "a paragraph"
 
 - word: 구조
   romaja: gujo
@@ -9660,7 +9660,7 @@
   romaja: guksi
   pos: n
   defs:
-    - def: "A national ideal or principle."
+    - def: "a national ideal or principle"
 
 - word: 국시
   romaja: guksi
@@ -9770,7 +9770,7 @@
   romaja: gukhoe
   pos: n
   defs:
-    - def: "A national parliament or assembly."
+    - def: "a national parliament or assembly"
 
 - word: 국회의원
   romaja: gukhoe-uiwon
@@ -9880,14 +9880,14 @@
   romaja: gunsa
   pos: n
   defs:
-    - def: "A soldier or soldiers."
-    - def: "Specifically, a soldier of NCO or lower rank."
+    - def: "a soldier or soldiers"
+    - def: "specifically, a soldier of NCO or lower rank"
 
 - word: 군사
   romaja: gunsa
   pos: n
   defs:
-    - def: "Military affairs."
+    - def: "military affairs"
       examples:
         - example: "군사 훈련은 힘들었지만, 난 이겨냈다."
           transliteration: "Gunsa hullyeoneun himdeureotjiman, nan igyeonaetda."
@@ -9970,8 +9970,8 @@
   romaja: gunhamjo
   pos: n
   defs:
-    - def: "The lesser frigatebird, Fregata ariel."
-    - def: "Any frigatebird."
+    - def: "the lesser frigatebird, Fregata ariel"
+    - def: "any frigatebird"
 
 - word: 굳
   romaja: gut
@@ -10041,7 +10041,7 @@
   romaja: gullida
   pos: v
   defs:
-    - def: "To cause (something round) to roll, turn (over and over again)"
+    - def: "to cause (something round) to roll, turn (over and over again)"
   conj: [굴린다, 굴려, 굴려요/굴리어요, 굴립니다]
 
 - word: 굴묵낭
@@ -10053,7 +10053,7 @@
 - word: 굴비
   pos: n
   defs:
-    - def: "A type of dried and salted fish (Larimichthys polyactis) in Korea."
+    - def: "a type of dried and salted fish (Larimichthys polyactis) in Korea"
 
 - word: 굴착기
   romaja: gulchakgi
@@ -10139,15 +10139,15 @@
   romaja: gupda
   pos: a
   defs:
-    - def: "To be bent, curved, crooked, humped, hunched"
+    - def: "to be bent, curved, crooked, humped, hunched"
   conj: [굽다, 굽어, 굽어요, 굽습니다]
 
 - word: 굽다
   romaja: gupda
   pos: v
   defs:
-    - def: "To bake, broil, roast (by laying something on the fire)"
-    - def: "To mount one 말 (mal, “horse/token”) on another so that they can go together, hence multiply faster, on the 윷 (yut, “Yut”) board."
+    - def: "to bake, broil, roast (by laying something on the fire)"
+    - def: "to mount one 말 (mal, “horse/token”) on another so that they can go together, hence multiply faster, on the 윷 (yut, “Yut”) board"
   conj: [굽다, 굽어, 굽어요, 굽습니다]
 
 - word: 굽이
@@ -10166,8 +10166,8 @@
   romaja: guphida
   pos: v
   defs:
-    - def: "To bend or curve something."
-    - def: "To vacillate or concede."
+    - def: "to bend or curve something"
+    - def: "to vacillate or concede"
   conj: [굽힌다, 굽혀, 굽혀요/굽히어요, 굽힙니다]
 
 - word: 굿
@@ -10206,8 +10206,8 @@
   romaja: gunggeumhada
   pos: a
   defs:
-    - def: "To be curious"
-    - def: "To be ravenous."
+    - def: "to be curious"
+    - def: "to be ravenous"
   conj: [궁금하다, 궁금해, 궁금해요, 궁금합니다]
 
 - word: 궁둥이
@@ -10364,7 +10364,7 @@
   romaja: gwigumeong
   pos: n
   defs:
-    - def: "The auditory canal, or by extension the ear"
+    - def: "the auditory canal, or by extension the ear"
 
 - word: 귀국
   romaja: gwiguk
@@ -10406,13 +10406,13 @@
   romaja: gwimit
   pos: n
   defs:
-    - def: "The root or base of the ear."
+    - def: "the root or base of the ear"
 
 - word: 귀밑털
   romaja: gwimitteol
   pos: n
   defs:
-    - def: "The hair under the ears; sideburns."
+    - def: "the hair under the ears; sideburns"
 
 - word: 귀뿔논병아리
   romaja: gwippullonbyeong-ari
@@ -10435,7 +10435,7 @@
   romaja: gwissadaegi
   pos: n
   defs:
-    - def: "A slap upside the head, i.e. on the cheek and/or ear."
+    - def: "a slap upside the head, i.e. on the cheek and/or ear"
 
 - word: 귀엣말
   romaja: gwienmal
@@ -10502,7 +10502,7 @@
   romaja: gwichaeksayu
   pos: n
   defs:
-    - def: "grounds to consider someone at fault; in South Korea, frequently a prerequisite for civil liability."
+    - def: "grounds to consider someone at fault; in South Korea, frequently a prerequisite for civil liability"
 
 - word: 귀하다
   romaja: gwihada
@@ -10568,8 +10568,8 @@
   romaja: gyujeong
   pos: n
   defs:
-    - def: "A provision or rule."
-    - def: "The definition or specification of something, especially in a law or regulation."
+    - def: "a provision or rule"
+    - def: "the definition or specification of something, especially in a law or regulation"
 
 - word: 규칙
   romaja: gyuchik
@@ -10596,14 +10596,14 @@
 - word: 균
   pos: n
   defs:
-    - def: "均:  An ancient Chinese musical term indicating which of the twelve pitches of the Chinese chromatic scale would be the starting pitch"
+    - def: "均: An ancient Chinese musical term indicating which of the twelve pitches of the Chinese chromatic scale would be the starting pitch"
       examples:
         - example: "태주균"
           transliteration: "taeju-gyun"
           translation: "starting from the da cu pitch"
     - def: "囷: A container for storing grain"
     - def: "菌: microbe, germ"
-    - def: "菌:  bacteria"
+    - def: "菌: bacteria"
 
 - word: 균계
   romaja: gyun-gye
@@ -10681,7 +10681,7 @@
   romaja: geukkeuje
   pos: n
   defs:
-    - def: "Two days before yesterday; three days ago"
+    - def: "two days before yesterday; three days ago"
 
 - word: 그나마
   romaja: geunama
@@ -10699,7 +10699,7 @@
   romaja: geunyang
   pos: adv
   defs:
-    - def: "simply; just like that; just as it is."
+    - def: "simply; just like that; just as it is"
     - def: "for no particular reason"
 
 - word: 그네
@@ -10912,7 +10912,7 @@
   romaja: geureomeuro
   pos: adv
   defs:
-    - def: "Accordingly, consequently."
+    - def: "accordingly, consequently"
 
 - word: 그러하다
   romaja: geureohada
@@ -11140,7 +11140,7 @@
   romaja: Geuriseueo
   pos: n
   defs:
-    - def: "The Greek language."
+    - def: "The Greek language"
 
 - word: 그리움
   romaja: geurium
@@ -11234,7 +11234,7 @@
   romaja: geuman
   pos: adv
   defs:
-    - def: "this much only; no more. often used in imperatives."
+    - def: "this much only; no more. often used in imperatives"
       examples:
         - example: "그만 먹어!"
           transliteration: "Geuman meogeo!"
@@ -11244,21 +11244,21 @@
   romaja: geumanduda
   pos: v
   defs:
-    - def: "To quit."
-    - def: "To not do something one had been going to do."
+    - def: "to quit"
+    - def: "to not do something one had been going to do"
   conj: [그만둔다, 그만두어, 그만두어요/그만둬요, 그만둡니다]
 
 - word: 그만큼
   romaja: geumankeum
   pos: adv
   defs:
-    - def: "To that extent"
+    - def: "to that extent"
 
 - word: 그만큼
   romaja: geumankeum
   pos: n
   defs:
-    - def: "That extent; that amount"
+    - def: "that extent; that amount"
 
 - word: 그물
   romaja: geumul
@@ -11274,7 +11274,7 @@
   romaja: geumeum
   pos: n
   defs:
-    - def: "Clipping of 그믐날 (geumeumnal, “last day of the month”)."
+    - def: "Clipping of 그믐날 (geumeumnal, “last day of the month”)"
 
 - word: 그믐날
   romaja: geumeumnal
@@ -11346,8 +11346,8 @@
   romaja: geuchida
   pos: v
   defs:
-    - def: "To stop something."
-    - def: "To come to a stop."
+    - def: "to stop something"
+    - def: "to come to a stop"
   conj: [그친다, 그쳐, 그쳐요/그치어요, 그칩니다]
 
 - word: 그토록
@@ -11372,7 +11372,7 @@
   romaja: geukbokhada
   pos: v
   defs:
-    - def: "To overcome; to prevail against adversity."
+    - def: "to overcome; to prevail against adversity"
       examples:
         - example: "위기를 극복하다"
           transliteration: "wigireul geukbokhada"
@@ -11481,13 +11481,13 @@
   romaja: geunbonjeok
   pos: n
   defs:
-    - def: "Something basic or fundamental."
+    - def: "something basic or fundamental"
 
 - word: 근본적
   romaja: geunbonjeok
   pos: det
   defs:
-    - def: "Basic or fundamental."
+    - def: "basic or fundamental"
 
 - word: 근삿값
   romaja: geunsatgap
@@ -11658,7 +11658,7 @@
   romaja: geulja
   pos: n
   defs:
-    - def: "A letter or character of a writing system."
+    - def: "a letter or character of a writing system"
 
 - word: 글피
   romaja: geulpi
@@ -11699,7 +11699,7 @@
   romaja: geumgangmochi
   pos: n
   defs:
-    - def: "The Kumgang fat minnow, Phoxinus kumgangensis."
+    - def: "the Kumgang fat minnow, Phoxinus kumgangensis"
 
 - word: 금개구리
   romaja: geumgaeguri
@@ -12133,7 +12133,7 @@
   romaja: gidaedoeda
   pos: v
   defs:
-    - def: "To be expected"
+    - def: "to be expected"
       examples:
         - example: "잘 될 것으로 기대된다."
           transliteration: "jal doel geos-euro gidaedoenda."
@@ -12198,7 +12198,7 @@
   romaja: gittongchada
   pos: a
   defs:
-    - def: "To be stunning, astounding"
+    - def: "to be stunning, astounding"
   conj: [기똥차다, 기똥차, 기똥차요, 기똥찹니다]
 
 - word: 기라성
@@ -12212,7 +12212,7 @@
   romaja: gireogi
   pos: n
   defs:
-    - def: "wild goose that flies in a V-shaped flock or wedge."
+    - def: "wild goose that flies in a V-shaped flock or wedge"
 
 - word: 기록
   romaja: girok
@@ -12224,8 +12224,8 @@
   romaja: girokhada
   pos: v
   defs:
-    - def: "To record in a document."
-    - def: "To break a record."
+    - def: "to record in a document"
+    - def: "to break a record"
   conj: [기록한다, 기록해, 기록해요, 기록합니다]
 
 - word: 기르다
@@ -12258,7 +12258,7 @@
   romaja: gireumjonggae
   pos: n
   defs:
-    - def: "The spine loach, Cobitis sinensis."
+    - def: "The spine loach, Cobitis sinensis"
 
 - word: 기린
   romaja: girin
@@ -12283,14 +12283,14 @@
   romaja: gimandoeda
   pos: v
   defs:
-    - def: "To be deceived"
+    - def: "to be deceived"
   conj: [기만된다, 기만돼, 기만돼요/기만되어요, 기만됩니다]
 
 - word: 기만하다
   romaja: gimanhada
   pos: v
   defs:
-    - def: "To deceive."
+    - def: "to deceive"
   conj: [기만한다, 기만해, 기만해요, 기만합니다]
 
 - word: 기망
@@ -12351,7 +12351,7 @@
   romaja: gibonjeok
   pos: n
   defs:
-    - def: "Something which is basic."
+    - def: "something which is basic"
 
 - word: 기부
   romaja: gibu
@@ -12373,7 +12373,7 @@
   romaja: gippeohada
   pos: v
   defs:
-    - def: "To be happy about something; to appreciate"
+    - def: "to be happy about something; to appreciate"
   conj: [기뻐한다, 기뻐해, 기뻐해요, 기뻐합니다]
 
 - word: 기쁘다
@@ -12471,7 +12471,7 @@
     - def: "dormitory, dorm, hall of residence"
       examples:
         - example: "기숙사가 어디입니까?"
-          transliteration: " Gisuksaga eodiimnikka?"
+          transliteration: "Gisuksaga eodiimnikka?"
           translation: "Where is the dormitory?"
 
 - word: 기술
@@ -12620,8 +12620,8 @@
   romaja: giulda
   pos: v
   defs:
-    - def: "To tilt."
-    - def: "To set."
+    - def: "to tilt"
+    - def: "to set"
   conj: [기운다, 기울어, 기울어요, 기웁니다]
 
 - word: 기울이다
@@ -12896,7 +12896,7 @@
   romaja: gilgeori
   pos: n
   defs:
-    - def: "A thoroughfare; a busy street"
+    - def: "a thoroughfare; a busy street"
 
 - word: 길냥이
   romaja: gillyang-i
@@ -13013,7 +13013,7 @@
   romaja: gimchijjigae
   pos: n
   defs:
-    - def: "A sort of Korean stew made of kimchi and pork."
+    - def: "a sort of Korean stew made of kimchi and pork"
 
 - word: 김치찌게
   pos: n
@@ -13075,7 +13075,7 @@
   romaja: gipda
   pos: a
   defs:
-    - def: "To be deep"
+    - def: "to be deep"
   conj: [깊다, 깊어, 깊어요, 깊습니다]
 
 - word: 깊이
@@ -13187,8 +13187,8 @@
   romaja: kkabulda
   pos: v
   defs:
-    - def: "To act rashly or impetuously."
-    - def: "To be tossed up and down."
+    - def: "to act rashly or impetuously"
+    - def: "to be tossed up and down"
   conj: [까분다, 까불어, 까불어요, 까붑니다]
 
 - word: 까비
@@ -13205,13 +13205,7 @@
 - word: 까지
   pos: part
   defs:
-    - def: "until, till, by (a time), up to
-Used to illustrate the extent of a finished action or situation.
-
-Used to illustrate to what extent an action will continue.
-
-Used to illustrate the degree or intensity of a situation.
-"
+    - def: "until, till, by (a time), up to"
     - def: "Used to illustrate the extent of a finished action or situation."
     - def: "Used to illustrate to what extent an action will continue."
     - def: "Used to illustrate the degree or intensity of a situation."
@@ -13256,7 +13250,7 @@ Used to illustrate the degree or intensity of a situation.
   romaja: kkal
   pos: suf
   defs:
-    - def: "Denotes the nature, state or property of something."
+    - def: "denotes the nature, state or property of something"
 
 - word: 깔개
   romaja: kkalgae
@@ -13437,7 +13431,7 @@ Used to illustrate the degree or intensity of a situation.
 - word: 꺼
   pos: n
   defs:
-    - def: "that of."
+    - def: "that of"
       examples:
         - example: "내 꺼에요."
           translation: "It’s mine."
@@ -13453,13 +13447,8 @@ Used to illustrate the degree or intensity of a situation.
   romaja: kkeojida
   pos: v
   defs:
-    - def: " to be extinguished
- to go out"
     - def: "to be extinguished"
     - def: "to go out"
-    - def: " to be turned off
- to go out, to go off
- to stall"
     - def: "to be turned off"
     - def: "to go out, to go off"
     - def: "to stall"
@@ -13488,26 +13477,26 @@ Used to illustrate the degree or intensity of a situation.
   romaja: kkeokjeogu
   pos: n
   defs:
-    - def: "The floating goby, Gymnogobius urotaenia."
-    - def: "the Japanese aucha perch."
+    - def: "the floating goby, Gymnogobius urotaenia"
+    - def: "the Japanese aucha perch"
 
 - word: 꺽저기
   romaja: kkeokjeogi
   pos: n
   defs:
-    - def: "The Japanese aucha perch, Coreoperca kawamebari."
+    - def: "the Japanese aucha perch, Coreoperca kawamebari"
 
 - word: 꺽정이
   romaja: kkeokjeong-i
   pos: n
   defs:
-    - def: "The rough-skinned sculpin, Trachidermus fasciatus"
+    - def: "the rough-skinned sculpin, Trachidermus fasciatus"
 
 - word: 꺽지
   romaja: kkeokji
   pos: n
   defs:
-    - def: "The Korean aucha perch, Coreoperca herzi."
+    - def: "the Korean aucha perch, Coreoperca herzi"
 
 - word: 꺾다
   romaja: kkeokda
@@ -13680,8 +13669,8 @@ Used to illustrate the degree or intensity of a situation.
   romaja: kkol
   pos: n
   defs:
-    - def: "The shape or appearance of a thing."
-    - def: "The condition or state of someone or something."
+    - def: "the shape or appearance of a thing"
+    - def: "the condition or state of someone or something"
 
 - word: 꼴사납다
   romaja: kkolsanapda
@@ -13790,7 +13779,7 @@ Used to illustrate the degree or intensity of a situation.
   romaja: kkwae
   pos: adv
   defs:
-    - def: "To a more than ordinary degree; rather, fairly."
+    - def: "to a more than ordinary degree; rather, fairly"
 
 - word: 꽹과리
   pos: n
@@ -13800,7 +13789,7 @@ Used to illustrate the degree or intensity of a situation.
 - word: 꾀꼬리
   pos: n
   defs:
-    - def: "an oriole, especially, golden oriole, Oriolus oriolus."
+    - def: "an oriole, especially, golden oriole, Oriolus oriolus"
 
 - word: 꾀병
   romaja: kkoebyeong
@@ -14160,7 +14149,7 @@ Used to illustrate the degree or intensity of a situation.
   romaja: kkeurida
   pos: v
   defs:
-    - def: "to boil something; to cause something to boil."
+    - def: "to boil something; to cause something to boil"
   conj: [끓인다, 끓여, 끓여요/끓이어요, 끓입니다]
 
 - word: 끔찍하다
@@ -14197,13 +14186,13 @@ Used to illustrate the degree or intensity of a situation.
   romaja: kkeunnaeda
   pos: v
   defs:
-    - def: "To finish something."
+    - def: "to finish something"
   conj: [끝낸다, 끝내, 끝내요/끝내어요, 끝냅니다]
 
 - word: 끼
   pos: n
   defs:
-    - def: "A meal"
+    - def: "a meal"
 
 - word: 끼니
   romaja: kkini
@@ -14490,10 +14479,10 @@ Used to illustrate the degree or intensity of a situation.
   romaja: nada
   pos: v
   defs:
-    - def: "To be born"
-    - def: "To appear, arise, occur, take place"
-    - def: "To break out, come out, turn out"
-    - def: "To grow, spread"
+    - def: "to be born"
+    - def: "to appear, arise, occur, take place"
+    - def: "to break out, come out, turn out"
+    - def: "to grow, spread"
   conj: [난다, 나, 나요, 납니다]
 
 - word: 나도
@@ -14928,7 +14917,7 @@ Used to illustrate the degree or intensity of a situation.
   pos: n
   defs:
     - def: "half day; half a day"
-    - def: "A certain time or period in a day."
+    - def: "a certain time or period in a day"
 
 - word: 나중
   romaja: najung
@@ -14937,7 +14926,7 @@ Used to illustrate the degree or intensity of a situation.
     - def: "the future; a later time"
       examples:
         - example: "나중에 제가 드릴게요."
-          transliteration: " Najung-e jega deurilgeyo."
+          transliteration: "Najung-e jega deurilgeyo."
           translation: "I will give [it to you] at a later time."
         - example: "나중에 또 봐요."
           transliteration: "Najung-e tto bwayo."
@@ -15104,7 +15093,7 @@ Used to illustrate the degree or intensity of a situation.
   romaja: nak
   pos: n
   defs:
-    - def: "Initialing terms related to fishing."
+    - def: "initialing terms related to fishing"
 
 - word: 낚시
   romaja: naksi
@@ -15145,7 +15134,7 @@ Used to illustrate the degree or intensity of a situation.
   defs:
     - def: "亂: revolt"
     - def: "欄: column (of a newspaper, etc.)"
-    - def: "難: (In compounds) difficult, difficulty"
+    - def: "難: (in compounds) difficult, difficulty"
 
 - word: 난각
   romaja: nan-gak
@@ -15298,7 +15287,7 @@ Used to illustrate the degree or intensity of a situation.
   romaja: nalgae
   pos: n
   defs:
-    - def: "wing (of a bird, aeroplane etc)"
+    - def: "wing (of a bird, aeroplane etc.)"
       examples:
         - example: "잠자리의 날개는 두 짝이다."
           transliteration: "Jamjariui nalgaeneun du jjagida."
@@ -15820,14 +15809,14 @@ Used to illustrate the degree or intensity of a situation.
   romaja: natda
   pos: v
   defs:
-    - def: "to recover from an illness."
+    - def: "to recover from an illness"
   conj: [낫는다, 나아, 나아요, 낫습니다]
 
 - word: 낫다
   romaja: natda
   pos: a
   defs:
-    - def: "to be better (than something)."
+    - def: "to be better (than something)"
   conj: [낫는다, 나아, 나아요, 낫습니다]
 
 - word: 낫돌고래
@@ -15869,7 +15858,7 @@ Used to illustrate the degree or intensity of a situation.
   romaja: natda
   pos: a
   defs:
-    - def: "To be low (in height, in value)"
+    - def: "to be low (in height, in value)"
       examples:
         - example: "낮은 울타리"
           transliteration: "najeun ultari"
@@ -16131,9 +16120,9 @@ Used to illustrate the degree or intensity of a situation.
   romaja: naemilda
   pos: v
   defs:
-    - def: "To push or thrust out or forward."
-    - def: "To hand out."
-    - def: "To hand off."
+    - def: "to push or thrust out or forward"
+    - def: "to hand out"
+    - def: "to hand off"
   conj: [내민다, 내밀어, 내밀어요, 내밉니다]
 
 - word: 내보내다
@@ -16147,7 +16136,7 @@ Used to illustrate the degree or intensity of a situation.
   romaja: naebu
   pos: n
   defs:
-    - def: "The interior or inside."
+    - def: "the interior or inside"
 
 - word: 내심
   romaja: naesim
@@ -16174,7 +16163,7 @@ Used to illustrate the degree or intensity of a situation.
   romaja: naeeum
   pos: n
   defs:
-    - def: "An inoffensive smell, usually referred in literature."
+    - def: "an inoffensive smell, usually referred in literature"
 
 - word: 내일
   romaja: naeil
@@ -16530,18 +16519,18 @@ Used to illustrate the degree or intensity of a situation.
   romaja: neomeogada
   pos: v
   defs:
-    - def: "To collapse or tilt."
-    - def: "To cross over"
-    - def: "To shift or be transferred."
-    - def: "To set."
-    - def: "To fall for (a fraud)."
+    - def: "to collapse or tilt"
+    - def: "to cross over"
+    - def: "to shift or be transferred"
+    - def: "to set"
+    - def: "to fall for (a fraud)"
   conj: [넘어간다, 넘어가, 넘어가요, 넘어갑니다]
 
 - word: 넘어서다
   romaja: neomeoseoda
   pos: v
   defs:
-    - def: "To cross over or pass through."
+    - def: "to cross over or pass through"
   conj: [넘어선다, 넘어서어, 넘어서어요, 넘어섭니다]
 
 - word: 넘어지다
@@ -16855,7 +16844,7 @@ Used to illustrate the degree or intensity of a situation.
   hanja: 盧
   pos: propn
   defs:
-    - def: "A surname."
+    - def: "a surname"
 
 - word: 노
   romaja: "no"
@@ -17466,7 +17455,7 @@ Used to illustrate the degree or intensity of a situation.
   pos: n
   defs:
     - def: "essay"
-    - def: "An academic paper."
+    - def: "an academic paper"
 
 - word: 논병아리
   romaja: nonbyeong-ari
@@ -17580,8 +17569,8 @@ Used to illustrate the degree or intensity of a situation.
   romaja: nori
   pos: n
   defs:
-    - def: "A game."
-    - def: "Play; relaxation and entertainment."
+    - def: "a game"
+    - def: "play; relaxation and entertainment"
       examples:
         - example: "그들은 카드 놀이를 하고 있다."
           transliteration: "Geudeureun kadeu norireul hago itda."
@@ -17697,7 +17686,7 @@ Used to illustrate the degree or intensity of a situation.
   romaja: nongsanmul
   pos: n
   defs:
-    - def: "An agricultural product or products."
+    - def: "an agricultural product or products"
 
 - word: 농어
   romaja: nong-eo
@@ -17722,7 +17711,7 @@ Used to illustrate the degree or intensity of a situation.
   romaja: nongchon
   pos: n
   defs:
-    - def: "A rural hamlet; a farm town."
+    - def: "a rural hamlet; a farm town"
 
 - word: 높다
   romaja: nopda
@@ -17735,7 +17724,7 @@ Used to illustrate the degree or intensity of a situation.
   romaja: nopajida
   pos: v
   defs:
-    - def: "To be heightened or raised; to become higher or more intense."
+    - def: "to be heightened or raised; to become higher or more intense"
   conj: [높아진다, 높아져, 높아져요/높아지어요, 높아집니다]
 
 - word: 높이
@@ -17748,8 +17737,8 @@ Used to illustrate the degree or intensity of a situation.
   romaja: nopida
   pos: v
   defs:
-    - def: "To raise or elevate."
-    - def: "To address respectfully."
+    - def: "to raise or elevate"
+    - def: "to address respectfully"
   conj: [높인다, 높여, 높여요/높이어요, 높입니다]
 
 - word: 놓다
@@ -17768,7 +17757,7 @@ Used to illustrate the degree or intensity of a situation.
   romaja: noida
   pos: v
   defs:
-    - def: "To be laid, or put"
+    - def: "to be laid, or put"
   conj: [놓인다, 놓여, 놓여요/놓이어요, 놓입니다]
 
 - word: 놓치다
@@ -17903,7 +17892,7 @@ Used to illustrate the degree or intensity of a situation.
   romaja: nunan
   pos: propn
   defs:
-    - def: "A  surname​."
+    - def: "a surname​"
 
 - word: 누님
   romaja: nunim
@@ -17948,8 +17937,8 @@ Used to illustrate the degree or intensity of a situation.
   romaja: nureuda
   pos: v
   defs:
-    - def: "To press"
-    - def: "To oppress, suppress"
+    - def: "to press"
+    - def: "to oppress, suppress"
   conj: [누른다, 눌러, 눌러요, 누릅니다]
 
 - word: 누르다
@@ -18475,9 +18464,9 @@ Used to illustrate the degree or intensity of a situation.
   romaja: neullida
   pos: v
   defs:
-    - def: "To expand something."
-    - def: "To increase something."
-    - def: "To improve something by leaps and bounds."
+    - def: "to expand something"
+    - def: "to increase something"
+    - def: "to improve something by leaps and bounds"
   conj: [늘린다, 늘려, 늘려요/늘리어요, 늘립니다]
 
 - word: 늘어나다
@@ -18606,7 +18595,6 @@ Used to illustrate the degree or intensity of a situation.
 - word: 니
   pos: n
   defs:
-    - def: "a tooth"
     - def: "a tooth"
 
 - word: 니
@@ -18813,7 +18801,7 @@ Used to illustrate the degree or intensity of a situation.
   romaja: da
   pos: a
   defs:
-    - def: "To be (something). Used after a vowel."
+    - def: "to be (something). Used after a vowel"
 
 - word: 다
   romaja: da
@@ -18902,7 +18890,7 @@ Used to illustrate the degree or intensity of a situation.
   romaja: dagaoda
   pos: v
   defs:
-    - def: "To approach; to draw near."
+    - def: "to approach; to draw near"
   conj: [다가온다, 다가와, 다가와요, 다가옵니다]
 
 - word: 다각형
@@ -19204,8 +19192,8 @@ Used to illustrate the degree or intensity of a situation.
   romaja: daso
   pos: n
   defs:
-    - def: "Large and small amounts."
-    - def: "A small amount or degree."
+    - def: "large and small amounts"
+    - def: "a small amount or degree"
 
 - word: 다수
   romaja: dasu
@@ -19265,8 +19253,7 @@ Used to illustrate the degree or intensity of a situation.
   pos: n
   defs:
     - def: "diamond (uncountable: mineral)"
-    - def: "a diamond (gemstone)
-"
+    - def: "a diamond (gemstone)"
     - def: "diamonds"
 
 - word: 다이어그램
@@ -19308,9 +19295,9 @@ Used to illustrate the degree or intensity of a situation.
   romaja: dajida
   pos: v
   defs:
-    - def: "To crush."
-    - def: "To strengthen or harden."
-    - def: "To mince or chop fine."
+    - def: "to crush"
+    - def: "to strengthen or harden"
+    - def: "to mince or chop fine"
   conj: [다진다, 다져, 다져요/다지어요, 다집니다]
 
 - word: 다짐
@@ -19362,7 +19349,7 @@ Used to illustrate the degree or intensity of a situation.
   romaja: dakeuseokeul
   pos: n
   defs:
-    - def: "Circles (dark discoloration and bagginess) around the eyes."
+    - def: "circles (dark discoloration and bagginess) around the eyes"
 
 - word: 다투다
   romaja: datuda
@@ -19381,8 +19368,8 @@ Used to illustrate the degree or intensity of a situation.
   romaja: dahada
   pos: v
   defs:
-    - def: "To complete or finish."
-    - def: "To be finished or used up"
+    - def: "to complete or finish"
+    - def: "to be finished or used up"
   conj: [다한다, 다해, 다해요, 다합니다]
 
 - word: 다행
@@ -19459,7 +19446,7 @@ Used to illustrate the degree or intensity of a situation.
   romaja: dandanhada
   pos: a
   defs:
-    - def: "To be hard, solid, firm (resistant to pressure)"
+    - def: "to be hard, solid, firm (resistant to pressure)"
   conj: [단단하다, 단단해, 단단해요, 단단합니다]
 
 - word: 단락
@@ -19520,7 +19507,7 @@ Used to illustrate the degree or intensity of a situation.
   romaja: dansunhada
   pos: a
   defs:
-    - def: "To be simple."
+    - def: "to be simple"
   conj: [단순하다, 단순해, 단순해요, 단순합니다]
 
 - word: 단순히
@@ -19954,7 +19941,7 @@ Used to illustrate the degree or intensity of a situation.
   romaja: dakgalbi
   pos: n
   defs:
-    - def: "a dish originating from Gangwon province which is made of spiced chicken and a lot of vegetables."
+    - def: "a dish originating from Gangwon province which is made of spiced chicken and a lot of vegetables"
 
 - word: 닭고기
   romaja: dakgogi
@@ -20030,7 +20017,7 @@ Used to illustrate the degree or intensity of a situation.
   romaja: damgida
   pos: v
   defs:
-    - def: "To be put in; to go into; to be included in."
+    - def: "to be put in; to go into; to be included in"
   conj: [담긴다, 담겨, 담겨요/담기어요, 담깁니다]
 
 - word: 담다
@@ -20305,14 +20292,14 @@ Used to illustrate the degree or intensity of a situation.
   romaja: dang-yeonhada
   pos: a
   defs:
-    - def: "To be reasonable or natural."
+    - def: "to be reasonable or natural"
   conj: [당연하다, 당연해, 당연해요, 당연합니다]
 
 - word: 당연해
   romaja: dang-yeonhada
   pos: a
   defs:
-    - def: "To be reasonable or natural."
+    - def: "to be reasonable or natural"
   conj: [당연하다, 당연해, 당연해요, 당연합니다]
 
 - word: 당연히
@@ -20501,23 +20488,23 @@ Used to illustrate the degree or intensity of a situation.
   romaja: daeda
   pos: v
   defs:
-    - def: "To arrive at a given time, to make it on time"
-    - def: "To target, to face"
-    - def: "To touch"
-    - def: "To work by using tools or something"
-    - def: "To stop a vehicle"
-    - def: "To provide"
-    - def: "To overlap, to support"
-    - def: "To aim a gun or a hose, etc."
-    - def: "To put money on gambling or a bet, etc."
-    - def: "To look for somebody and introduce him/her"
-    - def: "To irrigate"
-    - def: "To liaise, to enter into a relation"
-    - def: "To have physical contact"
-    - def: "To compare"
-    - def: "To give a reason"
-    - def: "To tell the truth"
-    - def: "To oppose each about"
+    - def: "to arrive at a given time, to make it on time"
+    - def: "to target, to face"
+    - def: "to touch"
+    - def: "to work by using tools or something"
+    - def: "to stop a vehicle"
+    - def: "to provide"
+    - def: "to overlap, to support"
+    - def: "to aim a gun or a hose, etc."
+    - def: "to put money on gambling or a bet, etc."
+    - def: "to look for somebody and introduce him/her"
+    - def: "to irrigate"
+    - def: "to liaise, to enter into a relation"
+    - def: "to have physical contact"
+    - def: "to compare"
+    - def: "to give a reason"
+    - def: "to tell the truth"
+    - def: "to oppose each about"
   conj: [댄다, 대, 대요/대어요, 댑니다]
 
 - word: 대다
@@ -21051,7 +21038,7 @@ Used to illustrate the degree or intensity of a situation.
   romaja: daepokjeok
   pos: n
   defs:
-    - def: "Something which is drastic or substantial."
+    - def: "something which is drastic or substantial"
 
 - word: 대표
   romaja: daepyo
@@ -21076,7 +21063,7 @@ Used to illustrate the degree or intensity of a situation.
   romaja: daepyojeok
   pos: n
   defs:
-    - def: "Something which is representative; supreme."
+    - def: "something which is representative; supreme"
 
 - word: 대프리카
   romaja: Daepeurika
@@ -21148,7 +21135,7 @@ Used to illustrate the degree or intensity of a situation.
   romaja: daehyeong
   pos: n
   defs:
-    - def: "Large; on a large scale."
+    - def: "large; on a large scale"
 
 - word: 대화
   romaja: daehwa
@@ -21179,7 +21166,7 @@ Used to illustrate the degree or intensity of a situation.
   romaja: daek
   pos: pron
   defs:
-    - def: "a respectful term of address for someone of equal or lower status."
+    - def: "a respectful term of address for someone of equal or lower status"
 
 - word: 댄서
   pos: n
@@ -21341,14 +21328,14 @@ Used to illustrate the degree or intensity of a situation.
   romaja: deohada
   pos: a
   defs:
-    - def: "To be more than."
+    - def: "to be more than"
   conj: [더하다, 더해, 더해요, 더합니다]
 
 - word: 더하다
   romaja: deohada
   pos: v
   defs:
-    - def: "To add."
+    - def: "to add"
   conj: [더하다, 더해, 더해요, 더합니다]
 
 - word: 덕
@@ -21574,7 +21561,7 @@ after adjective stems, indicates a state which no longer exists"
   romaja: derida
   pos: v
   defs:
-    - def: "To bring or take along an animal or lower-status person, such as a child."
+    - def: "to bring or take along an animal or lower-status person, such as a child"
 
 - word: 데메테르
   romaja: demetereu
@@ -21762,7 +21749,7 @@ after adjective stems, indicates a state which no longer exists"
 - word: 도다
   pos: suf
   defs:
-    - def: "An intensifying, emphatic/exclamatory ending."
+    - def: "an intensifying, emphatic/exclamatory ending"
 
 - word: 도다리
   romaja: dodari
@@ -21855,7 +21842,7 @@ after adjective stems, indicates a state which no longer exists"
   romaja: domabaem
   pos: n
   defs:
-    - def: "Any lizard."
+    - def: "any lizard"
     - def: "Specifically the Tsushima ground skink, Scincella vandenburghi."
 
 - word: 도망
@@ -21918,8 +21905,8 @@ after adjective stems, indicates a state which no longer exists"
   romaja: dosi
   pos: n
   defs:
-    - def: "city."
-    - def: "A village serving as the cultural or economic center of a region."
+    - def: "city"
+    - def: "village serving as the cultural or economic center of a region"
 
 - word: 도시
   romaja: dosi
@@ -22216,7 +22203,7 @@ after adjective stems, indicates a state which no longer exists"
   romaja: dokteukhada
   pos: a
   defs:
-    - def: "To be unique."
+    - def: "to be unique"
   conj: [독특하다, 독특해, 독특해요, 독특합니다]
 
 - word: 돈
@@ -22653,7 +22640,7 @@ after adjective stems, indicates a state which no longer exists"
   pos: n
   defs:
     - def: "friend, mate, pal, comrade"
-    - def: "comrade (title used by a Communist regime),  friend"
+    - def: "comrade (title used by a Communist regime), friend"
 
 - word: 동물
   romaja: dongmul
@@ -23140,15 +23127,15 @@ after adjective stems, indicates a state which no longer exists"
   romaja: duda
   pos: v
   defs:
-    - def: "To put"
-    - def: "To leave (behind), let there be"
+    - def: "to put"
+    - def: "to leave (behind), let there be"
       examples:
         - example: "당신에게 그것들을 남겨 둘까요?"
           transliteration: "Dangsinege geugeotdeureul namgyeo dulkkayo?"
           translation: "Should I just leave them with you?"
-    - def: "To keep (from), preserve"
-    - def: "To have (in mind)"
-    - def: "To set up"
+    - def: "to keep (from), preserve"
+    - def: "to have (in mind)"
+    - def: "to set up"
   conj: [둔다, 두어, 두어요/둬요, 둡니다]
 
 - word: 두더지
@@ -23379,7 +23366,7 @@ after adjective stems, indicates a state which no longer exists"
   romaja: dunchida
   pos: v
   defs:
-    - def: "To inhabit; fortify, camp, station"
+    - def: "to inhabit; fortify, camp, station"
   conj: [둔친다, 둔쳐, 둔쳐요/둔치어요, 둔칩니다]
 
 - word: 둘
@@ -23418,8 +23405,8 @@ after adjective stems, indicates a state which no longer exists"
   romaja: dulleossada
   pos: v
   defs:
-    - def: "To surround."
-    - def: "To focus on something."
+    - def: "to surround"
+    - def: "to focus on something"
   conj: [둘러싼다, 둘러싸, 둘러싸요, 둘러쌉니다]
 
 - word: 둥간어
@@ -23888,7 +23875,7 @@ after adjective stems, indicates a state which no longer exists"
   romaja: deullyeooda
   pos: v
   defs:
-    - def: "To be bruited about; to have come to hearing."
+    - def: "to be bruited about; to have come to hearing"
   conj: [들려온다, 들려와, 들려와요, 들려옵니다]
 
 - word: 들르다
@@ -23987,16 +23974,16 @@ after adjective stems, indicates a state which no longer exists"
   romaja: deuryeodaboda
   pos: v
   defs:
-    - def: "To look into"
-    - def: "To look in on"
+    - def: "to look into"
+    - def: "to look in on"
   conj: [들여다본다, 들여다봐, 들여다봐요/들여다보아요, 들여다봅니다]
 
 - word: 들이다
   romaja: deurida
   pos: v
   defs:
-    - def: "To let in someone or something."
-    - def: "To spend or expend, as money or effort."
+    - def: "to let in someone or something"
+    - def: "to spend or expend, as money or effort"
   conj: [들인다, 들여, 들여요/들이어요, 들입니다]
 
 - word: 들치기
@@ -24645,14 +24632,14 @@ after adjective stems, indicates a state which no longer exists"
   romaja: ttaerida
   pos: v
   defs:
-    - def: "To beat or strike."
+    - def: "to beat or strike"
   conj: [때린다, 때려, 때려요/때리어요, 때립니다]
 
 - word: 때리다
   romaja: ttaerida
   pos: v
   defs:
-    - def: "To beat or strike."
+    - def: "to beat or strike"
       examples:
         - example: "나는 화가 너무 많이 나서 나도 모르게 친구의 얼굴을 때려버렸다. "
           transliteration: "Naneun hwaga neomu mani naseo nado moreuge chin-guui eolgureul ttaeryeobeoryeotda. "
@@ -24772,8 +24759,8 @@ after adjective stems, indicates a state which no longer exists"
   romaja: tteoollida
   pos: v
   defs:
-    - def: "To make someone think of something; to bring to mind."
-    - def: "To cause to appear."
+    - def: "to make someone think of something; to bring to mind"
+    - def: "to cause to appear"
   conj: [떠올린다, 떠올려, 떠올려요/떠올리어요, 떠올립니다]
 
 - word: 떡
@@ -25280,7 +25267,7 @@ after adjective stems, indicates a state which no longer exists"
   romaja: ttuida
   pos: v
   defs:
-    - def: "To be visible or seen"
+    - def: "to be visible or seen"
   conj: [띈다, 띄어, 띄어요, 띕니다]
 
 - word: 띠
@@ -27472,10 +27459,10 @@ after adjective stems, indicates a state which no longer exists"
   romaja: makda
   pos: v
   defs:
-    - def: "To stop up"
-    - def: "To enclose, fence, screen off, shield"
-    - def: "To curb, defend, protect"
-    - def: "To keep (from doing), hinder, prevent"
+    - def: "to stop up"
+    - def: "to enclose, fence, screen off, shield"
+    - def: "to curb, defend, protect"
+    - def: "to keep (from doing), hinder, prevent"
     - def: ""
       examples:
         - example: "혈관이 막히다."
@@ -27872,13 +27859,13 @@ specifically Potamogeton oxyphyllus."
   pos: n
   defs:
     - def: "final period; terminal period; last stage"
-    - def: ": terminal; approaching death"
+    - def: "terminal; approaching death"
 
 - word: 말다
   romaja: malda
   pos: v
   defs:
-    - def: ", used to negate imperatives, with —지 (ji)) to not do something, to stop doing"
+    - def: "used to negate imperatives, with —지 (ji)) to not do something, to stop doing"
       examples:
         - example: "잔디에 앉지 마시오."
           transliteration: "Jandie anji masio."
@@ -27902,7 +27889,7 @@ specifically Potamogeton oxyphyllus."
   romaja: malttonggari
   pos: n
   defs:
-    - def: "The common buzzard, Buteo buteo."
+    - def: "the common buzzard, Buteo buteo"
 
 - word: 말똥구리
   romaja: malttongguri
@@ -28110,7 +28097,7 @@ specifically Potamogeton oxyphyllus."
           transliteration: "Nega yeogi itdago geunyeo-ege malhae."
           translation: "Tell her you’re here."
         - example: "어제 일은 미안하다고 말하고 싶어요. — 괜찮아요. 아나."
-          transliteration: "Eoje ireun mianhadago malhago sipeoyo.  gwaenchanayo. Ana."
+          transliteration: "Eoje ireun mianhadago malhago sipeoyo. Gwaenchanayo. Ana."
           translation: "I want to say I’m sorry for yesterday. — It’s okay, Anna."
     - def: "to explain (by talking)"
       examples:
@@ -28459,7 +28446,7 @@ to get a blow, to be struck"
   romaja: matgida
   pos: v
   defs:
-    - def: "To entrust someone with something."
+    - def: "to entrust someone with something"
   conj: [맡긴다, 맡겨, 맡겨요/맡기어요, 맡깁니다]
 
 - word: 맡다
@@ -28551,14 +28538,14 @@ to get a blow, to be struck"
   romaja: maeda
   pos: v
   defs:
-    - def: "To bind, fasten, tie, hang"
+    - def: "to bind, fasten, tie, hang"
   conj: [맨다, 매, 매요/매어요, 맵니다]
 
 - word: 매다
   romaja: maeda
   pos: v
   defs:
-    - def: "To weed (unwanted grasses out of a cultivated area)."
+    - def: "to weed (unwanted grasses out of a cultivated area)"
   conj: [맨다, 매, 매요/매어요, 맵니다]
 
 - word: 매달
@@ -28894,7 +28881,7 @@ to get a blow, to be struck"
 - word: 머루
   pos: n
   defs:
-    - def: "wild grape,  grape"
+    - def: "wild grape, grape"
 
 - word: 머리
   romaja: meori
@@ -29125,7 +29112,7 @@ to get a blow, to be struck"
   romaja: meomchuda
   pos: v
   defs:
-    - def: "To stop; to halt."
+    - def: "to stop; to halt"
   conj: [멈춘다, 멈추어, 멈추어요/멈춰요, 멈춥니다]
 
 - word: 멈칫
@@ -29898,7 +29885,7 @@ to get a blow, to be struck"
     - def: "which number"
       examples:
         - example: "몇 층에 사세요?"
-          transliteration: " Myeot cheung-e saseyo?"
+          transliteration: "Myeot cheung-e saseyo?"
           translation: "What floor do you live on?"
     - def: "some"
   rels: [며칠]
@@ -30209,7 +30196,7 @@ to get a blow, to be struck"
   romaja: mosida
   pos: v
   defs:
-    - def: "To serve or wait on a higher-status person."
+    - def: "to serve or wait on a higher-status person"
   conj: [모신다, 모셔, 모셔요/모시어요, 모십니다]
 
 - word: 모양
@@ -31043,8 +31030,8 @@ to get a blow, to be struck"
   romaja: muneojida
   pos: v
   defs:
-    - def: "To collapse."
-    - def: "To crumble or decay. (of a physical or social structure)"
+    - def: "to collapse"
+    - def: "to crumble or decay. (of a physical or social structure)"
   conj: [무너진다, 무너져, 무너져요/무너지어요, 무너집니다]
 
 - word: 무늬
@@ -31400,7 +31387,7 @@ to get a blow, to be struck"
   romaja: mujamaekjilhada
   pos: v
   defs:
-    - def: "To dip, dive, duck, submerge, swim under water"
+    - def: "to dip, dive, duck, submerge, swim under water"
   conj: [무자맥질한다, 무자맥질해, 무자맥질해요, 무자맥질합니다]
 
 - word: 무제한
@@ -31913,13 +31900,13 @@ to get a blow, to be struck"
   romaja: mulda
   pos: v
   defs:
-    - def: "To bite, gnaw"
-    - def: "To bite, sting"
-    - def: "To bite, swallow (bait)"
-    - def: "To bite, take hold (in the mouth)"
-    - def: "To bite, mate, mesh, gear"
-    - def: "To bite, mate, couple (unduly, deceptively)"
-    - def: "To pay (tax, fine, penalty, etc.), compensate, make up (for the loss)"
+    - def: "to bite, gnaw"
+    - def: "to bite, sting"
+    - def: "to bite, swallow (bait)"
+    - def: "to bite, take hold (in the mouth)"
+    - def: "to bite, mate, mesh, gear"
+    - def: "to bite, mate, couple (unduly, deceptively)"
+    - def: "to pay (tax, fine, penalty, etc.), compensate, make up (for the loss)"
   conj: [문다, 물어, 물어요, 뭅니다]
 
 - word: 물두꺼비
@@ -32040,21 +32027,21 @@ to get a blow, to be struck"
   romaja: mureotteda
   pos: v
   defs:
-    - def: "To bite off"
+    - def: "to bite off"
   conj: [물어뗀다, 물어떼, 물어떼요/물어떼어요, 물어뗍니다]
 
 - word: 물어뜯다
   romaja: mureotteutda
   pos: v
   defs:
-    - def: "To bite off"
+    - def: "to bite off"
   conj: [물어뜯는다, 물어뜯어, 물어뜯어요, 물어뜯습니다]
 
 - word: 물어보다
   romaja: mureoboda
   pos: v
   defs:
-    - def: "To ask (about something)."
+    - def: "to ask (about something)"
   conj: [물어본다, 물어봐, 물어봐요/물어보아요, 물어봅니다]
 
 - word: 물에네르기
@@ -32133,7 +32120,7 @@ to get a blow, to be struck"
   romaja: mwo
   pos: pron
   defs:
-    - def: "contraction of 무엇 (mueot):  what"
+    - def: "contraction of 무엇 (mueot): what"
       examples:
         - example: "이게 뭐예요?"
           transliteration: "Ige mwoyeyo?"
@@ -32496,14 +32483,14 @@ to get a blow, to be struck"
   romaja: mia
   pos: propn
   defs:
-    - def: "A female given name: Mia"
+    - def: "a female given name: Mia"
 
 - word: 미안하다
   romaja: mianhada
   pos: a
   defs:
-    - def: "To be ashamed of oneself."
-    - def: "To be sorry."
+    - def: "to be ashamed of oneself"
+    - def: "to be sorry"
   conj: [미안하다, 미안해, 미안해요, 미안합니다]
   tags: [topik1]
 
@@ -33386,7 +33373,6 @@ to get a blow, to be struck"
         - example: "지금 바로 시작합니다!"
           transliteration: "Jigeum baro sijakhamnida!"
           translation: "It will start right now."
-    - def: "↑    "
 
 - word: 바로가기
   romaja: barogagi
@@ -33564,7 +33550,7 @@ to get a blow, to be struck"
   defs:
     - def: "uncommon, insufficient; rarely encountered"
       examples:
-        - example: " 1992,  “두만강 (Duman-gang) [Tumen River]”, in  조선말대사전 (Joseonmaldaesajeon) [Dictionary of Korean language]:"
+        - example: "1992, “두만강 (Duman-gang) [Tumen River]”, in  조선말대사전 (Joseonmaldaesajeon) [Dictionary of Korean language]:"
           translation: "사랑채는 동향으로 앉아서 여름에는 해가 발랐다.Sarangchaeneun donghyang-euro anjaseo yeoreumeneun haega ballatda.The building used as a salon is placed in the east and the sun was shining in the summer which is uncommon."
   conj: [바른다, 발라, 발라요, 바릅니다]
 
@@ -33786,7 +33772,7 @@ to get a blow, to be struck"
   defs:
     - def: "A  surname​."
       examples:
-        - example: " c. 1280 AD,  Il-yeon, 일연(一然) (iryeon)),  “기이 권제1(紀異卷第一), 신라시조 혁거세왕(新羅始祖 赫居世王) (gii gwonje1, sillasijo hyeokgeosewang(新羅始祖 赫居世王))”, in  Samguk yusa, 삼국유사(三國遺事) (samgugyusa):"
+        - example: "c. 1280 AD, Il-yeon, 일연(一然) (iryeon)), “기이 권제1(紀異卷第一), 신라시조 혁거세왕(新羅始祖 赫居世王) (gii gwonje1, sillasijo hyeokgeosewang(新羅始祖 赫居世王))”, in  Samguk yusa, 삼국유사(三國遺事) (samgugyusa):"
           translation: "사내는 박〔瓠〕과 같이 생긴 알에서 나왔고, 향인들은 박을 박(朴)이라 이르므로, 그 성을 박으로 하였다.(The boy came from an egg that looked like a gourd, and countrymen named him Bak because gourd was called Bak.)Sanaeneun   bak〔瓠〕gwa gachi saenggin areseo nawatgo, hyang-indeureun bageul bagira ireumeuro, geu seong-eul bageuro hayeotda.(The boy came from an egg that looked like a gourd, and countrymen named him Bak because gourd was called Bak.)(please add an English translation of this quote)"
 
 - word: 박
@@ -34477,7 +34463,7 @@ to get a blow, to be struck"
   romaja: balgyeondoeda
   pos: v
   defs:
-    - def: "To be discovered."
+    - def: "to be discovered"
   conj: [발견된다, 발견돼, 발견돼요/발견되어요, 발견됩니다]
 
 - word: 발견하다
@@ -34814,7 +34800,7 @@ to get a blow, to be struck"
   romaja: balkyeojida
   pos: v
   defs:
-    - def: "To be discovered, revealed."
+    - def: "to be discovered, revealed"
   conj: [밝혀진다, 밝혀져, 밝혀져요/밝혀지어요, 밝혀집니다]
 
 - word: 밝히다
@@ -35035,7 +35021,7 @@ to get a blow, to be struck"
     - def: "just a moment ago; just now"
       examples:
         - example: "방금 왔어요."
-          transliteration: " Banggeum wasseoyo."
+          transliteration: "Banggeum wasseoyo."
           translation: "[He] arrived just a moment ago."
 
 - word: 방기
@@ -35325,8 +35311,8 @@ to get a blow, to be struck"
   romaja: banghaehada
   pos: v
   defs:
-    - def: "To hinder or obstruct."
-    - def: "To interfere with."
+    - def: "to hinder or obstruct"
+    - def: "to interfere with"
   conj: [방해한다, 방해해, 방해해요, 방해합니다]
 
 - word: 방향
@@ -36366,10 +36352,10 @@ to get a blow, to be struck"
   romaja: beoreojida
   pos: v
   defs:
-    - def: "To occur or take place."
-    - def: "To become separated."
-    - def: "To become estranged."
-    - def: "To differ."
+    - def: "to occur or take place"
+    - def: "to become separated"
+    - def: "to become estranged"
+    - def: "to differ"
   conj: [벌어진다, 벌어져, 벌어져요/벌어지어요, 벌어집니다]
 
 - word: 벌이다
@@ -37085,12 +37071,12 @@ to get a blow, to be struck"
     - def: "very (in a negative context)"
       examples:
         - example: "별로 많이 기다리지 않았어요."
-          transliteration: " Byeollo mani gidariji anasseoyo."
+          transliteration: "Byeollo mani gidariji anasseoyo."
           translation: "[I] have not been waiting very long."
     - def: "not really (sometimes used with a negative)"
       examples:
         - example: "별로 많지 않아요."
-          transliteration: " Byeollo manchi anayo."
+          transliteration: "Byeollo manchi anayo."
           translation: "There is really not a lot."
     - def: "not matching"
       examples:
@@ -37325,7 +37311,7 @@ to get a blow, to be struck"
 - word: 보관하다
   pos: v
   defs:
-    - def: "To keep."
+    - def: "to keep"
   conj: [보관한다, 보관해, 보관해요, 보관합니다]
 
 - word: 보급
@@ -38131,8 +38117,8 @@ to get a blow, to be struck"
   romaja: bokda
   pos: v
   defs:
-    - def: "To parch food."
-    - def: "To annoy someone."
+    - def: "to parch food"
+    - def: "to annoy someone"
   conj: [볶는다, 볶아, 볶아요, 볶습니다]
 
 - word: 볶이
@@ -38653,7 +38639,7 @@ to get a blow, to be struck"
   romaja: bureojida
   pos: v
   defs:
-    - def: "To break (as of an arm, leg, wing, sword, stick, etc.)"
+    - def: "to break (as of an arm, leg, wing, sword, stick, etc.)"
   conj: [부러진다, 부러져, 부러져요/부러지어요, 부러집니다]
 
 - word: 부럼
@@ -38708,22 +38694,22 @@ to get a blow, to be struck"
   romaja: bureuda
   pos: v
   defs:
-    - def: "To call, name"
+    - def: "to call, name"
       examples:
         - example: "제가 당신의 상사, 케이시 위버입니다. 그렇지만, 그저 저를 케이시라고 불러주세요. ― 감사합니다. 위버 님. ― 그저 케이시요. ― 네. 위버 님. ― 그럼, 알겠어요."
           transliteration: "Jega dangsinui sangsa, keisi wibeoimnida. Geureochiman, geujeo jeoreul keisirago bulleojuseyo. ― gamsahamnida. Wibeo nim. ― geujeo keisiyo. ― ne. Wibeo nim. ― geureom, algesseoyo."
           translation: "I am your boss, Caty Weaver. But, please call me Caty. ― Thank you, Ms. Weaver. ― Just Caty. ― Sure thing, Ms. Weaver. ― Okay then."
-    - def: "To bid, offer (price)"
+    - def: "to bid, offer (price)"
       examples:
         - example: "부르는 게 값"
           transliteration: "bureuneun ge gap"
           translation: "Whatever is offered is the price. (as when supply of goods is extremely limited)"
-    - def: "To cry, shout, yell"
+    - def: "to cry, shout, yell"
       examples:
         - example: "난 그녀의 이름을 불렀다."
           transliteration: "Nan geunyeoui ireumeul bulleotda."
           translation: "I called out her name."
-    - def: "To sing, chant"
+    - def: "to sing, chant"
   conj: [부른다, 불러, 불러요, 부릅니다]
 
 - word: 부르다
@@ -38880,10 +38866,10 @@ to get a blow, to be struck"
   romaja: buseojida
   pos: v
   defs:
-    - def: "To be shattered (For something hard to break into small pieces. )"
-    - def: "To break (For waves or light to dash against something, spread out, and then be scattered. )"
-    - def: "be broken; break down (For something that has a certain structure to be destroyed so much as to be useless. )"
-    - def: "be broken; be shattered (For one's hope or expectation to be destroyed. )"
+    - def: "to be shattered (for something hard to break into small pieces)"
+    - def: "to break (for waves or light to dash against something, spread out, and then be scattered)"
+    - def: "be broken; break down (for something that has a certain structure to be destroyed so much as to be useless)"
+    - def: "be broken; be shattered (for one's hope or expectation to be destroyed)"
   conj: [부서진다, 부서져, 부서져요/부서지어요, 부서집니다]
 
 - word: 부수
@@ -39176,7 +39162,7 @@ to get a blow, to be struck"
   romaja: bujokhada
   pos: a
   defs:
-    - def: "To be insufficient; not enough."
+    - def: "to be insufficient; not enough"
   conj: [부족하다, 부족해, 부족해요, 부족합니다]
 
 - word: 부줌부라
@@ -39731,7 +39717,7 @@ Used to illustrate the time that a certain action or situation began or will beg
   romaja: bunseokhada
   pos: v
   defs:
-    - def: "To analyze."
+    - def: "to analyze"
   conj: [분석한다, 분석해, 분석해요, 분석합니다]
 
 - word: 분수
@@ -39896,7 +39882,7 @@ Used to illustrate the time that a certain action or situation began or will beg
   romaja: bulganeunghada
   pos: a
   defs:
-    - def: "To be impossible."
+    - def: "to be impossible"
   conj: [불가능하다, 불가능해, 불가능해요, 불가능합니다]
 
 - word: 불가리아
@@ -40098,7 +40084,7 @@ Used to illustrate the time that a certain action or situation began or will beg
   romaja: bullida
   pos: v
   defs:
-    - def: "To be called."
+    - def: "to be called"
   conj: [불린다, 불려, 불려요/불리어요, 불립니다]
 
 - word: 불만
@@ -40441,7 +40427,7 @@ Used to illustrate the time that a certain action or situation began or will beg
       examples:
         - example: "시험에 붙다."
           transliteration: "Siheome butda."
-          translation: "To pass the test."
+          translation: "to pass the test"
     - def: "to be near"
     - def: "to catch fire"
       examples:
@@ -40850,14 +40836,14 @@ Used to illustrate the time that a certain action or situation began or will beg
   romaja: bida
   pos: a
   defs:
-    - def: "To be empty, hollow, vacant"
+    - def: "to be empty, hollow, vacant"
   conj: [비다, 벼, 벼요/비어요, 빕니다]
 
 - word: 비다
   romaja: bida
   pos: v
   defs:
-    - def: "To empty, drain; evacuate, vacate"
+    - def: "to empty, drain; evacuate, vacate"
   conj: [비다, 벼, 벼요/비어요, 빕니다]
 
 - word: 비단
@@ -41515,8 +41501,8 @@ Used to illustrate the time that a certain action or situation began or will beg
   romaja: billida
   pos: v
   defs:
-    - def: "To borrow."
-    - def: "To lend."
+    - def: "to borrow"
+    - def: "to lend"
   conj: [빌린다, 빌려, 빌려요/빌리어요, 빌립니다]
 
 - word: 빗
@@ -41633,7 +41619,7 @@ Used to illustrate the time that a certain action or situation began or will beg
   romaja: binnada
   pos: v
   defs:
-    - def: "To shine."
+    - def: "to shine"
       examples:
         - example: "너의 눈이 달빛 밑에 빛나."
           transliteration: "Neoui nuni dalbit mite binna."
@@ -41745,14 +41731,14 @@ Used to illustrate the time that a certain action or situation began or will beg
   romaja: ppalda
   pos: v
   defs:
-    - def: "To sip, suck; to fellate"
+    - def: "to sip, suck; to fellate"
   conj: [빤다, 빨아, 빨아요, 빱니다]
 
 - word: 빨다
   romaja: ppalda
   pos: v
   defs:
-    - def: "To wash (clothes), launder"
+    - def: "to wash (clothes), launder"
   conj: [빤다, 빨아, 빨아요, 빱니다]
 
 - word: 빨다
@@ -42839,7 +42825,7 @@ Used to illustrate the time that a certain action or situation began or will beg
   romaja: sayongdoeda
   pos: v
   defs:
-    - def: "To be used (for some purpose)."
+    - def: "to be used (for some purpose)"
   conj: [사용된다, 사용돼, 사용돼요/사용되어요, 사용됩니다]
 
 - word: 사용자
@@ -43660,9 +43646,9 @@ Used to illustrate the time that a certain action or situation began or will beg
   romaja: saraoda
   pos: v
   defs:
-    - def: "To have been living."
-    - def: "To survive; to have survived."
-    - def: "To have made a living at a certain job over a long time."
+    - def: "to have been living"
+    - def: "to survive; to have survived"
+    - def: "to have made a living at a certain job over a long time"
   conj: [살아온다, 살아와, 살아와요, 살아옵니다]
 
 - word: 살인
@@ -43722,7 +43708,7 @@ Used to illustrate the time that a certain action or situation began or will beg
   romaja: salpida
   pos: v
   defs:
-    - def: "To look closely; to observe."
+    - def: "to look closely; to observe"
   conj: [살핀다, 살펴, 살펴요/살피어요, 살핍니다]
 
 - word: 삵
@@ -43841,7 +43827,7 @@ Used to illustrate the time that a certain action or situation began or will beg
   romaja: samseong
   pos: n
   defs:
-    - def: "To introspect three times daily."
+    - def: "to introspect three times daily"
 
 - word: 삼성
   romaja: samseong
@@ -43907,17 +43893,17 @@ Used to illustrate the time that a certain action or situation began or will beg
   romaja: samkida
   pos: v
   defs:
-    - def: "To swallow. (to cause to pass from the mouth into the stomach)"
+    - def: "to swallow. (to cause to pass from the mouth into the stomach)"
       examples:
         - example: "아이가 무엇을 삼켰는지 자꾸 토한다."
           transliteration: "Aiga mueoseul samkyeonneunji jakku tohanda."
           translation: "The kid keeps gagging, like he swallowed something."
-    - def: "To suppress or stifle an expression of emotion."
+    - def: "to suppress or stifle an expression of emotion"
       examples:
         - example: "막 쏟아지려는 눈물을 못내 삼키며 집을 뛰쳐나갔다."
           transliteration: "Mak ssodajiryeoneun nunmureul monnae samkimyeo jibeul ttwichyeonagatda."
           translation: "I ran out of the house, holding back the tears that were ready to flow."
-    - def: "To secretly make something one's own; to steal."
+    - def: "to secretly make something one's own; to steal"
       examples:
         - example: "남의 돈을 슬쩍 삼키고는 오리발을 내밀었다."
           transliteration: "Namui doneul seuljjeok samkigoneun oribareul naemireotda."
@@ -44269,7 +44255,7 @@ Used to illustrate the time that a certain action or situation began or will beg
   romaja: sanghwandoeda
   pos: v
   defs:
-    - def: "To be repaid; be redeemed"
+    - def: "to be repaid; be redeemed"
       examples:
         - example: "네, 그것들은 다시 상환됩니다."
           transliteration: "Ne, geugeotdeureun dasi sanghwandoemnida."
@@ -44636,7 +44622,7 @@ Used to illustrate the time that a certain action or situation began or will beg
   romaja: saenggakdoeda
   pos: v
   defs:
-    - def: "To occur or come to mind."
+    - def: "to occur or come to mind"
   conj: [생각된다, 생각돼, 생각돼요/생각되어요, 생각됩니다]
 
 - word: 생각하다
@@ -44683,7 +44669,7 @@ Used to illustrate the time that a certain action or situation began or will beg
   romaja: saenggyeonada
   pos: v
   defs:
-    - def: "To emerge; to be generated."
+    - def: "to emerge; to be generated"
   conj: [생겨난다, 생겨나, 생겨나요, 생겨납니다]
 
 - word: 생기다
@@ -44784,7 +44770,7 @@ Used to illustrate the time that a certain action or situation began or will beg
   romaja: saengsanhada
   pos: v
   defs:
-    - def: "To produce."
+    - def: "to produce"
   conj: [생산한다, 생산해, 생산해요, 생산합니다]
 
 - word: 생생하다
@@ -45420,7 +45406,7 @@ Used to illustrate the time that a certain action or situation began or will beg
   romaja: seokda
   pos: v
   defs:
-    - def: "To mix"
+    - def: "to mix"
   conj: [섞는다, 섞어, 섞어요, 섞습니다]
 
 - word: 섞이다
@@ -45615,7 +45601,7 @@ Used to illustrate the time that a certain action or situation began or will beg
   romaja: seontaekhada
   pos: v
   defs:
-    - def: "To choose or select."
+    - def: "to choose or select"
   conj: [선택한다, 선택해, 선택해요, 선택합니다]
 
 - word: 선풍
@@ -47317,7 +47303,7 @@ Used to illustrate the time that a certain action or situation began or will beg
   romaja: sojunghada
   pos: a
   defs:
-    - def: "To be precious."
+    - def: "to be precious"
   conj: [소중하다, 소중해, 소중해요, 소중합니다]
 
 - word: 소지품
@@ -47552,7 +47538,7 @@ Used to illustrate the time that a certain action or situation began or will beg
   romaja: sokhada
   pos: v
   defs:
-    - def: "To be part of; to be a member of."
+    - def: "to be part of; to be a member of"
   conj: [속한다, 속해, 속해요, 속합니다]
 
 - word: 손
@@ -48309,14 +48295,14 @@ Used to illustrate the time that a certain action or situation began or will beg
   romaja: surihada
   pos: v
   defs:
-    - def: "To repair or fix."
+    - def: "to repair or fix"
   conj: [수리한다, 수리해, 수리해요, 수리합니다]
 
 - word: 수많다
   romaja: sumanta
   pos: a
   defs:
-    - def: "To be many; numerous."
+    - def: "to be many; numerous"
 
 - word: 수말
   romaja: sumal
@@ -50227,7 +50213,7 @@ Used to illustrate the time that a certain action or situation began or will beg
   romaja: sida
   pos: a
   defs:
-    - def: "To be sour"
+    - def: "to be sour"
   conj: [시다, 셔, 셔요/시어요, 십니다]
 
 - word: 시달리다
@@ -51512,9 +51498,9 @@ Used to illustrate the time that a certain action or situation began or will beg
   romaja: sillida
   pos: v
   defs:
-    - def: "To be planted"
-    - def: "To be loaded"
-    - def: "To be printed"
+    - def: "to be planted"
+    - def: "to be loaded"
+    - def: "to be printed"
   conj: [실린다, 실려, 실려요/실리어요, 실립니다]
 
 - word: 실린더
@@ -51652,7 +51638,7 @@ Used to illustrate the time that a certain action or situation began or will beg
   romaja: silcheonhada
   pos: v
   defs:
-    - def: "To implement; to carry out in practice."
+    - def: "to implement; to carry out in practice"
   conj: [실천한다, 실천해, 실천해요, 실천합니다]
 
 - word: 실체
@@ -51767,17 +51753,17 @@ Used to illustrate the time that a certain action or situation began or will beg
   romaja: simda
   pos: v
   defs:
-    - def: "To plant, sow (seed or plants)"
+    - def: "to plant, sow (seed or plants)"
       examples:
         - example: "정원에 사과나무를 심다"
           transliteration: "jeong-wone sagwanamureul simda"
           translation: "to plant an apple tree in a garden"
-    - def: "To plant, implant, instill, inculcate (a thought or a sentiment)"
+    - def: "to plant, implant, instill, inculcate (a thought or a sentiment)"
       examples:
         - example: "나는 학생들에게 올바른 사상을 심어 주려고 했다."
           transliteration: "Naneun haksaengdeurege olbareun sasang-eul simeo juryeogo haetda."
           translation: "I tried to inculcate a right thought in [my] student."
-    - def: "To plant (a person) secretly as a spy"
+    - def: "to plant (a person) secretly as a spy"
   conj: [심는다, 심어, 심어요, 심습니다]
 
 - word: 심리
@@ -52301,8 +52287,8 @@ Used to illustrate the time that a certain action or situation began or will beg
   romaja: ssaida
   pos: v
   defs:
-    - def: "To be scattered, sown."
-    - def: "To be constructed."
+    - def: "to be scattered, sown"
+    - def: "to be constructed"
   conj: [쌓인다, 쌓여, 쌓여요/쌓이어요, 쌓입니다]
 
 - word: 쌤
@@ -52437,7 +52423,7 @@ Used to illustrate the time that a certain action or situation began or will beg
   romaja: ssodajida
   pos: v
   defs:
-    - def: "To splash out, to be spilled or poured."
+    - def: "to splash out, to be spilled or poured"
   conj: [쏟아진다, 쏟아져, 쏟아져요/쏟아지어요, 쏟아집니다]
 
 - word: 쏠다
@@ -52590,8 +52576,8 @@ Used to illustrate the time that a certain action or situation began or will beg
   romaja: sseu-ida
   pos: v
   defs:
-    - def: "To be used."
-    - def: "To be written."
+    - def: "to be used"
+    - def: "to be written"
   conj: [쓰인다, 쓰여, 쓰여요/쓰이어요, 쓰입니다]
 
 - word: 쓰촨
@@ -52925,8 +52911,8 @@ Used to illustrate the time that a certain action or situation began or will beg
   romaja: akkida
   pos: v
   defs:
-    - def: "To cherish"
-    - def: "To save or conserve something."
+    - def: "to cherish"
+    - def: "to save or conserve something"
   conj: [아낀다, 아껴, 아껴요/아끼어요, 아낍니다]
 
 - word: 아나운서
@@ -53337,7 +53323,7 @@ Used to illustrate the time that a certain action or situation began or will beg
     - def: "maybe"
       examples:
         - example: "좋아, 나중에 봐, 아마도. — 아마도, 나중에 봐."
-          transliteration: "Joa, najung-e bwa, amado.  amado, najung-e bwa."
+          transliteration: "Joa, najung-e bwa, amado. Amado, najung-e bwa."
           translation: "Okay. See you later, maybe. — Maybe I’ll see you later."
 
 - word: 아마추어
@@ -54117,7 +54103,7 @@ Used to illustrate the time that a certain action or situation began or will beg
     - def: "an apartment, a flat"
       examples:
         - example: "난 조나단이야. 난 아파트 b4호에 살아. — 난 아파트 c2에 살아."
-          transliteration: "Nan jonadaniya. Nan apateu b4ho-e sara.  nan apateu c2e sara."
+          transliteration: "Nan jonadaniya. Nan apateu b4ho-e sara. Nan apateu c2e sara."
           translation: "I am Jonathan. I am in apartment B4. — I am in apartment C2."
 
 - word: 아포스트로피
@@ -54871,8 +54857,8 @@ Used to illustrate the time that a certain action or situation began or will beg
           translation: "Tell her you’re here.—Right, thanks, Pete."
     - def: "to know (To have met someone before or get along with him/her as an acquaintance.)"
       examples:
-        - example: "마샤가 제 룸메이트이에요.  — 저는 마샤를 알고 지내요. 좋은 분이지요."
-          transliteration: "Masyaga je rummeiteu-ieyo.  — jeoneun masyareul algo jinaeyo. Joeun bunijiyo."
+        - example: "마샤가 제 룸메이트이에요. — 저는 마샤를 알고 지내요. 좋은 분이지요."
+          transliteration: "Masyaga je rummeiteu-ieyo. — Jeoneun masyareul algo jinaeyo. Joeun bunijiyo."
           translation: "Marsha is my roommate. — I know Marsha. She is nice."
     - def: "to regard; think of"
     - def: "to know; think (To consider or assume a fact as being of a certain quality.)"
@@ -55362,7 +55348,7 @@ Used to illustrate the time that a certain action or situation began or will beg
   romaja: apduda
   pos: v
   defs:
-    - def: "To have lying ahead of one; to look toward"
+    - def: "to have lying ahead of one; to look toward"
   conj: [앞둔다, 앞두어, 앞두어요/앞둬요, 앞둡니다]
 
 - word: 앞뒤
@@ -55442,7 +55428,7 @@ Used to illustrate the time that a certain action or situation began or will beg
   defs:
     - def: "Aegukka, the North Korean national anthem."
     - def: "Aegukga, the South Korean national anthem."
-    - def: "Any patriotic song."
+    - def: "any patriotic song"
 
 - word: 애국심
   romaja: aeguksim
@@ -55552,7 +55538,7 @@ Used to illustrate the time that a certain action or situation began or will beg
   romaja: aesseuda
   pos: v
   defs:
-    - def: "To exert or strain oneself to reach a goal."
+    - def: "to exert or strain oneself to reach a goal"
   conj: [애쓴다, 애써, 애써요, 애씁니다]
 
 - word: 애완동물
@@ -55831,7 +55817,7 @@ Used to illustrate the time that a certain action or situation began or will beg
     - def: "vegetable"
       examples:
         - example: "야채와 과일에는 비타민이 많이 들어 있다."
-          transliteration: " Yachaewa gwaireneun bitamini mani deureo itda."
+          transliteration: "Yachaewa gwaireneun bitamini mani deureo itda."
           translation: "There are many vitamins in vegetables and fruit."
 
 - word: 야쿠자
@@ -56594,8 +56580,8 @@ Used to illustrate the time that a certain action or situation began or will beg
           transliteration: "Gonghangkkaji jihacheoreul tamyeon doel geot gateunde hoksi jihacheori eodi inneunji aseyo?"
           translation: "I think I can take the subway to the airport. Do you know where the subway is?"
         - example: "헬스클럽이 어디 맞은편이라고? — 헬스클럽은 라운지 맞은 편이야. — 라운지 맞은편이라… 알겠어. 고마워."
-          transliteration: "Helseukeulleobi eodi majeunpyeonirago?  helseukeulleobeun raunji majeun pyeoniya.  raunji majeunpyeonira… algesseo. Gomawo."
-          translation: "The gym is across from … what? — The gym is across from the lounge. — Across from the lounge.  Right. Thanks!"
+          transliteration: "Helseukeulleobi eodi majeunpyeonirago? Helseukeulleobeun raunji majeun pyeoniya. Raunji majeunpyeonira… algesseo. Gomawo."
+          translation: "The gym is across from … what? — The gym is across from the lounge. — Across from the lounge. Right. Thanks!"
     - def: "somewhere (to refer to a place without saying exactly where you mean)"
     - def: "somewhere (to refer to an unfixed place)"
     - def: "somehow, some way, something (to refer to a something that is hard to express)"
@@ -56799,7 +56785,7 @@ Used to illustrate the time that a certain action or situation began or will beg
   pos: a
   defs:
     - def: "to be young, infantile, juvenile"
-    - def: "to be inexperienced, ignorant,  foolish"
+    - def: "to be inexperienced, ignorant, foolish"
   conj: [어리다, 어려, 어려요/어리어요, 어립니다]
 
 - word: 어리다
@@ -57042,10 +57028,10 @@ Used to illustrate the time that a certain action or situation began or will beg
     - def: "hey! (for calling a person of the same status or lower in an informal way)"
       examples:
         - example: "어이, 나 좀 도와줘."
-          transliteration: " Eoi, na jom dowajwo."
+          transliteration: "Eoi, na jom dowajwo."
           translation: "Hey, help me out a bit."
         - example: "어이, 여기 간식이라도 있냐?"
-          transliteration: " Eoi, yeogi gansigirado innya?"
+          transliteration: "Eoi, yeogi gansigirado innya?"
           translation: "Hey, are there even any snacks in here?"
 
 - word: 어저께
@@ -57143,9 +57129,9 @@ Used to illustrate the time that a certain action or situation began or will beg
   defs:
     - def: "How, in what way or for what purpose."
       examples:
-        - example: "아나: 피트 안녕. 안녕. 우리 여기 있어. — 피트: 안녕, 아나. 안녕. 마샤. —아나: 안녕. —피트: 너희 둘은 어찌 지내? —마샤: 난 좋아."
-          transliteration: "Ana: piteu annyeong. Annyeong. Uri yeogi isseo.  piteu: annyeong, ana. Annyeong. Masya. Ana: annyeong. Piteu: neohui dureun eojji jinae? Masya: nan joa."
-          translation: "Anna: Pete, hi! Hi, we are here! —Pete: Hi, Anna! Hi, Marsha! —Anna: Hi! —Pete: How are you two? —Marsha: I am great!"
+        - example: "아나: 피트 안녕. 안녕. 우리 여기 있어. — 피트: 안녕, 아나. 안녕. 마샤. — 아나: 안녕. — 피트: 너희 둘은 어찌 지내? — 마샤: 난 좋아."
+          transliteration: "Ana: piteu annyeong. Annyeong. Uri yeogi isseo. — Piteu: annyeong, ana. Annyeong. Masya. — Ana: annyeong. — Piteu: neohui dureun eojji jinae? — Masya: nan joa."
+          translation: "Anna: Pete, hi! Hi, we are here! — Pete: Hi, Anna! Hi, Marsha! — Anna: Hi! — Pete: How are you two? — Marsha: I am great!"
 
 - word: 어찌하다
   romaja: eojjihada
@@ -57307,7 +57293,7 @@ Used to illustrate the time that a certain action or situation began or will beg
     - def: "When"
       examples:
         - example: "언제가 네 생일이니?"
-          transliteration: " Eonjega ne saeng-irini?"
+          transliteration: "Eonjega ne saeng-irini?"
           translation: "When is your birthday?"
 
 - word: 언제
@@ -57318,7 +57304,7 @@ Used to illustrate the time that a certain action or situation began or will beg
     - def: "sometime, any time"
       examples:
         - example: "언제 한 번 만나 소주 한 잔 합시다."
-          transliteration: " Eonje han beon manna soju han jan hapsida."
+          transliteration: "Eonje han beon manna soju han jan hapsida."
           translation: "Let's get together and have a glass of soju some time."
         - example: "할머니댁은 언제 가도 마음이 편하다."
           transliteration: "Halmeonidaegeun eonje gado ma-eumi pyeonhada."
@@ -57697,8 +57683,8 @@ Used to illustrate the time that a certain action or situation began or will beg
   romaja: eopsaeda
   pos: v
   defs:
-    - def: "To eliminate."
-    - def: "To kill"
+    - def: "to eliminate"
+    - def: "to kill"
   conj: [없앤다, 없애, 없애요/없애어요, 없앱니다]
 
 - word: 없어지다
@@ -58737,7 +58723,7 @@ Used to illustrate the time that a certain action or situation began or will beg
   romaja: yeon-gudoeda
   pos: v
   defs:
-    - def: "To be researched; be studied"
+    - def: "to be researched; be studied"
       examples:
         - example: "2015년, 과학자들은, 중국에서 연구된 빙하의 82퍼센트의 크기가 감소하였다는 것을 발견하였다."
           transliteration: "2015nyeon, gwahakjadeureun, junggugeseo yeon-gudoen binghaui 82peosenteuui keugiga gamsohayeotdaneun geoseul balgyeonhayeotda."
@@ -58782,7 +58768,7 @@ Used to illustrate the time that a certain action or situation began or will beg
   romaja: yeon-guhada
   pos: v
   defs:
-    - def: "To conduct research."
+    - def: "to conduct research"
   conj: [연구한다, 연구해, 연구해요, 연구합니다]
 
 - word: 연극
@@ -59932,7 +59918,7 @@ Used to illustrate the time that a certain action or situation began or will beg
   romaja: yesangdoeda
   pos: v
   defs:
-    - def: "To be predicted or anticipated."
+    - def: "to be predicted or anticipated"
   conj: [예상된다, 예상돼, 예상돼요/예상되어요, 예상됩니다]
 
 - word: 예상하다
@@ -60200,7 +60186,7 @@ Used to illustrate the time that a certain action or situation began or will beg
   romaja: oda
   pos: v
   defs:
-    - def: "To come"
+    - def: "to come"
       examples:
         - example: "파티에 와서 고마워."
           transliteration: "Patie waseo gomawo."
@@ -60321,7 +60307,7 @@ Used to illustrate the time that a certain action or situation began or will beg
     - def: "the first occurrence after a long absence"
       examples:
         - example: "오래간만 입니다!"
-          transliteration: " Oraeganman imnida!"
+          transliteration: "Oraeganman imnida!"
           translation: "Long time, no see! (literally, \"It has been a long time!\")"
 
 - word: 오래다
@@ -60372,7 +60358,7 @@ Used to illustrate the time that a certain action or situation began or will beg
   romaja: oraetdong-an
   pos: n
   defs:
-    - def: "A long time."
+    - def: "a long time"
 
 - word: 오렌지
   romaja: orenji
@@ -60519,7 +60505,7 @@ Used to illustrate the time that a certain action or situation began or will beg
   romaja: oda
   pos: v
   defs:
-    - def: "To come"
+    - def: "to come"
       examples:
         - example: "파티에 와서 고마워."
           transliteration: "Patie waseo gomawo."
@@ -60836,8 +60822,8 @@ Used to illustrate the time that a certain action or situation began or will beg
   defs:
     - def: "p.m."
       examples:
-        - example: "아나. — 네, 위버님. — 바빠요? —네, 위버님. 바쁩니다. — 내 사무실로 오후 5시에 오세요. — 오후 5시요."
-          transliteration: "Ana.  ne, wibeonim.  bappayo? Ne, wibeonim. Bappeumnida.  nae samusillo ohu 5sie oseyo.  ohu 5siyo."
+        - example: "아나. — 네, 위버님. — 바빠요? — 네, 위버님. 바쁩니다. — 내 사무실로 오후 5시에 오세요. — 오후 5시요."
+          transliteration: "Ana. — Ne, wibeonim. — Bappayo? — Ne, wibeonim. Bappeumnida. — Nae samusillo ohu 5sie oseyo. — Ohu 5siyo."
           translation: "Anna. — Yes, Ms. Weaver. — Are you busy? — Yes, Ms. Weaver. I am busy. — My office. 5:00 p.m. —  5:00 p.m."
     - def: "afternoon"
 
@@ -61098,9 +61084,9 @@ Used to illustrate the time that a certain action or situation began or will beg
   romaja: ollaoda
   pos: v
   defs:
-    - def: "To come up; to ascend."
-    - def: "To come to the capital, especially to Seoul."
-    - def: "To be set on the table."
+    - def: "to come up; to ascend"
+    - def: "to come to the capital, especially to Seoul"
+    - def: "to be set on the table"
   conj: [올라온다, 올라와, 올라와요, 올라옵니다]
 
 - word: 올려놓다
@@ -61369,7 +61355,7 @@ Used to illustrate the time that a certain action or situation began or will beg
   romaja: oda
   pos: v
   defs:
-    - def: "To come"
+    - def: "to come"
       examples:
         - example: "파티에 와서 고마워."
           transliteration: "Patie waseo gomawo."
@@ -61873,8 +61859,8 @@ Used to illustrate the time that a certain action or situation began or will beg
   romaja: oechida
   pos: v
   defs:
-    - def: "To shout or cry out."
-    - def: "To proclaim."
+    - def: "to shout or cry out"
+    - def: "to proclaim"
   conj: [외친다, 외쳐, 외쳐요/외치어요, 외칩니다]
 
 - word: 외침
@@ -61952,7 +61938,7 @@ Used to illustrate the time that a certain action or situation began or will beg
           transliteration: "Jega dowadeurijiyo."
           translation: "I can give you a hand."
         - example: "만나서 반가웠어요. — 저도요. 잘 가요."
-          transliteration: "Mannaseo ban-gawosseoyo.  jeodoyo. Jal gayo."
+          transliteration: "Mannaseo ban-gawosseoyo. — Jeodoyo. Jal gayo."
           translation: "Nice to meet you! — You too, Bye."
   notes:
     - In the 해요체 (haeyoche, “polite”) speech level, there is no explicit marker to distinguish between indicative, interrogative, imperative, and hortative moods. The mood distinction is made with punctuation (e.g. “?”, “!”) and pitch (e.g. rising for interrogative) only.
@@ -62801,7 +62787,7 @@ Used to illustrate the time that a certain action or situation began or will beg
     - def: "post office"
       examples:
         - example: "우체국이 어디입니까?"
-          transliteration: " Uchegugi eodiimnikka?"
+          transliteration: "Uchegugi eodiimnikka?"
           translation: "Where is the post-office?"
   tags: [topik1]
 
@@ -62836,7 +62822,7 @@ Used to illustrate the time that a certain action or situation began or will beg
     - def: "post office"
       examples:
         - example: "우펀국이 어디입니까?"
-          transliteration: " Upeon-gugi eodiimnikka?"
+          transliteration: "Upeon-gugi eodiimnikka?"
           translation: "Where is the post-office?"
 
 - word: 우편
@@ -63106,9 +63092,9 @@ Used to illustrate the time that a certain action or situation began or will beg
   romaja: ullida
   pos: v
   defs:
-    - def: "To sound or ring, or make a sound."
-    - def: "To sound or ring something, or cause something to make a sound."
-    - def: "To cause to weep."
+    - def: "to sound or ring, or make a sound"
+    - def: "to sound or ring something, or cause something to make a sound"
+    - def: "to cause to weep"
   conj: [울린다, 울려, 울려요/울리어요, 울립니다]
 
 - word: 울산
@@ -64192,14 +64178,14 @@ Used to illustrate the time that a certain action or situation began or will beg
   romaja: yumyeonghada
   pos: a
   defs:
-    - def: "To be famous."
+    - def: "to be famous"
   conj: [유명하다, 유명해, 유명해요, 유명합니다]
 
 - word: 유명한
   romaja: yumyeonghada
   pos: a
   defs:
-    - def: "To be famous."
+    - def: "famous"
   conj: [유명하다, 유명해, 유명해요, 유명합니다]
 
 - word: 유모
@@ -64708,7 +64694,7 @@ Used to illustrate the time that a certain action or situation began or will beg
     - def: "은 (eun) marks the topic of the sentence. The topic of a sentence is not to be confused with the subject of the sentence."
       examples:
         - example: "그것은 큰 책이야. — 맞아, 맞아, 피트."
-          transliteration: "Geugeoseun keun chaegiya.  maja, maja, piteu."
+          transliteration: "Geugeoseun keun chaegiya. — maja, maja, piteu."
           translation: "It is a big book. — Yes. Yes it is, Pete."
         - example: "네, 어제 일은 얘기하지 않기로 하지요."
           transliteration: "Ne, eoje ireun yaegihaji ankiro hajiyo."
@@ -65268,7 +65254,7 @@ Used to illustrate the time that a certain action or situation began or will beg
   romaja: uimun
   pos: n
   defs:
-    - def: "Doubt."
+    - def: "doubt"
 
 - word: 의문사
   pos: n
@@ -65350,7 +65336,7 @@ Used to illustrate the time that a certain action or situation began or will beg
   romaja: uisikhada
   pos: v
   defs:
-    - def: "To be aware or conscious of something."
+    - def: "to be aware or conscious of something"
   conj: [의식한다, 의식해, 의식해요, 의식합니다]
 
 - word: 의심
@@ -65728,7 +65714,7 @@ Used to illustrate the time that a certain action or situation began or will beg
   romaja: ikkeulda
   pos: v
   defs:
-    - def: "To pull or lead."
+    - def: "to pull or lead"
   conj: [이끈다, 이끌어, 이끌어요, 이끕니다]
 
 - word: 이끼
@@ -65784,14 +65770,14 @@ Used to illustrate the time that a certain action or situation began or will beg
   romaja: inyeom
   pos: n
   defs:
-    - def: "The ideology or principle underlying an intellectual position."
+    - def: "the ideology or principle underlying an intellectual position"
     - def: "idea; Idea"
 
 - word: 이다
   romaja: ida
   pos: a
   defs:
-    - def: "To be (something); to equal"
+    - def: "to be (something); to equal"
   conj: [이다, 이야, 이에요/예요, 입니다]
   syns: [다]
   tags: [topik1]
@@ -65853,7 +65839,7 @@ Used to illustrate the time that a certain action or situation began or will beg
     - def: "a little later; after a while; a short time later"
       examples:
         - example: "이따가 만나자."
-          transliteration: " Ittaga mannaja."
+          transliteration: "Ittaga mannaja."
           translation: "See you later."
 
 - word: 이때
@@ -65938,8 +65924,8 @@ Used to illustrate the time that a certain action or situation began or will beg
   romaja: ireoda
   pos: v
   defs:
-    - def: "To do this; to act in this way."
-    - def: "To say this."
+    - def: "to do this; to act in this way"
+    - def: "to say this"
   conj: [이런다, 이래, 이래요, 이럽니다]
 
 - word: 이러쿵저러쿵
@@ -66106,8 +66092,8 @@ Used to illustrate the time that a certain action or situation began or will beg
   romaja: iri
   pos: adv
   defs:
-    - def: "To this place, hither, here"
-    - def: "In this way, like this, so"
+    - def: "to this place, hither, here"
+    - def: "in this way, like this, so"
 
 - word: 이리
   romaja: iri
@@ -66898,9 +66884,9 @@ Used to illustrate the time that a certain action or situation began or will beg
   romaja: ikhida
   pos: v
   defs:
-    - def: "To become habituated to something."
-    - def: "To ripen something."
-    - def: "To cook something through."
+    - def: "to become habituated to something"
+    - def: "to ripen something"
+    - def: "to cook something through"
   conj: [익힌다, 익혀, 익혀요/익히어요, 익힙니다]
 
 - word: 인
@@ -67240,7 +67226,7 @@ Used to illustrate the time that a certain action or situation began or will beg
   romaja: insikhada
   pos: v
   defs:
-    - def: "To recognize or understand."
+    - def: "to recognize or understand"
   conj: [인식한다, 인식해, 인식해요, 인식합니다]
 
 - word: 인어
@@ -67784,12 +67770,12 @@ Used to illustrate the time that a certain action or situation began or will beg
   romaja: ireoseoda
   pos: v
   defs:
-    - def: "To stand up."
+    - def: "to stand up"
       examples:
         - example: "그 여자는 군중 너머를 보려고 일어섰다."
           transliteration: "Geu yeojaneun gunjung neomeoreul boryeogo ireoseotda."
           translation: "She stood in order to see over the crowd."
-    - def: "To take place; to arise."
+    - def: "to take place; to arise"
   conj: [일어선다, 일어서어, 일어서어요, 일어섭니다]
 
 - word: 일여덟
@@ -68310,7 +68296,7 @@ Used to illustrate the time that a certain action or situation began or will beg
         - example: "물속에 물고기가 있다."
           transliteration: "Mulsoge mulgogiga itda."
           translation: "There are fish in the water."
-    - def: "To be (in a state)"
+    - def: "to be (in a state)"
       examples:
         - example: "서 있다"
           transliteration: "seo itda"
@@ -68321,7 +68307,7 @@ Used to illustrate the time that a certain action or situation began or will beg
         - example: "모여 있다"
           transliteration: "moyeo itda"
           translation: "to be gathered"
-    - def: "To have"
+    - def: "to have"
       examples:
         - example: "그녀는 남자 친구가 있다."
           transliteration: "Geunyeoneun namja chin-guga itda."
@@ -68941,7 +68927,7 @@ rat (Chinese zodiac sign)"
   romaja: jayuropda
   pos: a
   defs:
-    - def: "To be free; unfettered."
+    - def: "to be free; unfettered"
   conj: [자유롭다, 자유로워, 자유로워요, 자유롭습니다]
 
 - word: 자유적
@@ -69214,7 +69200,7 @@ rat (Chinese zodiac sign)"
   romaja: jagyonghada
   pos: v
   defs:
-    - def: "To act on or affect something."
+    - def: "to act on or affect something"
   conj: [작용한다, 작용해, 작용해요, 작용합니다]
 
 - word: 작은
@@ -69388,9 +69374,9 @@ rat (Chinese zodiac sign)"
   romaja: jaldoeda
   pos: v
   defs:
-    - def: "To do well; to prosper."
-    - def: "To turn out well."
-    - def: "To be just great."
+    - def: "to do well; to prosper"
+    - def: "to turn out well"
+    - def: "to be just great"
   conj: [잘된다, 잘돼, 잘돼요/잘되어요, 잘됩니다]
 
 - word: 잘못
@@ -69414,16 +69400,16 @@ rat (Chinese zodiac sign)"
   romaja: jalmotdoeda
   pos: v
   defs:
-    - def: "To go wrong, to go awry."
-    - def: "To die unexpectedly, of accident or disease."
+    - def: "to go wrong, to go awry"
+    - def: "to die unexpectedly, of accident or disease"
   conj: [잘못된다, 잘못돼, 잘못돼요/잘못되어요, 잘못됩니다]
 
 - word: 잘못하다
   romaja: jalmothada
   pos: v
   defs:
-    - def: "To err; to make a mistake."
-    - def: "To do something incorrectly."
+    - def: "to err; to make a mistake"
+    - def: "to do something incorrectly"
   conj: [잘못한다, 잘못해, 잘못해요, 잘못합니다]
 
 - word: 잘생기다
@@ -69490,7 +69476,7 @@ rat (Chinese zodiac sign)"
     - def: "(for a) short time, for a moment, awhile, briefly"
       examples:
         - example: "잠깐 기다리세요."
-          transliteration: " Jamkkan gidariseyo."
+          transliteration: "Jamkkan gidariseyo."
           translation: "Please wait a minute."
 
 - word: 잠꼬대
@@ -69643,7 +69629,7 @@ rat (Chinese zodiac sign)"
   romaja: japhida
   pos: v
   defs:
-    - def: "To be caught."
+    - def: "to be caught"
   conj: [잡힌다, 잡혀, 잡혀요/잡히어요, 잡힙니다]
 
 - word: 잣
@@ -70423,7 +70409,7 @@ rat (Chinese zodiac sign)"
     - def: "um; uh; erm (An exclamation used when one finds it awkward and uncomfortable to bring up something.)"
       examples:
         - example: "저기. 내가 미안해. — 괜찮아. 아나."
-          transliteration: "Jeogi. Naega mianhae.  gwaenchana. Ana."
+          transliteration: "Jeogi. Naega mianhae. — Gwaenchana. Ana."
           translation: "Well, I am sorry. — It’s okay, Anna."
 
 - word: 저널리스트
@@ -70574,7 +70560,7 @@ rat (Chinese zodiac sign)"
   romaja: jeojireuda
   pos: v
   defs:
-    - def: "To commit (wrongdoing)"
+    - def: "to commit (wrongdoing)"
   conj: [저지른다, 저질러, 저질러요, 저지릅니다]
 
 - word: 저지하다
@@ -70776,7 +70762,7 @@ rat (Chinese zodiac sign)"
   romaja: jeokjeolhada
   pos: a
   defs:
-    - def: "To be suited; to be appropriate"
+    - def: "to be suited; to be appropriate"
   conj: [적절하다, 적절해, 적절해요, 적절합니다]
 
 - word: 적정량
@@ -71415,7 +71401,7 @@ rat (Chinese zodiac sign)"
     - def: "telephone number"
       examples:
         - example: "전화번호가 몇 번이에요?"
-          transliteration: " Jeonhwabeonhoga myeot beonieyo?"
+          transliteration: "Jeonhwabeonhoga myeot beonieyo?"
           translation: "what's your phone number?"
 
 - word: 전화하다
@@ -71754,12 +71740,12 @@ rat (Chinese zodiac sign)"
   romaja: jeopsuhada
   pos: v
   defs:
-    - def: "To receive, take (To get applications, reports, etc., through verbal or written means.)"
+    - def: "to receive, take (To get applications, reports, etc., through verbal or written means.)"
       examples:
         - example: "존슨 씨가 당신의 상세한 얘기를 접수할 겁니다."
           transliteration: "Jonseun ssiga dangsinui sangsehan yaegireul jeopsuhal geomnida."
           translation: "Mr. Johnson will take your detail."
-    - def: "To receive (To get money, items, etc.)"
+    - def: "to receive (to get money, items, etc.)"
   conj: [접수한다, 접수해, 접수해요, 접수합니다]
 
 - word: 접시
@@ -72465,8 +72451,8 @@ rat (Chinese zodiac sign)"
   romaja: jeotda
   pos: v
   defs:
-    - def: "To become wet."
-    - def: "To indulge in."
+    - def: "to become wet"
+    - def: "to indulge in"
   conj: [젖는다, 젖어, 젖어요, 젖습니다]
 
 - word: 젖당못견딤증
@@ -72527,7 +72513,7 @@ rat (Chinese zodiac sign)"
   romaja: jegonghada
   pos: v
   defs:
-    - def: "To provide or furnish."
+    - def: "to provide or furnish"
   conj: [제공한다, 제공해, 제공해요, 제공합니다]
 
 - word: 제과점
@@ -72723,7 +72709,7 @@ rat (Chinese zodiac sign)"
   romaja: je-oehada
   pos: v
   defs:
-    - def: "To exclude (from consideration)."
+    - def: "to exclude (from consideration)"
   conj: [제외한다, 제외해, 제외해요, 제외합니다]
 
 - word: 제우스
@@ -72818,10 +72804,10 @@ rat (Chinese zodiac sign)"
     - def: "Jeju (island, province and its capital in South Korea)"
       examples:
         - example: "제주도"
-          transliteration: " Jejudo"
+          transliteration: "Jejudo"
           translation: "Jeju island, Jejudo"
         - example: "제주시"
-          transliteration: " Jejusi"
+          transliteration: "Jejusi"
           translation: "Jeju city"
 
 - word: 제주도
@@ -73051,7 +73037,7 @@ rat (Chinese zodiac sign)"
     - def: "a little; a bit"
       examples:
         - example: "조금만 기다리십시오."
-          transliteration: " Jogeumman gidarisipsio."
+          transliteration: "Jogeumman gidarisipsio."
           translation: "Please wait a little."
 
 - word: 조금씩
@@ -73837,7 +73823,7 @@ rat (Chinese zodiac sign)"
           transliteration: "Geurigo, oneul eotteoseumnikka?  aju joayo, gamsahamnida. Makeu."
           translation: "And how are you today? - Very well thank you Mark."
         - example: "오늘 오후에 들러요. — 좋아요."
-          transliteration: "Oneul ohue deulleoyo.  joayo."
+          transliteration: "Oneul ohue deulleoyo. — Joayo."
           translation: "Come by this afternoon. — Okay."
     - def: "good; nice (Well-rounded and kind in personality.)"
     - def: "good; kind (Kind and gentle in the way one speaks and acts.)"
@@ -74320,7 +74306,7 @@ rat (Chinese zodiac sign)"
   romaja: jusik
   pos: n
   defs:
-    - def: "Food and alcohol."
+    - def: "food and alcohol"
 
 - word: 주어
   pos: n
@@ -74336,7 +74322,7 @@ rat (Chinese zodiac sign)"
   romaja: jueojida
   pos: v
   defs:
-    - def: "To be provided; given."
+    - def: "to be provided; given"
   conj: [주어진다, 주어져, 주어져요/주어지어요, 주어집니다]
 
 - word: 주연
@@ -74668,8 +74654,8 @@ rat (Chinese zodiac sign)"
   romaja: jugida
   pos: v
   defs:
-    - def: "To kill; to cause to die."
-    - def: "To extinguish."
+    - def: "to kill; to cause to die"
+    - def: "to extinguish"
   conj: [죽인다, 죽여, 죽여요/죽이어요, 죽입니다]
 
 - word: 죽지
@@ -74788,14 +74774,14 @@ rat (Chinese zodiac sign)"
   romaja: jureodeulda
   pos: v
   defs:
-    - def: "To diminish or decrease."
+    - def: "to diminish or decrease"
   conj: [줄어든다, 줄어들어, 줄어들어요, 줄어듭니다]
 
 - word: 줄이다
   romaja: jurida
   pos: v
   defs:
-    - def: "To reduce something."
+    - def: "to reduce something"
   conj: [줄인다, 줄여, 줄여요/줄이어요, 줄입니다]
 
 - word: 줄종개
@@ -75181,8 +75167,8 @@ rat (Chinese zodiac sign)"
   romaja: jwida
   pos: v
   defs:
-    - def: "To clench"
-    - def: "To grasp, to grab, to hold, to squeeze"
+    - def: "to clench"
+    - def: "to grasp, to grab, to hold, to squeeze"
       examples:
         - example: "손으로 쥐고 놓지 않다."
           transliteration: "Soneuro jwigo nochi anta."
@@ -75190,9 +75176,9 @@ rat (Chinese zodiac sign)"
         - example: "그래서 그는 격자 무늬 어깨걸이를 벗고, 몸을 구부려 양 꼬리를 쥐고 당겼다."
           transliteration: "Geuraeseo geuneun gyeokja munui eokkaegeorireul beotgo, momeul guburyeo yang kkorireul jwigo danggyeotda."
           translation: "So he took off his plaid, and bent down and took hold of the sheep's tail, and he pulled!"
-    - def: "To grab, to take hold of, to control. (To have power to do as one wishes.)"
-    - def: "To have (To have evidence, etc.)"
-    - def: "To make, to have (To earn or have money, wealth, etc.)"
+    - def: "to grab, to take hold of, to control. (to have power to do as one wishes)"
+    - def: "to have (to have evidence, etc.)"
+    - def: "to make, to have (to earn or have money, wealth, etc.)"
   conj: [쥔다, 쥐어, 쥐어요, 쥡니다]
 
 - word: 쥐며느리
@@ -75270,7 +75256,7 @@ rat (Chinese zodiac sign)"
   romaja: jeunggahada
   pos: v
   defs:
-    - def: "To increase or add."
+    - def: "to increase or add"
       examples:
         - example: "인구가 130(백삼십)만 명에서 140(백사십)만 명으로 증가했다."
           transliteration: "In-guga 130(baeksamsip)man myeong-eseo 140(baeksasip)man myeong-euro jeunggahaetda."
@@ -75873,7 +75859,7 @@ rat (Chinese zodiac sign)"
   romaja: jibaehada
   pos: v
   defs:
-    - def: "To rule; to control"
+    - def: "to rule; to control"
   conj: [지배한다, 지배해, 지배해요, 지배합니다]
 
 - word: 지복직관
@@ -76653,7 +76639,7 @@ such a municipality in North Korea, the Republic of China, the People's Republic
   romaja: jinjja
   pos: n
   defs:
-    - def: "That which is real or actual."
+    - def: "that which is real or actual"
     - def: ""
       examples:
         - example: "퍼피볼은 진짜 슈퍼볼에 대한 대체물입니다."
@@ -76712,7 +76698,7 @@ such a municipality in North Korea, the Republic of China, the People's Republic
   romaja: jinhaengdoeda
   pos: v
   defs:
-    - def: "To progress; to come to progress"
+    - def: "to progress; to come to progress"
   conj: [진행된다, 진행돼, 진행돼요/진행되어요, 진행됩니다]
 
 - word: 진행자
@@ -77199,15 +77185,15 @@ such a municipality in North Korea, the Republic of China, the People's Republic
   romaja: jipda
   pos: v
   defs:
-    - def: "To rely, rest (on a cane, stick, etc.)"
+    - def: "to rely, rest (on a cane, stick, etc.)"
       examples:
         - example: "땅 짚고 헤엄치기"
           transliteration: "ttang jipgo heeomchigi"
           translation: "as easy or safe as swimming (with the arms) resting on the ground"
-    - def: "To dip (a dipstick to stand on the bottom)"
-    - def: "To point (at something specific as (if) with a finger)"
-    - def: "To touch, feel (at some body part to examine the temperature, pulses, etc.)"
-    - def: "To guess, estimate (relying on, or starting from, some baseline)"
+    - def: "to dip (a dipstick to stand on the bottom)"
+    - def: "to point (at something specific as (if) with a finger)"
+    - def: "to touch, feel (at some body part to examine the temperature, pulses, etc.)"
+    - def: "to guess, estimate (relying on, or starting from, some baseline)"
   conj: [짚는다, 짚어, 짚어요, 짚습니다]
 
 - word: 짜
@@ -77997,7 +77983,7 @@ such a municipality in North Korea, the Republic of China, the People's Republic
   romaja: chamdoeda
   pos: a
   defs:
-    - def: "To be true, truthful, correct, right"
+    - def: "to be true, truthful, correct, right"
   conj: [참되다, 참돼, 참돼요/참되어요, 참됩니다]
 
 - word: 참둑중개
@@ -78058,7 +78044,7 @@ such a municipality in North Korea, the Republic of China, the People's Republic
   romaja: chamseokhada
   pos: v
   defs:
-    - def: "To attend a meeting or other gathering."
+    - def: "to attend a meeting or other gathering"
   conj: [참석한다, 참석해, 참석해요, 참석합니다]
 
 - word: 참수리
@@ -78209,7 +78195,7 @@ such a municipality in North Korea, the Republic of China, the People's Republic
     - def: "window"
       examples:
         - example: "창문의 유리가 반짝거린다."
-          transliteration: " Changmunui yuriga banjjakgeorinda."
+          transliteration: "Changmunui yuriga banjjakgeorinda."
           translation: "The glass of the window is gleaming."
         - example: "도둑이 창문을 통해 들어온 것 같다."
           transliteration: "Dodugi changmuneul tonghae deureoon geot gatda."
@@ -78307,8 +78293,8 @@ such a municipality in North Korea, the Republic of China, the People's Republic
   romaja: chajagada
   pos: v
   defs:
-    - def: "To go to see or meet someone."
-    - def: "To retrieve or recover something."
+    - def: "to go to see or meet someone"
+    - def: "to retrieve or recover something"
   conj: [찾아간다, 찾아가, 찾아가요, 찾아갑니다]
 
 - word: 찾아내다
@@ -78402,9 +78388,9 @@ such a municipality in North Korea, the Republic of China, the People's Republic
   romaja: chae-uda
   pos: v
   defs:
-    - def: "To fill; to cause to be filled."
-    - def: "To complete or fulfill."
-    - def: "To satisfy."
+    - def: "to fill; to cause to be filled"
+    - def: "to complete or fulfill"
+    - def: "to satisfy"
   conj: [채운다, 채워, 채워요, 채웁니다]
 
 - word: 채찍
@@ -78519,13 +78505,13 @@ such a municipality in North Korea, the Republic of China, the People's Republic
   romaja: chaenggida
   pos: v
   defs:
-    - def: "To collect or pack."
+    - def: "to collect or pack"
       examples:
         - example: "비행기에서 내리시기 전에 모든 소지품을 챙기셨는지 확인해 주시기 바랍니다."
           transliteration: "Bihaenggieseo naerisigi jeone modeun sojipumeul chaenggisyeonneunji hwaginhae jusigi baramnida."
           translation: "Before getting off the airplane, please ensure that all your belongings are with you."
-    - def: "To put aright; to set in order."
-    - def: "To keep for oneself; to appropriate."
+    - def: "to put aright; to set in order"
+    - def: "to keep for oneself; to appropriate"
   conj: [챙긴다, 챙겨, 챙겨요/챙기어요, 챙깁니다]
 
 - word: 처남
@@ -78621,7 +78607,7 @@ such a municipality in North Korea, the Republic of China, the People's Republic
   romaja: cheok
   pos: n
   defs:
-    - def: "隻:  boat"
+    - def: "隻: boat"
     - def: "尺: Synonym of 자 (ja), the Korean foot of about 30.3 cm"
 
 - word: 척량
@@ -79395,7 +79381,7 @@ such a municipality in North Korea, the Republic of China, the People's Republic
   romaja: chyeodaboda
   pos: v
   defs:
-    - def: "To look at or glance."
+    - def: "to look at or glance"
   conj: [쳐다본다, 쳐다봐, 쳐다봐요/쳐다보아요, 쳐다봅니다]
 
 - word: 쳐죽이다
@@ -79953,7 +79939,7 @@ such a municipality in North Korea, the Republic of China, the People's Republic
   romaja: chujinhada
   pos: v
   defs:
-    - def: "To promote or propel an initiative."
+    - def: "to promote or propel an initiative"
   conj: [추진한다, 추진해, 추진해요, 추진합니다]
 
 - word: 추천
@@ -80120,7 +80106,7 @@ such a municipality in North Korea, the Republic of China, the People's Republic
   romaja: chulbalhada
   pos: v
   defs:
-    - def: "To depart"
+    - def: "to depart"
   conj: [출발한다, 출발해, 출발해요, 출발합니다]
 
 - word: 출산
@@ -80295,7 +80281,7 @@ such a municipality in North Korea, the Republic of China, the People's Republic
   romaja: chungbunhada
   pos: a
   defs:
-    - def: "To be sufficient or adequate."
+    - def: "to be sufficient or adequate"
   conj: [충분하다, 충분해, 충분해요, 충분합니다]
 
 - word: 충분히
@@ -81502,7 +81488,7 @@ such a municipality in North Korea, the Republic of China, the People's Republic
   romaja: keojida
   pos: v
   defs:
-    - def: "To become large or larger; to expand."
+    - def: "to become large or larger; to expand"
   conj: [커진다, 커져, 커져요/커지어요, 커집니다]
 
 - word: 커튼
@@ -81634,7 +81620,7 @@ such a municipality in North Korea, the Republic of China, the People's Republic
   romaja: kenggida
   pos: v
   defs:
-    - def: "To be drawn tight; to become strained"
+    - def: "to be drawn tight; to become strained"
     - def: "to strain, tighten"
   conj: [켕긴다, 켕겨, 켕겨요/켕기어요, 켕깁니다]
 
@@ -81647,54 +81633,54 @@ such a municipality in North Korea, the Republic of China, the People's Republic
   romaja: kyeoda
   pos: v
   defs:
-    - def: "To light an oil lamp or candle; strike a match or lighter"
-    - def: "To turn something on"
+    - def: "to light an oil lamp or candle; strike a match or lighter"
+    - def: "to turn something on"
   conj: [켠다, 켜어, 켜어요, 켭니다]
 
 - word: 켜다
   romaja: kyeoda
   pos: v
   defs:
-    - def: "To split a wood lengthwise with a saw"
-    - def: "To play the string instrument"
-    - def: "To reel silk off cocoons"
-    - def: "To make a taffy white"
+    - def: "to split a wood lengthwise with a saw"
+    - def: "to play the string instrument"
+    - def: "to reel silk off cocoons"
+    - def: "to make a taffy white"
   conj: [켠다, 켜어, 켜어요, 켭니다]
 
 - word: 켜다
   romaja: kyeoda
   pos: v
   defs:
-    - def: "To drink at a gulp"
-    - def: "To drink water very often because of thirst"
+    - def: "to drink at a gulp"
+    - def: "to drink water very often because of thirst"
   conj: [켠다, 켜어, 켜어요, 켭니다]
 
 - word: 켜다
   romaja: kyeoda
   pos: v
   defs:
-    - def: "To stretch"
+    - def: "to stretch"
   conj: [켠다, 켜어, 켜어요, 켭니다]
 
 - word: 켜다
   romaja: kyeoda
   pos: v
   defs:
-    - def: "To corrugate"
+    - def: "to corrugate"
   conj: [켠다, 켜어, 켜어요, 켭니다]
 
 - word: 켜다
   romaja: kyeoda
   pos: v
   defs:
-    - def: "To make a sound using something like ure"
+    - def: "to make a sound using something like ure"
   conj: [켠다, 켜어, 켜어요, 켭니다]
 
 - word: 켜다
   romaja: kyeoda
   pos: v
   defs:
-    - def: "To fan"
+    - def: "to fan"
   conj: [켠다, 켜어, 켜어요, 켭니다]
 
 - word: 켤레
@@ -82006,7 +81992,7 @@ such a municipality in North Korea, the Republic of China, the People's Republic
     - def: "OK, agreed (on a proposal)."
       examples:
         - example: "— 치맥 어때?— 콜!"
-          transliteration: " chimaek eottae? kol!"
+          transliteration: "chimaek eottae? kol!"
           translation: "— How about chicken and beer?— OK!"
 
 - word: 콜라
@@ -84341,8 +84327,8 @@ such a municipality in North Korea, the Republic of China, the People's Republic
   defs:
     - def: "Compost."
       examples:
-        - example: "그 시설은 단지 8주만에 음식물 쓰레기를,  가정용 및 농업용으로 적합한 풍부하고 깨끗한 퇴비로 만들 것입니다."
-          transliteration: "Geu siseoreun danji 8jumane eumsingmul sseuregireul,  gajeong-yong mit nong-eobyong-euro jeokhaphan pungbuhago kkaekkeuthan toebiro mandeul geosimnida."
+        - example: "그 시설은 단지 8주만에 음식물 쓰레기를, 가정용 및 농업용으로 적합한 풍부하고 깨끗한 퇴비로 만들 것입니다."
+          transliteration: "Geu siseoreun danji 8jumane eumsingmul sseuregireul, gajeong-yong mit nong-eobyong-euro jeokhaphan pungbuhago kkaekkeuthan toebiro mandeul geosimnida."
           translation: "[The] facility […] in just eight weeks, turns [the food waste] into a rich, clean compost suitable for home and agricultural use."
 
 - word: 퇴직금
@@ -84686,7 +84672,7 @@ such a municipality in North Korea, the Republic of China, the People's Republic
       examples:
         - example: "트림(이) 나오다"
           transliteration: "teurim(i) naoda"
-          translation: " to come out"
+          translation: "to come out"
         - example: "트림(을) 시키다"
           transliteration: "teurim(eul) sikida"
           translation: "to cause (someone) to burp"
@@ -84735,13 +84721,13 @@ such a municipality in North Korea, the Republic of China, the People's Republic
   romaja: teukbyeol
   pos: n
   defs:
-    - def: "The state or quality of being special."
+    - def: "the state or quality of being special"
 
 - word: 특별하다
   romaja: teukbyeolhada
   pos: a
   defs:
-    - def: "To be special or exceptional."
+    - def: "to be special or exceptional"
   conj: [특별하다, 특별해, 특별해요, 특별합니다]
 
 - word: 특별히
@@ -84974,14 +84960,14 @@ such a municipality in North Korea, the Republic of China, the People's Republic
   romaja: pagoedoeda
   pos: v
   defs:
-    - def: "To be destroyed or demolished."
+    - def: "to be destroyed or demolished"
   conj: [파괴된다, 파괴돼, 파괴돼요/파괴되어요, 파괴됩니다]
 
 - word: 파괴하다
   romaja: pagoehada
   pos: v
   defs:
-    - def: "To destroy or demolish."
+    - def: "to destroy or demolish"
   conj: [파괴한다, 파괴해, 파괴해요, 파괴합니다]
 
 - word: 파나마
@@ -85091,7 +85077,7 @@ such a municipality in North Korea, the Republic of China, the People's Republic
   romaja: paryeomchihada
   pos: a
   defs:
-    - def: "To be brazen or shameless."
+    - def: "to be brazen or shameless"
   conj: [파렴치하다, 파렴치해, 파렴치해요, 파렴치합니다]
 
 - word: 파리
@@ -85116,7 +85102,7 @@ such a municipality in North Korea, the Republic of China, the People's Republic
   romaja: parihada
   pos: a
   defs:
-    - def: "To be thin or emaciated"
+    - def: "to be thin or emaciated"
   conj: [파리하다, 파리해, 파리해요, 파리합니다]
 
 - word: 파마
@@ -85334,14 +85320,14 @@ such a municipality in North Korea, the Republic of China, the People's Republic
   romaja: pahada
   pos: v
   defs:
-    - def: "To crush or prevail over an enemy."
+    - def: "to crush or prevail over an enemy"
   conj: [파한다, 파해, 파해요, 파합니다]
 
 - word: 파하다
   romaja: pahada
   pos: v
   defs:
-    - def: "To end."
+    - def: "to end"
   conj: [파한다, 파해, 파해요, 파합니다]
 
 - word: 파행
@@ -85513,13 +85499,13 @@ such a municipality in North Korea, the Republic of China, the People's Republic
   romaja: pandan
   pos: n
   defs:
-    - def: "Judgment; decision."
+    - def: "judgment; decision"
 
 - word: 판단하다
   romaja: pandanhada
   pos: v
   defs:
-    - def: "To adjudge; to determine"
+    - def: "to adjudge; to determine"
   conj: [판단한다, 판단해, 판단해요, 판단합니다]
 
 - word: 판도
@@ -85872,14 +85858,14 @@ such a municipality in North Korea, the Republic of China, the People's Republic
   romaja: peojeul
   pos: n
   defs:
-    - def: "puzzle ((type of game)"
+    - def: "puzzle (type of game)"
 
 - word: 퍼지다
   romaja: peojida
   pos: v
   defs:
-    - def: "To spread outwards."
-    - def: "To diffuse."
+    - def: "to spread outwards"
+    - def: "to diffuse"
   conj: [퍼진다, 퍼져, 퍼져요/퍼지어요, 퍼집니다]
 
 - word: 펄럭
@@ -86547,7 +86533,7 @@ such a municipality in North Korea, the Republic of China, the People's Republic
   romaja: pogihada
   pos: v
   defs:
-    - def: "To give up or abandon."
+    - def: "to give up or abandon"
   conj: [포기한다, 포기해, 포기해요, 포기합니다]
 
 - word: 포도
@@ -87208,8 +87194,8 @@ such a municipality in North Korea, the Republic of China, the People's Republic
   romaja: pullida
   pos: v
   defs:
-    - def: "To be untied."
-    - def: "To be solved."
+    - def: "to be untied"
+    - def: "to be solved"
   conj: [풀린다, 풀려, 풀려요/풀리어요, 풀립니다]
 
 - word: 풀망둑
@@ -87394,7 +87380,7 @@ such a municipality in North Korea, the Republic of China, the People's Republic
   romaja: pungbuhada
   pos: a
   defs:
-    - def: "To be rich, plentiful, abundant, ample"
+    - def: "to be rich, plentiful, abundant, ample"
   conj: [풍부하다, 풍부해, 풍부해요, 풍부합니다]
 
 - word: 풍선
@@ -88847,7 +88833,7 @@ to say, to talk"
   romaja: hayata
   pos: a
   defs:
-    - def: "To be pure white"
+    - def: "to be pure white"
   conj: [하얗다, 하얘, 하얘요, 하얗습니다]
 
 - word: 하얀색
@@ -88866,7 +88852,7 @@ to say, to talk"
   romaja: hayata
   pos: a
   defs:
-    - def: "To be pure white"
+    - def: "to be pure white"
   conj: [하얗다, 하얘, 하얘요, 하얗습니다]
 
 - word: 하얼빈
@@ -90263,7 +90249,7 @@ to say, to talk
   romaja: haegyeolhada
   pos: v
   defs:
-    - def: "To resolve a dispute or confusion."
+    - def: "to resolve a dispute or confusion"
       examples:
         - example: "문제를 해결하는 데에는 여러 가지의 방법이 있다."
           transliteration: "Munjereul haegyeolhaneun deeneun yeoreo gajiui bangbeobi itda."
@@ -91549,7 +91535,7 @@ to say, to talk
   romaja: hyeon-geum
   pos: n
   defs:
-    - def: "Mistaken name for the 거문고 (geomun-go).  "
+    - def: "Mistaken name for the 거문고 (geomun-go)."
 
 - word: 현대
   romaja: hyeondae
@@ -91849,7 +91835,7 @@ to say, to talk
   romaja: hyeongseongdoeda
   pos: v
   defs:
-    - def: "To be formed or shaped."
+    - def: "to be formed or shaped"
   conj: [형성된다, 형성돼, 형성돼요/형성되어요, 형성됩니다]
 
 - word: 형성하다
@@ -92776,7 +92762,7 @@ to say, to talk
   romaja: hwaksilhada
   pos: a
   defs:
-    - def: "To be certain or definite."
+    - def: "to be certain or definite"
   conj: [확실하다, 확실해, 확실해요, 확실합니다]
 
 - word: 확실히
@@ -92992,8 +92978,8 @@ to say, to talk
   romaja: hwaryonghada
   pos: v
   defs:
-    - def: "To apply; to make use of."
-    - def: "To conjugate."
+    - def: "to apply; to make use of"
+    - def: "to conjugate"
   conj: [활용한다, 활용해, 활용해요, 활용합니다]
 
 - word: 황
@@ -93144,7 +93130,7 @@ to say, to talk
   pos: n
   defs:
     - def: "膾: sliced raw fish; sashimi"
-    - def: "回:  time, occurence, occasion"
+    - def: "回: time, occurence, occasion"
 
 - word: 회견
   romaja: hoegyeon
@@ -93308,7 +93294,7 @@ to say, to talk
   romaja: hoeeumbu
   pos: n
   defs:
-    - def: "The perineal region; the perineum."
+    - def: "the perineal region; the perineum"
 
 - word: 회의
   romaja: hoe-ui
@@ -93401,7 +93387,7 @@ to say, to talk
   romaja: hyogwajeok
   pos: n
   defs:
-    - def: "Something which is effective."
+    - def: "something which is effective"
 
 - word: 효모
   romaja: hyomo
@@ -93500,7 +93486,7 @@ to say, to talk
   romaja: huban
   pos: n
   defs:
-    - def: "The latter or second half."
+    - def: "the latter or second half"
 
 - word: 후배
   romaja: hubae
@@ -93607,7 +93593,7 @@ to say, to talk
 - word: 훈
   pos: n
   defs:
-    - def: "Teaching, instruction, guidance."
+    - def: "teaching, instruction, guidance"
     - def: "meaning of a hanja (Chinese character)"
     - def: "hun (塤), an ancient flute made of clay or ceramic"
 
@@ -93884,15 +93870,15 @@ to say, to talk
   romaja: heuk
   pos: n
   defs:
-    - def: "The color black."
-    - def: "A black stone used in the game of go."
+    - def: "the color black"
+    - def: "a black stone used in the game of go"
 
 - word: 흑
   romaja: heuk
   pos: intj
   defs:
-    - def: "Sobbing."
-    - def: "Expressing shock or disappointment."
+    - def: "sobbing"
+    - def: "expressing shock or disappointment"
 
 - word: 흑고니
   pos: n
@@ -93903,7 +93889,7 @@ to say, to talk
   romaja: heukgireogi
   pos: n
   defs:
-    - def: "The brent goose, Branta bernicla."
+    - def: "The brent goose, Branta bernicla"
 
 - word: 흑기사
   romaja: heukgisa
@@ -93916,7 +93902,7 @@ to say, to talk
   romaja: heukdurumi
   pos: n
   defs:
-    - def: "The hooded crane, Grus monacha."
+    - def: "The hooded crane, Grus monacha"
 
 - word: 흑로
   romaja: heungno
@@ -93946,7 +93932,7 @@ to say, to talk
   romaja: heugyeoksa
   pos: n
   defs:
-    - def: "a past thing that would like to make it didn't happen."
+    - def: "a past thing that would like to make it didn't happen"
 
 - word: 흑인
   romaja: heugin
@@ -93970,8 +93956,8 @@ to say, to talk
   romaja: heukheuk
   pos: adv
   defs:
-    - def: "The sound of sobbing."
-    - def: "The sound a person makes when feeling a cold shiver through their spine."
+    - def: "the sound of sobbing"
+    - def: "the sound a person makes when feeling a cold shiver through their spine"
 
 - word: 흔들다
   romaja: heundeulda
@@ -94003,8 +93989,8 @@ to say, to talk
   romaja: heunhada
   pos: a
   defs:
-    - def: "To be frequent or common."
-    - def: "To be commonplace; ordinary."
+    - def: "to be frequent or common"
+    - def: "to be commonplace; ordinary"
   conj: [흔하다, 흔해, 흔해요, 흔합니다]
 
 - word: 흔히
@@ -94040,8 +94026,8 @@ to say, to talk
   romaja: heullida
   pos: v
   defs:
-    - def: "To flow with, or spill."
-    - def: "To drop something."
+    - def: "to flow with, or spill"
+    - def: "to drop something"
   conj: [흘린다, 흘려, 흘려요/흘리어요, 흘립니다]
 
 - word: 흙
@@ -94103,7 +94089,7 @@ to say, to talk
   romaja: heunggyeopda
   pos: a
   defs:
-    - def: "to be delightful; to be full of merriment."
+    - def: "to be delightful; to be full of merriment"
   conj: [흥겹다, 흥겨워, 흥겨워요, 흥겹습니다]
 
 - word: 흥륭
@@ -94293,7 +94279,7 @@ to say, to talk
   romaja: huihanhada
   pos: a
   defs:
-    - def: "To be rare or unusual"
+    - def: "to be rare or unusual"
   conj: [희한하다, 희한해, 희한해요, 희한합니다]
 
 - word: 희한히
@@ -94408,7 +94394,7 @@ to say, to talk
   romaja: huinsaek
   pos: n
   defs:
-    - def: "The color white."
+    - def: "the color white"
 
 - word: 흰수마자
   romaja: huinsumaja
@@ -94486,8 +94472,8 @@ to say, to talk
   romaja: hi
   pos: suf
   defs:
-    - def: "a suffix deriving a passive verb."
-    - def: "a suffix deriving a causative verb."
+    - def: "a suffix deriving a passive verb"
+    - def: "a suffix deriving a causative verb"
 
 - word: 히드록시기
   romaja: hideuroksigi
@@ -94535,7 +94521,7 @@ to say, to talk
   romaja: hipeu
   pos: n
   defs:
-    - def: "The hips"
+    - def: "the hips"
 
 - word: 힌두교
   romaja: hindugyo
@@ -94613,8 +94599,8 @@ to say, to talk
   romaja: himjul
   pos: v
   defs:
-    - def: "Which will concentrate"
-    - def: "Which will be concentrated on"
+    - def: "which will concentrate"
+    - def: "which will be concentrated on"
 
 - word: 힙합
   romaja: hiphap

--- a/kedict.yml
+++ b/kedict.yml
@@ -64182,7 +64182,7 @@ Used to illustrate the time that a certain action or situation began or will beg
   conj: [유명하다, 유명해, 유명해요, 유명합니다]
 
 - word: 유명한
-  romaja: yumyeonghada
+  romaja: yumyeonghan
   pos: a
   defs:
     - def: "famous"
@@ -64441,16 +64441,16 @@ Used to illustrate the time that a certain action or situation began or will beg
 
 - word: 유해하다
   romaja: yuhaehada
-  pos: a
+  pos: v
   defs:
     - def: "to be harmful, noxious, injurious"
   conj: [유해하다, 유해해, 유해해요, 유해합니다]
 
 - word: 유해한
-  romaja: yuhaehada
+  romaja: yuhaehan
   pos: a
   defs:
-    - def: "to be harmful, noxious, injurious"
+    - def: "harmful, noxious, injurious"
   conj: [유해하다, 유해해, 유해해요, 유해합니다]
 
 - word: 유행
@@ -66353,12 +66353,12 @@ Used to illustrate the time that a certain action or situation began or will beg
   conj: [이상하다, 이상해, 이상해요, 이상합니다]
 
 - word: 이상한
-  pos: det
+  pos: a
   defs:
     - def: "strange, abnormal"
 
 - word: 이상한
-  pos: det
+  pos: a
   defs:
     - def: "demented; insane"
 


### PR DESCRIPTION
Hello! I made some improvements to the data and its web presentation. 

Changes include:
- Remove HTML displayed in text (권력욕)
- Streamline formatting for consistency 
- Fix duplicate + broken entries
- Improve grammar
  - Fix incorrect pos, romaja, and def
    - e.g. 유해하다/한, 유명하다/한, 이상하다/한
      - [이상한](https://en.wiktionary.org/wiki/%EC%9D%B4%EC%83%81%ED%95%9C) being a determiner seems to be a Wiktionary error. It must be confusing this with [이상](https://en.wiktionary.org/wiki/%E4%BB%A5%E4%B8%8A#Korean). 
  - Change KR `adjective` definitions to match EN `adjective` form, not verb `infinitive + adjective`